### PR TITLE
nimble/phy: Allow to selectively enable workaround for nRF52840

### DIFF
--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -280,20 +280,28 @@ ble_phy_apply_nrf52840_errata(uint8_t new_phy_mode)
     }
 
     if (new_coded) {
+#if MYNEWT_VAL(BLE_PHY_NRF52840_ERRATA_164)
         /* [164] */
         *(volatile uint32_t *)0x4000173C |= 0x80000000;
         *(volatile uint32_t *)0x4000173C =
                         ((*(volatile uint32_t *)0x4000173C & 0xFFFFFF00) | 0x5C);
+#endif
+#if MYNEWT_VAL(BLE_PHY_NRF52840_ERRATA_191)
         /* [191] */
         *(volatile uint32_t *) 0x40001740 =
                         ((*((volatile uint32_t *) 0x40001740)) & 0x7FFF00FF) |
                         0x80000000 | (((uint32_t)(196)) << 8);
+#endif
     } else {
+#if MYNEWT_VAL(BLE_PHY_NRF52840_ERRATA_164)
         /* [164] */
         *(volatile uint32_t *)0x4000173C &= ~0x80000000;
+#endif
+#if MYNEWT_VAL(BLE_PHY_NRF52840_ERRATA_191)
         /* [191] */
         *(volatile uint32_t *) 0x40001740 =
                         ((*((volatile uint32_t *) 0x40001740)) & 0x7FFFFFFF);
+#endif
     }
 }
 #endif

--- a/nimble/drivers/nrf52/syscfg.yml
+++ b/nimble/drivers/nrf52/syscfg.yml
@@ -52,3 +52,21 @@ syscfg.defs:
             state when wfr timer expires.
             This can be used to check if wfr is calculated properly.
         value: -1
+
+    BLE_PHY_NRF52840_ERRATA_164:
+        description: >
+            Enable workaround for anomaly 164 found in nRF52840.
+            "[164] RADIO: Low selectivity in long range mode"
+            This shall be only enabled for:
+            - nRF52840 Engineering A
+        value: 0
+
+    BLE_PHY_NRF52840_ERRATA_191:
+        description: >
+            Enable workaround for anomaly 191 found in nRF52840.
+            "[191] RADIO: High packet error rate in BLE Long Range mode"
+            This shall be only enabled for:
+            - nRF52840 Engineering B
+            - nRF52840 Engineering C
+            - nRF52840 Rev 1 (final silicon)
+        value: 1


### PR DESCRIPTION
There are known anomalies in nRF52840 engineering and final revisions
which, according to Nordic DevZone, should be only applied to chip
version affected. For this reason We need to allow workarounds for #164
and #191 to be enabled selectively.

Default configuration applies to nRF52840 Rev 1 (final silicon) and
Engineering B and C.

When building for nRF52840 Engineering A (found on early versions on
nRF52840 PDK) configuration should be changed.