### PR TITLE
mesh: Fix possible race condition and other issues

### DIFF
--- a/nimble/host/mesh/src/cfg_cli.c
+++ b/nimble/host/mesh/src/cfg_cli.c
@@ -163,7 +163,9 @@ static void net_key_status(struct bt_mesh_model *model,
 		return;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	k_sem_give(&cli->op_sync);
 }
@@ -200,7 +202,9 @@ static void app_key_status(struct bt_mesh_model *model,
 		return;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	k_sem_give(&cli->op_sync);
 }
@@ -250,7 +254,9 @@ static void mod_app_status(struct bt_mesh_model *model,
 		return;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	k_sem_give(&cli->op_sync);
 }

--- a/nimble/host/mesh/src/cfg_cli.c
+++ b/nimble/host/mesh/src/cfg_cli.c
@@ -313,7 +313,9 @@ static void mod_pub_status(struct bt_mesh_model *model,
 		return;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	if (param->pub) {
 		param->pub->addr = net_buf_simple_pull_le16(buf);
@@ -378,7 +380,9 @@ static void mod_sub_status(struct bt_mesh_model *model,
 		*param->sub_addr = sub_addr;
 	}
 
-	*param->status = status;
+	if (param->status) {
+		*param->status = status;
+	}
 
 	k_sem_give(&cli->op_sync);
 }

--- a/nimble/host/mesh/src/health_cli.c
+++ b/nimble/host/mesh/src/health_cli.c
@@ -154,7 +154,9 @@ static void health_attention_status(struct bt_mesh_model *model,
 
 	param = health_cli->op_param;
 
-	*param->attention = net_buf_simple_pull_u8(buf);
+	if (param->attention) {
+		*param->attention = net_buf_simple_pull_u8(buf);
+	}
 
 	k_sem_give(&health_cli->op_sync);
 }

--- a/nimble/host/mesh/src/net.c
+++ b/nimble/host/mesh/src/net.c
@@ -476,8 +476,7 @@ int bt_mesh_net_create(u16_t idx, u8_t flags, const u8_t key[16],
 	sub->net_idx = idx;
 
 	if ((MYNEWT_VAL(BLE_MESH_GATT_PROXY))) {
-		sub->node_id = BT_MESH_NODE_IDENTITY_RUNNING;
-		sub->node_id_start = k_uptime_get_32();
+		sub->node_id = BT_MESH_NODE_IDENTITY_STOPPED;
 	} else {
 		sub->node_id = BT_MESH_NODE_IDENTITY_NOT_SUPPORTED;
 	}

--- a/nimble/host/mesh/src/prov.c
+++ b/nimble/host/mesh/src/prov.c
@@ -1073,6 +1073,13 @@ static void prov_data(const u8_t *data)
 
 	bt_mesh_provision(pdu, net_idx, flags, iv_index, 0, addr, dev_key);
 
+#if MYNEWT_VAL(BLE_MESH_PB_GATT) && MYNEWT_VAL(BLE_MESH_GATT_PROXY)
+	/* After PB-GATT provisioning we should start advertising
+	 * using Node Identity.
+	 */
+	bt_mesh_proxy_identity_enable();
+#endif
+
 done:
 	os_mbuf_free_chain(msg);
 }

--- a/nimble/host/mesh/src/testing.c
+++ b/nimble/host/mesh/src/testing.c
@@ -133,7 +133,7 @@ void bt_test_print_credentials(void)
 
 	for (i = 0; i < MYNEWT_VAL(BLE_MESH_SUBNET_COUNT); ++i)
 	{
-		if (bt_mesh.app_keys[i].net_idx == BT_MESH_KEY_UNUSED) {
+		if (bt_mesh.sub[i].net_idx == BT_MESH_KEY_UNUSED) {
 			continue;
 		}
 


### PR DESCRIPTION
There's a small but real chance of a race-condition when sending
messages to the local node (through the local network interface) that
expected parameters will be NULL in the message handles. Add
appropriate NULL checks for them.

Fix Node Identity advertising with PB-ADV:
The Node Identity advertising should only be automatically enabled when provisioning happened over PB-GATT, but not when it happened over PB-ADV. Move the enabling of Node Identity to the provisioning code, where we know the bearer that was used (this information does not get passed to the bt_mesh_provision function).
 