### PR TITLE
nimble/mesh: Make use of advertising extensions

### DIFF
--- a/nimble/host/mesh/include/mesh/glue.h
+++ b/nimble/host/mesh/include/mesh/glue.h
@@ -238,7 +238,6 @@ void net_buf_reserve(struct os_mbuf *om, size_t reserve);
 #define net_buf_add_be32(a, b) net_buf_simple_add_be32(a, b)
 #define net_buf_add_be16(a, b) net_buf_simple_add_be16(a, b)
 
-#define bt_le_adv_stop() ble_gap_adv_stop()
 #define BT_GATT_CCC_NOTIFY BLE_GATT_CHR_PROP_NOTIFY
 #define bt_gatt_attr ble_gatt_attr
 
@@ -277,6 +276,7 @@ void bt_mesh_register_gatt(void);
 int bt_le_adv_start(const struct ble_gap_adv_params *param,
                     const struct bt_data *ad, size_t ad_len,
                     const struct bt_data *sd, size_t sd_len);
+int bt_le_adv_stop(void);
 
 struct k_delayed_work {
     struct os_callout work;

--- a/nimble/host/mesh/src/adv.c
+++ b/nimble/host/mesh/src/adv.c
@@ -369,6 +369,16 @@ done:
 
 int bt_mesh_scan_enable(void)
 {
+#if MYNEWT_VAL(BLE_EXT_ADV)
+	struct ble_gap_ext_disc_params uncoded_params =
+		{ .itvl = MESH_SCAN_INTERVAL, .window = MESH_SCAN_WINDOW,
+		.passive = 1 };
+
+	BT_DBG("");
+
+	return ble_gap_ext_disc(g_mesh_addr_type, 0, 0, 0, 0, 0,
+				&uncoded_params, NULL, NULL, NULL);
+#else
 	struct ble_gap_disc_params scan_param =
 		{ .passive = 1, .filter_duplicates = 0, .itvl =
 		  MESH_SCAN_INTERVAL, .window = MESH_SCAN_WINDOW };
@@ -376,6 +386,7 @@ int bt_mesh_scan_enable(void)
 	BT_DBG("");
 
 	return ble_gap_disc(g_mesh_addr_type, BLE_HS_FOREVER, &scan_param, NULL, NULL);
+#endif
 }
 
 int bt_mesh_scan_disable(void)


### PR DESCRIPTION
With this patch Mesh can make use of multi instances which came with
advertising extension. It creates one advertising instance for
PB-ADV and one for PB-GATT and PROXY.

That said, it is possible to create additional instances which are
used for non mesh purpose. Note that this brings limitation on Mesh
Friendship due to timings.

To make use of it application needs to set BLE_EXT_ADV and
BLE_MULTI_ADV_INSTANCES at least to 1. Mesh will use last available
advertising instance for PB-ADV and second to last for PB-GATT and
PROXY


