### PR TITLE
nimble/ll: Fix LE Ping with devices that don't support it

### DIFF
--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -387,10 +387,9 @@ ble_ll_ctrl_proc_unk_rsp(struct ble_ll_conn_sm *connsm, uint8_t *dptr)
         ctrl_proc = BLE_LL_CTRL_PROC_CONN_PARAM_REQ;
         break;
     case BLE_LL_CTRL_PING_REQ:
-        CONN_F_LE_PING_SUPP(connsm) = 0;
-#if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_PING) == 1)
-        os_callout_stop(&connsm->auth_pyld_timer);
-#endif
+        /* LL can authenticate remote device even if remote device does not
+         * support LE Ping feature.
+         */
         ctrl_proc = BLE_LL_CTRL_PROC_LE_PING;
         break;
 #if (BLE_LL_BT5_PHY_SUPPORTED ==1)


### PR DESCRIPTION
Core Specification 5.0 Vol. 6 Part D. 6.13 "LE PING":
"Either Link Layer can authenticate the remote device using the LE Ping
Procedure even if the remote device does not support the LE Ping
feature."

Both LE_PING_RSP and LL_UNKNOWN_RSP are valid reasponses for LE Ping
procedure.

This was affecting TP/SEC/MAS/BV-10-C qualification test case.