### PR TITLE
nimble/mesh: Fix segmentation fault when running on simulator

### DIFF
--- a/nimble/host/mesh/src/mesh.c
+++ b/nimble/host/mesh/src/mesh.c
@@ -220,15 +220,18 @@ int bt_mesh_init(uint8_t own_addr_type, const struct bt_mesh_prov *prov,
 		return err;
 	}
 
-	if (MYNEWT_VAL(BLE_MESH_PROV)) {
-		err = bt_mesh_prov_init(prov);
-		if (err) {
-			return err;
-		}
+#if (MYNEWT_VAL(BLE_MESH_PROV))
+	err = bt_mesh_prov_init(prov);
+	if (err) {
+		return err;
 	}
+#endif
 
 #if (MYNEWT_VAL(BLE_MESH_PROXY))
 	bt_mesh_proxy_init();
+#endif
+
+#if (MYNEWT_VAL(BLE_MESH_PROV))
 	/* Need this to proper link.rx.buf allocation */
 	bt_mesh_prov_reset_link();
 #endif

--- a/nimble/host/mesh/src/prov.c
+++ b/nimble/host/mesh/src/prov.c
@@ -1567,7 +1567,6 @@ int bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 
 #if !(MYNEWT_VAL(BLE_MESH_PB_GATT))
 	rx_buf = NET_BUF_SIMPLE(65);
-
 #endif
 
 	if (!prov_info) {
@@ -1587,9 +1586,7 @@ int bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 	k_delayed_work_init(&link.tx.retransmit, prov_retransmit);
 	link.rx.prev_id = XACT_NVAL;
 
-#if (MYNEWT_VAL(BLE_MESH_PB_GATT))
-	link.rx.buf = bt_mesh_proxy_get_buf();
-#else
+#if !(MYNEWT_VAL(BLE_MESH_PB_GATT))
 	net_buf_simple_init(rx_buf, 0);
 	link.rx.buf = rx_buf;
 #endif

--- a/nimble/host/mesh/src/shell.c
+++ b/nimble/host/mesh/src/shell.c
@@ -566,10 +566,16 @@ struct shell_cmd_help cmd_lpn_help = {
 
 #endif /* MESH_LOW_POWER */
 
-static int check_addr_unassigned(uint8_t addr[BLE_DEV_ADDR_LEN])
+static int check_pub_addr_unassigned(void)
 {
-	return memcmp(addr, (uint8_t[BLE_DEV_ADDR_LEN]){0, 0, 0, 0, 0, 0},
-			BLE_DEV_ADDR_LEN) == 0;
+#ifdef ARCH_sim
+	return 0;
+#else
+	uint8_t zero_addr[BLE_DEV_ADDR_LEN] = { 0 };
+
+	return memcmp(MYNEWT_VAL(BLE_PUBLIC_DEV_ADDR),
+		      zero_addr, BLE_DEV_ADDR_LEN) == 0;
+#endif
 }
 
 static int cmd_init(int argc, char *argv[])
@@ -577,7 +583,7 @@ static int cmd_init(int argc, char *argv[])
 	int err;
 	ble_addr_t addr;
 
-	if (check_addr_unassigned(MYNEWT_VAL(BLE_PUBLIC_DEV_ADDR))) {
+	if (check_pub_addr_unassigned()) {
 		/* Use NRPA */
 		err = ble_hs_id_gen_rnd(1, &addr);
 		assert(err == 0);


### PR DESCRIPTION
This PR also has fix needed to run it on simulator, however there are more changes need it to build nicely for native.. this is work ongoing.