### PR TITLE
nimble/transport: Use static allocation for mempools

### DIFF
--- a/nimble/transport/ram/include/transport/ram/ble_hci_ram.h
+++ b/nimble/transport/ram/include/transport/ram/ble_hci_ram.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-int ble_hci_ram_init(void);
+void ble_hci_ram_init(void);
 
 #ifdef __cplusplus
 }

--- a/nimble/transport/ram/pkg.yml
+++ b/nimble/transport/ram/pkg.yml
@@ -33,4 +33,4 @@ pkg.apis:
     - ble_transport
 
 pkg.init:
-    ble_hci_ram_pkg_init: 100
+    ble_hci_ram_init: 100


### PR DESCRIPTION
The size of buffers is known at compile time and failing
to malloc buffer results in assert anyway, so we should use
static buffers. This has the advantage of linker warning if
RAM is exceeded.