### PR TITLE
nimble/ll: Fix assertion when scheduling aux

### DIFF
--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -1158,11 +1158,8 @@ ble_ll_adv_aux_schedule_next(struct ble_ll_adv_sm *advsm)
     }
 
     /*
-     * In general we do not schedule next aux if current aux does not have
-     * AuxPtr in extended header as this means we do not need subsequent
-     * ADV_CHAIN_IND to be sent.
-     * However, if current aux is scannable we allow to schedule next aux as
-     * this will be 1st ADV_CHAIN_IND of scan response.
+     * Do not schedule next aux if current aux does not have AuxPtr in extended
+     * header as this means we do not need subsequent ADV_CHAIN_IND to be sent.
      */
     if (!(aux->ext_hdr & (1 << BLE_LL_EXT_ADV_AUX_PTR_BIT))) {
         return;

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -1147,8 +1147,15 @@ ble_ll_adv_aux_schedule_next(struct ble_ll_adv_sm *advsm)
     aux = AUX_CURRENT(advsm);
     aux_next = AUX_NEXT(advsm);
 
-    assert(aux->sch.enqueued);
     assert(!aux_next->sch.enqueued);
+
+    /*
+     * Do not schedule next aux if current aux is no longer scheduled since we
+     * do not have reference time for scheduling.
+     */
+    if (!aux->sch.enqueued) {
+        return;
+    }
 
     /*
      * In general we do not schedule next aux if current aux does not have


### PR DESCRIPTION
Advertising events are scheduled from LL task and we always try to
schedule two auxes one after another (for chaining). However, since this
does not happen in critical section it can happen that we're interrupted
after scheduling 1st aux, so when we try to schedule 2nd one there is no
aux scheduled anymore which causes an assert.

It it safe to just skip the scheduling in this case and thus handle this
gracefully. The only drawback is that we possibly truncate aux chain,
but this is harmless.