### PR TITLE
Remove misleading comments

### DIFF
--- a/nimble/host/services/ans/src/ble_svc_ans.c
+++ b/nimble/host/services/ans/src/ble_svc_ans.c
@@ -443,8 +443,6 @@ ble_svc_ans_chr_write(struct os_mbuf *om, uint16_t min_len,
  * 
  * XXX: We should technically be able to change the new alert and
  *      unread alert catagories when we have no active connections.
- * 
- * @return 0 on success, non-zero error code otherwise.
  */
 void
 ble_svc_ans_init(void)

--- a/nimble/host/services/bas/src/ble_svc_bas.c
+++ b/nimble/host/services/bas/src/ble_svc_bas.c
@@ -133,8 +133,6 @@ ble_svc_bas_battery_level_set(uint8_t level) {
 
 /**
  * Initialize the Battery Service.
- * 
- * @return 0 on success, non-zero error code otherwise.
  */
 void
 ble_svc_bas_init(void)


### PR DESCRIPTION
Remove misleading comments for `void *_init(void)` functions in services.