### PR TITLE
Fixes issue with mpool in ble_ll_init, corrupted mpool linked list.

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -3105,11 +3105,13 @@ ble_ll_scan_init(void)
     assert(scansm->scan_req_pdu != NULL);
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    err = os_mempool_init(&ext_adv_pool,
-                          MYNEWT_VAL(BLE_LL_EXT_ADV_AUX_PTR_CNT),
-                          sizeof (struct ble_ll_aux_data),
-                          ext_adv_mem,
-                          "ble_ll_aux_scan_pool");
-    assert(err == 0);
+    if (ext_adv_pool.mp_membuf_addr != (uint32_t )ext_adv_mem) { // don't init this pool twice on reinit
+        err = os_mempool_init(&ext_adv_pool,
+                              MYNEWT_VAL(BLE_LL_EXT_ADV_AUX_PTR_CNT),
+                              sizeof(struct ble_ll_aux_data),
+                              ext_adv_mem,
+                              "ble_ll_aux_scan_pool");
+        assert(err == 0);
+    }
 #endif
 }


### PR DESCRIPTION
Fixes: https://github.com/apache/mynewt-nimble/issues/46

Solution: Skip creating mpool a second time through ble_ll_init
Causes:   Orphan mpools in the global linked list, such that cli does
not work.  It might cause other issues which I didn't really study.