### PR TITLE
strip trailing whitespace from all files

### DIFF
--- a/nimble/controller/pkg.yml
+++ b/nimble/controller/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -963,7 +963,7 @@ ble_ll_scan_start(struct ble_ll_scan_sm *scansm, struct ble_ll_sched_item *sch)
      */
     assert(!sch || scan_chan < BLE_PHY_ADV_CHAN_START);
     assert(sch || scan_chan >= BLE_PHY_ADV_CHAN_START);
-    
+
     /* Set channel */
     rc = ble_phy_setchan(scan_chan, BLE_ACCESS_ADDR_ADV, BLE_LL_CRCINIT_ADV);
     assert(rc == 0);
@@ -2602,7 +2602,7 @@ ble_ll_scan_set_scan_params(uint8_t *cmd)
     scanp->scan_window = scan_window;
     scanp->scan_filt_policy = filter_policy;
     scanp->own_addr_type = own_addr_type;
-    
+
 #if (BLE_LL_SCAN_PHY_NUMBER == 2)
     g_ble_ll_scan_params[PHY_CODED].configured = 0;
 #endif

--- a/nimble/drivers/native/pkg.yml
+++ b/nimble/drivers/native/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/drivers/nrf51/pkg.yml
+++ b/nimble/drivers/nrf51/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/drivers/nrf52/pkg.yml
+++ b/nimble/drivers/nrf52/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/host/include/host/ble_att.h
+++ b/nimble/host/include/host/ble_att.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/include/host/ble_gatt.h
+++ b/nimble/host/include/host/ble_gatt.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -231,7 +231,7 @@ struct ble_gatt_chr_def {
     /** Specifies minimum required key size to access this characteristic. */
     uint8_t min_key_size;
 
-    /** 
+    /**
      * At registration time, this is filled in with the characteristic's value
      * attribute handle.
      */

--- a/nimble/host/include/host/ble_hs_test.h
+++ b/nimble/host/include/host/ble_hs_test.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/include/host/ble_monitor.h
+++ b/nimble/host/include/host/ble_monitor.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/include/host/ble_store.h
+++ b/nimble/host/include/host/ble_store.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -291,7 +291,7 @@ int ble_store_util_bonded_peers(ble_addr_t *out_peer_id_addrs,
                                 int *out_num_peers,
                                 int max_peers);
 int ble_store_util_delete_all(int type, const union ble_store_key *key);
-int ble_store_util_delete_peer(const ble_addr_t *peer_id_addr); 
+int ble_store_util_delete_peer(const ble_addr_t *peer_id_addr);
 int ble_store_util_delete_oldest_peer(void);
 int ble_store_util_count(int type, int *out_count);
 int ble_store_util_status_rr(struct ble_store_status_event *event, void *arg);

--- a/nimble/host/include/host/ble_uuid.h
+++ b/nimble/host/include/host/ble_uuid.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/mesh/pkg.yml
+++ b/nimble/host/mesh/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -31,7 +31,7 @@ pkg.deps:
     - "@apache-mynewt-core/util/mem"
     - "@apache-mynewt-core/crypto/tinycrypt"
     - nimble
-    - nimble/host  
+    - nimble/host
 
 pkg.deps.BLE_MESH_SHELL:
     - "@apache-mynewt-core/sys/shell"

--- a/nimble/host/mesh/syscfg.yml
+++ b/nimble/host/mesh/syscfg.yml
@@ -148,7 +148,7 @@ syscfg.defs:
     BLE_MESH_RELAY:
         description: >
             Support for acting as a Mesh Relay Node.
-        value: 0 
+        value: 0
 
     BLE_MESH_LOW_POWER:
         description: >
@@ -230,19 +230,19 @@ syscfg.defs:
             in value for each iteration. The value is in units of 100
             milliseconds, so e.g. a value of 300 means 3 seconds.
         value: MYNEWT_VAL_BLE_MESH_LPN_POLL_TIMEOUT
-        
+
     BLE_MESH_LPN_SCAN_LATENCY:
         description: >
             Latency in milliseconds that it takes to enable scanning. This
             is in practice how much time in advance before the Receive Window
             that scanning is requested to be enabled.
         value: 10
-        
+
     BLE_MESH_LPN_GROUPS:
         description: >
             Maximum number of groups that the LPN can subscribe to.
         value: 10
-        
+
     BLE_MESH_FRIEND:
         description: >
             Enable this option to be able to act as a Friend Node.
@@ -252,19 +252,19 @@ syscfg.defs:
         description: >
             Receive Window in milliseconds supported by the Friend node.
         value: 255
-        
+
     BLE_MESH_FRIEND_QUEUE_SIZE:
         description: >
-            Minimum number of buffers available to be stored for each 
+            Minimum number of buffers available to be stored for each
             local Friend Queue.
         value: 16
-        
+
     BLE_MESH_FRIEND_SUB_LIST_SIZE:
         description: >
             Size of the Subscription List that can be supported by a
             Friend node for a Low Power node.
         value: 3
-        
+
     BLE_MESH_FRIEND_LPN_COUNT:
         description: >
             Number of Low Power Nodes the Friend can have a Friendship
@@ -317,7 +317,7 @@ syscfg.defs:
         description: >
             Use this option to enable Beacon-related debug logs for the
             Bluetooth Mesh functionality.
-        value: 0    
+        value: 0
 
     BLE_MESH_DEBUG_CRYPTO:
         description: >
@@ -330,7 +330,7 @@ syscfg.defs:
             Use this option to enable Provisioning debug logs for the
             Bluetooth Mesh functionality.
         value: 0
-    
+
     BLE_MESH_DEBUG_ACCESS:
         description: >
             Use this option to enable Access layer and device composition
@@ -341,7 +341,7 @@ syscfg.defs:
         description: >
             Use this option to enable debug logs for the Foundation
             Models.
-        value: 0    
+        value: 0
 
     BLE_MESH_DEBUG_ADV:
         description: >
@@ -360,7 +360,7 @@ syscfg.defs:
             Use this option to enable Friend debug logs for the
             Bluetooth Mesh functionality.
         value: 0
-        
+
     BLE_MESH_DEBUG_PROXY:
         description: >
             Use this option to enable Proxy protocol debug logs.

--- a/nimble/host/pkg.yml
+++ b/nimble/host/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/host/pts/pts-gap.txt
+++ b/nimble/host/pts/pts-gap.txt
@@ -218,7 +218,7 @@ TC_SEC_AUT_BV_14_C	PASS	b set sm_data io_capabilities=1
 				      pairing for read
 				b passkey conn=<handle> action=3 key=123456
 				Note: enter '123456' passkey in PTS
-				Note: enter handle for characteristics value which 
+				Note: enter handle for characteristics value which
 				      requires authentication
 TC_SEC_AUT_BV_15_C	N/A
 TC_SEC_AUT_BV_16_C	N/A

--- a/nimble/host/pts/pts-gatt.txt
+++ b/nimble/host/pts/pts-gatt.txt
@@ -56,8 +56,8 @@ GATT/CL/GAD/BV-06-C	PASS	b conn peer_addr=<addr>
 				<answer YES>
 				b term conn=<handle>
 				<repeat>
-GATT/CL/GAD/BV-07-C	N/A	
-GATT/CL/GAD/BV-08-C	N/A	
+GATT/CL/GAD/BV-07-C	N/A
+GATT/CL/GAD/BV-08-C	N/A
 -------------------------------------------------------------------------------
 
 GATT/CL/GAR/BV-01-C	PASS	b conn peer_addr=<addr>
@@ -137,7 +137,7 @@ GATT/CL/GAR/BI-16-C	PASS	b conn peer_addr=<addr>
 GATT/CL/GAR/BI-17-C	PASS	b conn peer_addr=<addr>
 				b read conn=<handle> long=1 attr=<val_handle>
 				<answer YES>
-				b term conn=<handle>	
+				b term conn=<handle>
 GATT/CL/GAR/BV-05-C	PASS	b conn peer_addr=<addr>
 				b read conn=<handle> attr=<val_handle1> attr=<val_handle2>
 				b term conn=<handle>
@@ -184,7 +184,7 @@ GATT/CL/GAR/BI-26-C	PASS	b conn peer_addr=<addr>
 GATT/CL/GAR/BI-27-C	PASS	b conn peer_addr=<addr>
 				b read conn=<handle> attr=<val_handle>
 				<answer YES>
-				b term conn=<handle>	
+				b term conn=<handle>
 GATT/CL/GAR/BV-07-C	PASS	b conn peer_addr=<addr>
 				b read conn=<handle> long=1 attr=<val_handle>
 				<answer YES>
@@ -444,8 +444,8 @@ GATT/SR/GAR/BI-35-C	N/A
 -------------------------------------------------------------------------------
 
 GATT/SR/GAW/BV-01-C	PASS	b adv
-GATT/SR/GAW/BV-02-C	N/A	
-GATT/SR/GAW/BI-01-C	N/A	
+GATT/SR/GAW/BV-02-C	N/A
+GATT/SR/GAW/BI-01-C	N/A
 GATT/SR/GAW/BV-03-C	PASS	b adv
 GATT/SR/GAW/BI-02-C	PASS	b adv
 				<enter ffff>
@@ -460,7 +460,7 @@ GATT/SR/GAW/BI-08-C	PASS	b adv
 				<enter long value handle without WRITE flag>
 GATT/SR/GAW/BI-09-C	PASS	b adv
 GATT/SR/GAW/BI-11-C	N/A
-GATT/SR/GAW/BI-12-C	PASS	b adv	
+GATT/SR/GAW/BI-12-C	PASS	b adv
 GATT/SR/GAW/BI-13-C	PASS	b adv
 GATT/SR/GAW/BV-06-C	PASS	b adv
 GATT/SR/GAW/BV-10-C	PASS	b adv

--- a/nimble/host/services/ans/include/services/ans/ble_svc_ans.h
+++ b/nimble/host/services/ans/include/services/ans/ble_svc_ans.h
@@ -32,7 +32,7 @@ struct ble_hs_cfg;
 #define BLE_SVC_ANS_CHR_UUID16_UNR_ALERT_STAT               0x2a45
 #define BLE_SVC_ANS_CHR_UUID16_ALERT_NOT_CTRL_PT            0x2a44
 
-/* Alert Notification Service Category ID Bit Masks 
+/* Alert Notification Service Category ID Bit Masks
  *
  * TODO: Add remaining 2 optional categories */
 #define BLE_SVC_ANS_CAT_BM_NONE                             0x00
@@ -43,7 +43,7 @@ struct ble_hs_cfg;
 #define BLE_SVC_ANS_CAT_BM_MISSED_CALL                      0x10
 #define BLE_SVC_ANS_CAT_BM_SMS                              0x20
 #define BLE_SVC_ANS_CAT_BM_VOICE_MAIL                       0x40
-#define BLE_SVC_ANS_CAT_BM_SCHEDULE                         0x80    
+#define BLE_SVC_ANS_CAT_BM_SCHEDULE                         0x80
 
 /* Alert Notification Service Category IDs
  *
@@ -57,7 +57,7 @@ struct ble_hs_cfg;
 #define BLE_SVC_ANS_CAT_ID_VOICE_MAIL                       6
 #define BLE_SVC_ANS_CAT_ID_SCHEDULE                         7
 
-/* Number of valid ANS categories 
+/* Number of valid ANS categories
  *
  * TODO: Add remaining 2 optional categories */
 #define BLE_SVC_ANS_CAT_NUM                                 8
@@ -75,7 +75,7 @@ struct ble_hs_cfg;
 
 void ble_svc_ans_on_gap_connect(uint16_t conn_handle);
 
-int ble_svc_ans_new_alert_add(uint8_t cat_id, 
+int ble_svc_ans_new_alert_add(uint8_t cat_id,
                               const char * info_str);
 int ble_svc_ans_unr_alert_add(uint8_t cat_id);
 

--- a/nimble/host/services/ans/pkg.yml
+++ b/nimble/host/services/ans/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,10 +22,10 @@ pkg.description: Alert Notification Service Server.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - ble 
+    - ble
     - bluetooth
-    - ans 
-    - nimble 
+    - ans
+    - nimble
 
 pkg.deps:
     - nimble/host

--- a/nimble/host/services/ans/src/ble_svc_ans.c
+++ b/nimble/host/services/ans/src/ble_svc_ans.c
@@ -34,7 +34,7 @@
 
 /* Supported categories bitmasks */
 static uint8_t ble_svc_ans_new_alert_cat;
-static uint8_t ble_svc_ans_unr_alert_cat; 
+static uint8_t ble_svc_ans_unr_alert_cat;
 
 /* Characteristic values */
 static uint8_t ble_svc_ans_new_alert_val[BLE_SVC_ANS_NEW_ALERT_MAX_LEN];
@@ -50,7 +50,7 @@ static uint8_t ble_svc_ans_unr_alert_cnt[BLE_SVC_ANS_CAT_NUM];
 static uint16_t ble_svc_ans_new_alert_val_handle;
 static uint16_t ble_svc_ans_unr_alert_val_handle;
 
-/* Connection handle 
+/* Connection handle
  *
  * TODO: In order to support multiple connections we would need to save
  *       the handles for every connection, not just the most recent. Then
@@ -73,7 +73,7 @@ ble_svc_ans_unr_alert_notify(uint8_t cat_id);
 
 /* Save written value to local characteristic value */
 static int
-ble_svc_ans_chr_write(struct os_mbuf *om, uint16_t min_len, uint16_t max_len, 
+ble_svc_ans_chr_write(struct os_mbuf *om, uint16_t min_len, uint16_t max_len,
                       void *dst, uint16_t *len);
 
 static const struct ble_gatt_svc_def ble_svc_ans_defs[] = {
@@ -82,18 +82,18 @@ static const struct ble_gatt_svc_def ble_svc_ans_defs[] = {
         .type = BLE_GATT_SVC_TYPE_PRIMARY,
         .uuid = BLE_UUID16_DECLARE(BLE_SVC_ANS_UUID16),
         .characteristics = (struct ble_gatt_chr_def[]) { {
-            /** Supported New Alert Catagory 
-             * 
-             * This characteristic exposes what categories of new 
+            /** Supported New Alert Catagory
+             *
+             * This characteristic exposes what categories of new
              * alert are supported in the server.
              */
             .uuid = BLE_UUID16_DECLARE(BLE_SVC_ANS_CHR_UUID16_SUP_NEW_ALERT_CAT),
             .access_cb = ble_svc_ans_access,
             .flags = BLE_GATT_CHR_F_READ,
         }, {
-            /** New Alert 
+            /** New Alert
              *
-             * This characteristic exposes information about 
+             * This characteristic exposes information about
              * the count of new alerts (for a given category).
              */
             .uuid = BLE_UUID16_DECLARE(BLE_SVC_ANS_CHR_UUID16_NEW_ALERT),
@@ -101,18 +101,18 @@ static const struct ble_gatt_svc_def ble_svc_ans_defs[] = {
             .val_handle = &ble_svc_ans_new_alert_val_handle,
             .flags = BLE_GATT_CHR_F_NOTIFY,
         }, {
-            /** Supported Unread Alert Catagory 
+            /** Supported Unread Alert Catagory
              *
-             * This characteristic exposes what categories of 
+             * This characteristic exposes what categories of
              * unread alert are supported in the server.
              */
             .uuid = BLE_UUID16_DECLARE(BLE_SVC_ANS_CHR_UUID16_SUP_UNR_ALERT_CAT),
             .access_cb = ble_svc_ans_access,
             .flags = BLE_GATT_CHR_F_READ,
         }, {
-            /** Unread Alert Status 
+            /** Unread Alert Status
              *
-             * This characteristic exposes the count of unread 
+             * This characteristic exposes the count of unread
              * alert events existing in the server.
              */
             .uuid = BLE_UUID16_DECLARE(BLE_SVC_ANS_CHR_UUID16_UNR_ALERT_STAT),
@@ -120,13 +120,13 @@ static const struct ble_gatt_svc_def ble_svc_ans_defs[] = {
             .val_handle = &ble_svc_ans_unr_alert_val_handle,
             .flags = BLE_GATT_CHR_F_NOTIFY,
         }, {
-            /** Alert Notification Control Point 
+            /** Alert Notification Control Point
              *
-             * This characteristic allows the peer device to 
-             * enable/disable the alert notification of new alert 
-             * and unread event more selectively than can be done 
-             * by setting or clearing the notification bit in the 
-             * Client Characteristic Configuration for each alert 
+             * This characteristic allows the peer device to
+             * enable/disable the alert notification of new alert
+             * and unread event more selectively than can be done
+             * by setting or clearing the notification bit in the
+             * Client Characteristic Configuration for each alert
              * characteristic.
              */
             .uuid = BLE_UUID16_DECLARE(BLE_SVC_ANS_CHR_UUID16_ALERT_NOT_CTRL_PT),
@@ -152,11 +152,11 @@ ble_svc_ans_access(uint16_t conn_handle, uint16_t attr_handle,
 {
     uint16_t uuid16;
     int rc;
-    
+
     /* ANS Control point command and catagory variables */
     uint8_t cmd_id;
     uint8_t cat_id;
-    uint8_t cat_bit_mask; 
+    uint8_t cat_bit_mask;
     int i;
 
     uuid16 = ble_uuid_u16(ctxt->chr->uuid);
@@ -193,12 +193,12 @@ ble_svc_ans_access(uint16_t conn_handle, uint16_t attr_handle,
 
     case BLE_SVC_ANS_CHR_UUID16_UNR_ALERT_STAT:
         if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
-            rc = ble_svc_ans_chr_write(ctxt->om, 
-                                       sizeof ble_svc_ans_unr_alert_stat, 
+            rc = ble_svc_ans_chr_write(ctxt->om,
+                                       sizeof ble_svc_ans_unr_alert_stat,
                                        sizeof ble_svc_ans_unr_alert_stat,
                                        &ble_svc_ans_unr_alert_stat,
                                        NULL);
-            return rc; 
+            return rc;
         } else {
             rc = os_mbuf_append(ctxt->om, &ble_svc_ans_unr_alert_stat,
                                 sizeof ble_svc_ans_unr_alert_stat);
@@ -207,8 +207,8 @@ ble_svc_ans_access(uint16_t conn_handle, uint16_t attr_handle,
 
     case BLE_SVC_ANS_CHR_UUID16_ALERT_NOT_CTRL_PT:
         if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
-            rc = ble_svc_ans_chr_write(ctxt->om, 
-                                       sizeof ble_svc_ans_alert_not_ctrl_pt, 
+            rc = ble_svc_ans_chr_write(ctxt->om,
+                                       sizeof ble_svc_ans_alert_not_ctrl_pt,
                                        sizeof ble_svc_ans_alert_not_ctrl_pt,
                                        &ble_svc_ans_alert_not_ctrl_pt,
                                        NULL);
@@ -223,8 +223,8 @@ ble_svc_ans_access(uint16_t conn_handle, uint16_t attr_handle,
 
             /* Set cat_bit_mask to the appropriate bitmask based on cat_id */
             if (cat_id < BLE_SVC_ANS_CAT_NUM) {
-                cat_bit_mask = (1 << cat_id); 
-            } else if (cat_id == 0xff) { 
+                cat_bit_mask = (1 << cat_id);
+            } else if (cat_id == 0xff) {
                 cat_bit_mask = cat_id;
             } else {
                 /* invalid category ID */
@@ -233,7 +233,7 @@ ble_svc_ans_access(uint16_t conn_handle, uint16_t attr_handle,
 
             switch (cmd_id) {
             case BLE_SVC_ANS_CMD_EN_NEW_ALERT_CAT:
-                ble_svc_ans_new_alert_cat |= cat_bit_mask; 
+                ble_svc_ans_new_alert_cat |= cat_bit_mask;
                 break;
             case BLE_SVC_ANS_CMD_EN_UNR_ALERT_CAT:
                 ble_svc_ans_unr_alert_cat |= cat_bit_mask;
@@ -284,15 +284,15 @@ ble_svc_ans_access(uint16_t conn_handle, uint16_t attr_handle,
 }
 
 /**
- * This function must be called with the connection handlewhen a gap 
+ * This function must be called with the connection handlewhen a gap
  * connect event is received in order to send notifications to the
  * client.
  *
  * @params conn_handle          The connection handle for the current
  *                                  connection.
  */
-void 
-ble_svc_ans_on_gap_connect(uint16_t conn_handle) 
+void
+ble_svc_ans_on_gap_connect(uint16_t conn_handle)
 {
     ble_svc_ans_conn_handle = conn_handle;
 }
@@ -305,16 +305,16 @@ ble_svc_ans_on_gap_connect(uint16_t conn_handle)
  *                                  should be incremented and notified
  * @param info_str              The info string to be sent to the client
  *                                  with the notification.
- * 
- * @return 0 on success, non-zero error code otherwise. 
+ *
+ * @return 0 on success, non-zero error code otherwise.
  */
 int
 ble_svc_ans_new_alert_add(uint8_t cat_id, const char * info_str)
 {
-    uint8_t cat_bit_mask; 
-    
+    uint8_t cat_bit_mask;
+
     if (cat_id < BLE_SVC_ANS_CAT_NUM) {
-        cat_bit_mask = (1 << cat_id); 
+        cat_bit_mask = (1 << cat_id);
     } else {
         return BLE_HS_EINVAL;
     }
@@ -330,17 +330,17 @@ ble_svc_ans_new_alert_add(uint8_t cat_id, const char * info_str)
 /**
  * Adds an unread alert to the given category then notifies the client
  * if the given category is valid and enabled.
- * 
+ *
  * @param cat_flag              The flag for the category which should
  *                                  should be incremented and notified
- * 
- * @return 0 on success, non-zero error code otherwise. 
+ *
+ * @return 0 on success, non-zero error code otherwise.
  */
 int
 ble_svc_ans_unr_alert_add(uint8_t cat_id)
 {
-    uint8_t cat_bit_mask; 
-    
+    uint8_t cat_bit_mask;
+
     if (cat_id < BLE_SVC_ANS_CAT_NUM) {
         cat_bit_mask = 1 << cat_id;
     } else {
@@ -356,12 +356,12 @@ ble_svc_ans_unr_alert_add(uint8_t cat_id)
 }
 
 /**
- * Send a new alert notification to the given category with the 
+ * Send a new alert notification to the given category with the
  * given info string.
  *
- * @param cat_id                The ID of the category to send the 
+ * @param cat_id                The ID of the category to send the
  *                                  notification to.
- * @param info_str              The info string to send with the 
+ * @param info_str              The info string to send with the
  *                                  notification
  *
  * @return 0 on success, non-zero error code otherwise.
@@ -372,25 +372,25 @@ ble_svc_ans_new_alert_notify(uint8_t cat_id, const char * info_str)
     int info_str_len;
 
     /* Clear notification to remove old infomation that may persist */
-    memset(&ble_svc_ans_new_alert_val, '\0', 
-           BLE_SVC_ANS_NEW_ALERT_MAX_LEN); 
-    
+    memset(&ble_svc_ans_new_alert_val, '\0',
+           BLE_SVC_ANS_NEW_ALERT_MAX_LEN);
+
     /* Set ID and count values */
     ble_svc_ans_new_alert_val[0] = cat_id;
     ble_svc_ans_new_alert_val[1] = ble_svc_ans_new_alert_cnt[cat_id];
-    
+
     if (info_str) {
         info_str_len = strlen(info_str);
         if (info_str_len > BLE_SVC_ANS_INFO_STR_MAX_LEN) {
-            /* If info_str is longer than the max string length only 
+            /* If info_str is longer than the max string length only
              * write up to the maximum length */
-            memcpy(&ble_svc_ans_new_alert_val[2], info_str, 
+            memcpy(&ble_svc_ans_new_alert_val[2], info_str,
                    BLE_SVC_ANS_INFO_STR_MAX_LEN);
         } else {
             memcpy(&ble_svc_ans_new_alert_val[2], info_str, info_str_len);
         }
     }
-    return ble_gattc_notify(ble_svc_ans_conn_handle, 
+    return ble_gattc_notify(ble_svc_ans_conn_handle,
                             ble_svc_ans_new_alert_val_handle);
 }
 
@@ -407,12 +407,12 @@ ble_svc_ans_unr_alert_notify(uint8_t cat_id)
 {
     ble_svc_ans_unr_alert_stat[0] = cat_id;
     ble_svc_ans_unr_alert_stat[1] = ble_svc_ans_unr_alert_cnt[cat_id];
-    return ble_gattc_notify(ble_svc_ans_conn_handle, 
+    return ble_gattc_notify(ble_svc_ans_conn_handle,
                             ble_svc_ans_unr_alert_val_handle);
 }
 
 /**
- * Writes the received value from a characteristic write to 
+ * Writes the received value from a characteristic write to
  * the given destination.
  */
 static int
@@ -438,9 +438,9 @@ ble_svc_ans_chr_write(struct os_mbuf *om, uint16_t min_len,
 
 /**
  * Initialize the ANS with initial values for enabled categories
- * for new and unread alert characteristics. Bitwise or the 
+ * for new and unread alert characteristics. Bitwise or the
  * catagory bitmasks to enable multiple catagories.
- * 
+ *
  * XXX: We should technically be able to change the new alert and
  *      unread alert catagories when we have no active connections.
  */
@@ -457,7 +457,7 @@ ble_svc_ans_init(void)
 
     rc = ble_gatts_add_svcs(ble_svc_ans_defs);
     SYSINIT_PANIC_ASSERT(rc == 0);
-    
+
     ble_svc_ans_new_alert_cat = MYNEWT_VAL(BLE_SVC_ANS_NEW_ALERT_CAT);
     ble_svc_ans_unr_alert_cat = MYNEWT_VAL(BLE_SVC_ANS_UNR_ALERT_CAT);
 }

--- a/nimble/host/services/bas/pkg.yml
+++ b/nimble/host/services/bas/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,10 +22,10 @@ pkg.description: Battery Service
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - ble 
+    - ble
     - bluetooth
     - bas
-    - nimble 
+    - nimble
 
 pkg.deps:
     - nimble/host

--- a/nimble/host/services/dis/include/services/dis/ble_svc_dis.h
+++ b/nimble/host/services/dis/include/services/dis/ble_svc_dis.h
@@ -60,7 +60,7 @@ struct ble_svc_dis_data {
      * Firmware revision.
      * Represent the firmware revision for the firmware within the device.
      */
-    const char *firmware_revision; 
+    const char *firmware_revision;
     /**
      * Hardware revision.
      * Represent the hardware revision for the hardware within the device.
@@ -84,7 +84,7 @@ struct ble_svc_dis_data {
 extern struct ble_svc_dis_data ble_svc_dis_data;
 
 /**
- * Service initialisation. 
+ * Service initialisation.
  * Automatically called during package initialisation.
  */
 void ble_svc_dis_init(void);

--- a/nimble/host/services/dis/pkg.yml
+++ b/nimble/host/services/dis/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.description: Device Information Service Implementation.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - ble 
+    - ble
     - bluetooth
     - dis
     - nimble

--- a/nimble/host/services/dis/src/ble_svc_dis.c
+++ b/nimble/host/services/dis/src/ble_svc_dis.c
@@ -123,7 +123,7 @@ ble_svc_dis_access(uint16_t conn_handle, uint16_t attr_handle,
 {
     uint16_t uuid    = ble_uuid_u16(ctxt->chr->uuid);
     const char *info = NULL;
-    
+
     switch(uuid) {
 #if (MYNEWT_VAL(BLE_SVC_DIS_MODEL_NUMBER_READ_PERM) >= 0)
     case BLE_SVC_DIS_CHR_UUID16_MODEL_NUMBER:
@@ -134,7 +134,7 @@ ble_svc_dis_access(uint16_t conn_handle, uint16_t attr_handle,
 	}
 #endif
 	break;
-#endif	
+#endif
 #if (MYNEWT_VAL(BLE_SVC_DIS_SERIAL_NUMBER_READ_PERM) >= 0)
     case BLE_SVC_DIS_CHR_UUID16_SERIAL_NUMBER:
 	info = ble_svc_dis_data.serial_number;
@@ -144,7 +144,7 @@ ble_svc_dis_access(uint16_t conn_handle, uint16_t attr_handle,
 	}
 #endif
 	break;
-#endif	
+#endif
 #if (MYNEWT_VAL(BLE_SVC_DIS_FIRMWARE_REVISION_READ_PERM) >= 0)
     case BLE_SVC_DIS_CHR_UUID16_FIRMWARE_REVISION:
 	info = ble_svc_dis_data.firmware_revision;
@@ -154,7 +154,7 @@ ble_svc_dis_access(uint16_t conn_handle, uint16_t attr_handle,
 	}
 #endif
 	break;
-#endif	
+#endif
 #if (MYNEWT_VAL(BLE_SVC_DIS_HARDWARE_REVISION_READ_PERM) >= 0)
     case BLE_SVC_DIS_CHR_UUID16_HARDWARE_REVISION:
 	info = ble_svc_dis_data.hardware_revision;
@@ -164,7 +164,7 @@ ble_svc_dis_access(uint16_t conn_handle, uint16_t attr_handle,
 	}
 #endif
 	break;
-#endif	
+#endif
 #if (MYNEWT_VAL(BLE_SVC_DIS_SOFTWARE_REVISION_READ_PERM) >= 0)
     case BLE_SVC_DIS_CHR_UUID16_SOFTWARE_REVISION:
 	info = ble_svc_dis_data.software_revision;
@@ -174,7 +174,7 @@ ble_svc_dis_access(uint16_t conn_handle, uint16_t attr_handle,
 	}
 #endif
 	break;
-#endif	
+#endif
 #if (MYNEWT_VAL(BLE_SVC_DIS_MANUFACTURER_NAME_READ_PERM) >= 0)
     case BLE_SVC_DIS_CHR_UUID16_MANUFACTURER_NAME:
 	info = ble_svc_dis_data.manufacturer_name;

--- a/nimble/host/services/gap/pkg.yml
+++ b/nimble/host/services/gap/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -18,7 +18,7 @@
 #
 
 pkg.name: nimble/host/services/gap
-pkg.description: Implements the GAP Service. 
+pkg.description: Implements the GAP Service.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:

--- a/nimble/host/services/gatt/pkg.yml
+++ b/nimble/host/services/gatt/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/host/services/ias/include/services/ias/ble_svc_ias.h
+++ b/nimble/host/services/ias/include/services/ias/ble_svc_ias.h
@@ -28,7 +28,7 @@
 #define BLE_SVC_IAS_ALERT_LEVEL_MILD_ALERT                      1
 #define BLE_SVC_IAS_ALERT_LEVEL_HIGH_ALERT                      2
 
-typedef int ble_svc_ias_event_fn(uint8_t alert_level); 
+typedef int ble_svc_ias_event_fn(uint8_t alert_level);
 
 void ble_svc_ias_set_cb(ble_svc_ias_event_fn *cb);
 void ble_svc_ias_init(void);

--- a/nimble/host/services/ias/pkg.yml
+++ b/nimble/host/services/ias/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,9 +22,9 @@ pkg.description: Immediate Alert Service Implementation.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - ble 
+    - ble
     - bluetooth
-    - ias 
+    - ias
     - nimble
 
 pkg.deps:

--- a/nimble/host/services/ias/src/ble_svc_ias.c
+++ b/nimble/host/services/ias/src/ble_svc_ias.c
@@ -61,26 +61,26 @@ static const struct ble_gatt_svc_def ble_svc_ias_defs[] = {
 };
 
 /**
- * Writes the received value from a characteristic write to 
+ * Writes the received value from a characteristic write to
  * the given destination.
  */
 static int
-ble_svc_ias_chr_write(struct os_mbuf *om, uint16_t min_len, 
-                      uint16_t max_len, void *dst, 
+ble_svc_ias_chr_write(struct os_mbuf *om, uint16_t min_len,
+                      uint16_t max_len, void *dst,
                       uint16_t *len)
 {
     uint16_t om_len;
-    int rc; 
+    int rc;
 
     om_len = OS_MBUF_PKTLEN(om);
     if (om_len < min_len || om_len > max_len) {
         return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-    }   
+    }
 
     rc = ble_hs_mbuf_to_flat(om, dst, max_len, len);
     if (rc != 0) {
         return BLE_ATT_ERR_UNLIKELY;
-    }   
+    }
 
     return 0;
 }
@@ -94,9 +94,9 @@ ble_svc_ias_access(uint16_t conn_handle, uint16_t attr_handle,
                    struct ble_gatt_access_ctxt *ctxt, void *arg)
 {
     int rc;
-    
+
     assert(ctxt->chr == &ble_svc_ias_defs[0].characteristics[0]);
-    
+
     switch (ctxt->op) {
     case BLE_GATT_ACCESS_OP_WRITE_CHR:
         rc = ble_svc_ias_chr_write(ctxt->om,
@@ -121,7 +121,7 @@ ble_svc_ias_access(uint16_t conn_handle, uint16_t attr_handle,
  * Designates the specified function as the IAS callback.  This callback is
  * necessary for this service to function properly.
  *
- * @param cb                        The callback function to call when 
+ * @param cb                        The callback function to call when
  *                                      the client signals an alert.
  */
 void
@@ -137,7 +137,7 @@ void
 ble_svc_ias_init(void)
 {
     int rc;
-    
+
     /* Ensure this function only gets called by sysinit. */
     SYSINIT_ASSERT_ACTIVE();
 

--- a/nimble/host/services/lls/include/services/lls/ble_svc_lls.h
+++ b/nimble/host/services/lls/include/services/lls/ble_svc_lls.h
@@ -34,11 +34,11 @@ struct ble_hs_cfg;
 #define BLE_SVC_LLS_ALERT_LEVEL_MILD_ALERT                  1
 #define BLE_SVC_LLS_ALERT_LEVEL_HIGH_ALERT                  2
 
-typedef int ble_svc_lls_event_fn(uint8_t alert_level); 
+typedef int ble_svc_lls_event_fn(uint8_t alert_level);
 
 uint8_t ble_svc_lls_alert_level_get(void);
 int ble_svc_lls_alert_level_set(uint8_t alert_level);
-void ble_svc_lls_on_gap_disconnect(int reason); 
+void ble_svc_lls_on_gap_disconnect(int reason);
 
 void ble_svc_lls_set_cb(ble_svc_lls_event_fn *cb);
 void ble_svc_lls_init(void);

--- a/nimble/host/services/lls/pkg.yml
+++ b/nimble/host/services/lls/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -22,7 +22,7 @@ pkg.description: Link Loss Service Implementation.
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
-    - ble 
+    - ble
     - bluetooth
     - lls
     - nimble

--- a/nimble/host/services/lls/src/ble_svc_lls.c
+++ b/nimble/host/services/lls/src/ble_svc_lls.c
@@ -31,8 +31,8 @@ static uint8_t ble_svc_lls_alert_level;
 
 /* Write characteristic function */
 static int
-ble_svc_lls_chr_write(struct os_mbuf *om, uint16_t min_len, 
-                      uint16_t max_len, void *dst, 
+ble_svc_lls_chr_write(struct os_mbuf *om, uint16_t min_len,
+                      uint16_t max_len, void *dst,
                       uint16_t *len);
 
 /* Access function */
@@ -61,26 +61,26 @@ static const struct ble_gatt_svc_def ble_svc_lls_defs[] = {
 };
 
 /**
- * Writes the received value from a characteristic write to 
+ * Writes the received value from a characteristic write to
  * the given destination.
  */
 static int
-ble_svc_lls_chr_write(struct os_mbuf *om, uint16_t min_len, 
-                      uint16_t max_len, void *dst, 
+ble_svc_lls_chr_write(struct os_mbuf *om, uint16_t min_len,
+                      uint16_t max_len, void *dst,
                       uint16_t *len)
 {
     uint16_t om_len;
-    int rc; 
+    int rc;
 
     om_len = OS_MBUF_PKTLEN(om);
     if (om_len < min_len || om_len > max_len) {
         return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-    }   
+    }
 
     rc = ble_hs_mbuf_to_flat(om, dst, max_len, len);
     if (rc != 0) {
         return BLE_ATT_ERR_UNLIKELY;
-    }   
+    }
 
     return 0;
 }
@@ -102,11 +102,11 @@ ble_svc_lls_access(uint16_t conn_handle, uint16_t attr_handle,
         return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
 
     case BLE_GATT_ACCESS_OP_WRITE_CHR:
-        rc = ble_svc_lls_chr_write(ctxt->om, 
+        rc = ble_svc_lls_chr_write(ctxt->om,
                                    sizeof ble_svc_lls_alert_level,
                                    sizeof ble_svc_lls_alert_level,
                                    &ble_svc_lls_alert_level, NULL);
-        return rc; 
+        return rc;
 
     default:
         assert(0);
@@ -120,11 +120,11 @@ ble_svc_lls_access(uint16_t conn_handle, uint16_t attr_handle,
  * This function is the crux of the link loss service. The application
  * developer must call this function inside the gap event callback
  * function when a BLE_GAP_EVENT_DISCONNECT event is received and
- * pass the disconnect reason into this function. 
- * 
+ * pass the disconnect reason into this function.
+ *
  * Here, we then check if the disconnect reason is due to a timout, and if
- * so, we call the ble_svc_lls_event_fn callback with the current 
- * alert level. The actual alert implementation is left up to the 
+ * so, we call the ble_svc_lls_event_fn callback with the current
+ * alert level. The actual alert implementation is left up to the
  * developer.
  *
  * @param reason            The reason attatched to the GAP disconnect
@@ -135,7 +135,7 @@ ble_svc_lls_on_gap_disconnect(int reason)
 {
     if (reason == BLE_HS_HCI_ERR(BLE_ERR_CONN_SPVN_TMO)) {
             ble_svc_lls_cb_fn(ble_svc_lls_alert_level);
-    } 
+    }
 }
 
 /**
@@ -150,7 +150,7 @@ ble_svc_lls_alert_level_get(void)
 }
 
 /**
- * Sets the current alert level. 
+ * Sets the current alert level.
  *
  * @return 0 on success, BLE_HS_EINVAL if the given alert level is not valid.
  */
@@ -160,8 +160,8 @@ ble_svc_lls_alert_level_set(uint8_t alert_level)
     if (alert_level > BLE_SVC_LLS_ALERT_LEVEL_HIGH_ALERT) {
         return BLE_HS_EINVAL;
     }
-    
-    memcpy(&ble_svc_lls_alert_level, &alert_level, 
+
+    memcpy(&ble_svc_lls_alert_level, &alert_level,
            sizeof alert_level);
 
     return 0;
@@ -180,7 +180,7 @@ void
 ble_svc_lls_init(void)
 {
     int rc;
-    
+
     /* Ensure this function only gets called by sysinit. */
     SYSINIT_ASSERT_ACTIVE();
 

--- a/nimble/host/services/tps/pkg.yml
+++ b/nimble/host/services/tps/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -24,7 +24,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - ble
     - bluetooth
-    - tps 
+    - tps
     - nimble
 
 pkg.deps:

--- a/nimble/host/services/tps/src/ble_svc_tps.c
+++ b/nimble/host/services/tps/src/ble_svc_tps.c
@@ -66,9 +66,9 @@ ble_svc_tps_access(uint16_t conn_handle, uint16_t attr_handle,
                    struct ble_gatt_access_ctxt *ctxt, void *arg)
 {
     int rc;
-    
+
     assert(ctxt->chr == &ble_svc_tps_defs[0].characteristics[0]);
-    
+
     switch (ctxt->op) {
     case BLE_GATT_ACCESS_OP_READ_CHR:
         rc = ble_hs_hci_util_read_adv_tx_pwr(&ble_svc_tps_tx_power_level);

--- a/nimble/host/src/ble_att.c
+++ b/nimble/host/src/ble_att.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_att_clt.c
+++ b/nimble/host/src/ble_att_clt.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -763,7 +763,7 @@ ble_att_clt_tx_write_cmd(uint16_t conn_handle, uint16_t handle,
         assert(rc == 0);
         BLE_HS_LOG(DEBUG, "0x%02x", b);
     }
-    
+
 
     cmd = ble_att_cmd_get(BLE_ATT_OP_WRITE_CMD, sizeof(*cmd), &txom2);
     if (cmd == NULL) {

--- a/nimble/host/src/ble_att_cmd.c
+++ b/nimble/host/src/ble_att_cmd.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_att_cmd_priv.h
+++ b/nimble/host/src/ble_att_cmd_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -330,7 +330,7 @@ ble_att_svr_check_perms(uint16_t conn_handle, int is_read,
  * @param now                   The current OS time.
  *
  * @return                      The number of ticks until the current queued
- *                                  write times out.  
+ *                                  write times out.
  */
 int32_t
 ble_att_svr_ticks_until_tmo(const struct ble_att_svr_conn *svr, os_time_t now)
@@ -411,7 +411,7 @@ err:
 }
 
 static int
-ble_att_svr_read_flat(uint16_t conn_handle, 
+ble_att_svr_read_flat(uint16_t conn_handle,
                       struct ble_att_svr_entry *entry,
                       uint16_t offset,
                       uint16_t max_len,

--- a/nimble/host/src/ble_eddystone.c
+++ b/nimble/host/src/ble_eddystone.c
@@ -194,7 +194,7 @@ ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
     }
 
     svc_data = ble_eddystone_set_svc_data_base(BLE_EDDYSTONE_FRAME_TYPE_URL);
-    
+
     rc = ble_hs_hci_util_read_adv_tx_pwr(&tx_pwr);
     if (rc != 0) {
         return rc;

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -1637,7 +1637,7 @@ ble_gap_update_timer(void)
  * @param cb                    The callback to associate with the connection.
  * @param cb_arg                An optional argument that the callback
  *                                  receives.
- * 
+ *
  * @return                      0 on success;
  *                              BLE_HS_ENOTCONN if there is no connection with
  *                                  the specified handle.

--- a/nimble/host/src/ble_gatt_priv.h
+++ b/nimble/host/src/ble_gatt_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1191,7 +1191,7 @@ ble_gatts_start(void)
     int rc;
     int i;
 
-    ble_hs_lock(); 
+    ble_hs_lock();
     if (!ble_gatts_mutable()) {
         rc = BLE_HS_EBUSY;
         goto done;
@@ -1976,7 +1976,7 @@ ble_gatts_add_svcs(const struct ble_gatt_svc_def *svcs)
     void *p;
     int rc;
 
-    ble_hs_lock(); 
+    ble_hs_lock();
     if (!ble_gatts_mutable()) {
         rc = BLE_HS_EBUSY;
         goto done;

--- a/nimble/host/src/ble_hs_adv.c
+++ b/nimble/host/src/ble_hs_adv.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -406,7 +406,7 @@ ble_hs_conn_timer(void)
     /* If there are no timeouts configured, then there is nothing to check. */
 #if MYNEWT_VAL(BLE_L2CAP_RX_FRAG_TIMEOUT) == 0 && \
     BLE_HS_ATT_SVR_QUEUED_WRITE_TMO == 0
-     
+
     return BLE_HS_FOREVER;
 #endif
 
@@ -493,7 +493,7 @@ ble_hs_conn_timer(void)
     return next_exp_in;
 }
 
-int 
+int
 ble_hs_conn_init(void)
 {
     int rc;

--- a/nimble/host/src/ble_hs_conn_priv.h
+++ b/nimble/host/src/ble_hs_conn_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_hs_dbg_priv.h
+++ b/nimble/host/src/ble_hs_dbg_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_hs_flow.c
+++ b/nimble/host/src/ble_hs_flow.c
@@ -27,7 +27,7 @@ static int
 ble_hs_flow_tx_num_comp_pkts(void)
 {
     uint8_t buf[
-        BLE_HCI_HOST_NUM_COMP_PKTS_HDR_LEN + 
+        BLE_HCI_HOST_NUM_COMP_PKTS_HDR_LEN +
         BLE_HCI_HOST_NUM_COMP_PKTS_ENT_LEN
     ];
     struct hci_host_num_comp_pkts_entry entry;
@@ -153,7 +153,7 @@ ble_hs_flow_acl_free(struct os_mempool_ext *mpe, void *data, void *arg)
      * freed.
      */
     ble_hs_lock_nested();
-    
+
     conn = ble_hs_conn_find(conn_handle);
     if (conn != NULL) {
         ble_hs_flow_inc_completed_pkts(conn);
@@ -171,7 +171,7 @@ ble_hs_flow_connection_broken(uint16_t conn_handle)
 #if MYNEWT_VAL(BLE_HS_FLOW_CTRL) &&                 \
     MYNEWT_VAL(BLE_HS_FLOW_CTRL_TX_ON_DISCONNECT)
     ble_hs_lock();
-    ble_hs_flow_tx_num_comp_pkts(); 
+    ble_hs_flow_tx_num_comp_pkts();
     ble_hs_unlock();
 #endif
 }

--- a/nimble/host/src/ble_hs_flow_priv.h
+++ b/nimble/host/src/ble_hs_flow_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -96,7 +96,7 @@ void
 ble_hs_hci_add_avail_pkts(uint16_t delta)
 {
     BLE_HS_DBG_ASSERT(ble_hs_locked_by_cur_task());
-    
+
     if (ble_hs_hci_avail_pkts + delta > UINT16_MAX) {
         ble_hs_sched_reset(BLE_HS_ECONTROLLER);
     } else {
@@ -521,7 +521,7 @@ err:
  *                                  by the `om` parameter.
  *                              A BLE host core return code on unexpected
  *                                  error.
- * 
+ *
  */
 int
 ble_hs_hci_acl_tx(struct ble_hs_conn *conn, struct os_mbuf **om)

--- a/nimble/host/src/ble_hs_mbuf.c
+++ b/nimble/host/src/ble_hs_mbuf.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_hs_mbuf_priv.h
+++ b/nimble/host/src/ble_hs_mbuf_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_hs_misc.c
+++ b/nimble/host/src/ble_hs_misc.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_hs_startup_priv.h
+++ b/nimble/host/src/ble_hs_startup_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_l2cap.c
+++ b/nimble/host/src/ble_l2cap.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -382,7 +382,7 @@ err:
 /**
  * Transmits the L2CAP payload contained in the specified mbuf.  The supplied
  * mbuf is consumed, regardless of the outcome of the function call.
- * 
+ *
  * @param chan                  The L2CAP channel to transmit over.
  * @param txom                  The data to transmit.
  *

--- a/nimble/host/src/ble_l2cap_coc.c
+++ b/nimble/host/src/ble_l2cap_coc.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_l2cap_priv.h
+++ b/nimble/host/src/ble_l2cap_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_l2cap_sig.c
+++ b/nimble/host/src/ble_l2cap_sig.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -892,7 +892,7 @@ ble_l2cap_sig_disc_req_rx(uint16_t conn_handle, struct ble_l2cap_sig_hdr *hdr,
     req = (struct ble_l2cap_sig_disc_req *) (*om)->om_data;
 
     /* Let's find matching channel. Note that destination CID in the request
-     * is from peer perspective. It is source CID from nimble perspective 
+     * is from peer perspective. It is source CID from nimble perspective
      */
     chan = ble_hs_conn_chan_find_by_scid(conn, le16toh(req->dcid));
     if (!chan || (le16toh(req->scid) != chan->dcid)) {
@@ -1192,7 +1192,7 @@ ble_l2cap_sig_extract_expired(struct ble_l2cap_sig_proc_list *dst_list)
     proc = STAILQ_FIRST(&ble_l2cap_sig_procs);
     while (proc != NULL) {
         next = STAILQ_NEXT(proc, next);
-    
+
         time_diff = proc->exp_os_ticks - now;
         if (time_diff <= 0) {
             /* Procedure has expired; move it to the destination list. */

--- a/nimble/host/src/ble_l2cap_sig_cmd.c
+++ b/nimble/host/src/ble_l2cap_sig_cmd.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_l2cap_sig_priv.h
+++ b/nimble/host/src/ble_l2cap_sig_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_monitor_priv.h
+++ b/nimble/host/src/ble_monitor_priv.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/src/ble_sm_priv.h
+++ b/nimble/host/src/ble_sm_priv.h
@@ -196,7 +196,7 @@ struct ble_sm_dhkey_check {
 #if NIMBLE_BLE_SM
 
 #define BLE_SM_PROC_STATE_NONE              ((uint8_t)-1)
-    
+
 #define BLE_SM_PROC_STATE_PAIR              0
 #define BLE_SM_PROC_STATE_CONFIRM           1
 #define BLE_SM_PROC_STATE_RANDOM            2

--- a/nimble/host/src/ble_store_util.c
+++ b/nimble/host/src/ble_store_util.c
@@ -121,12 +121,12 @@ ble_store_util_delete_peer(const ble_addr_t *peer_id_addr)
     if (rc != 0) {
         return rc;
     }
-        
+
     rc = ble_store_util_delete_all(BLE_STORE_OBJ_TYPE_PEER_SEC, &key);
     if (rc != 0) {
         return rc;
     }
-        
+
     memset(&key, 0, sizeof key);
     key.cccd.peer_addr = *peer_id_addr;
 

--- a/nimble/host/src/ble_uuid.c
+++ b/nimble/host/src/ble_uuid.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/store/config/pkg.yml
+++ b/nimble/host/store/config/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/host/store/ram/pkg.yml
+++ b/nimble/host/store/ram/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/pkg.yml
+++ b/nimble/host/test/pkg.yml
@@ -5,7 +5,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_att_clt_test.c
+++ b/nimble/host/test/src/ble_att_clt_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_att_svr_test.c
+++ b/nimble/host/test/src/ble_att_svr_test.c
@@ -2017,7 +2017,7 @@ TEST_CASE(ble_att_svr_test_oom)
     ble_hs_test_util_prev_tx_dequeue();
 
     /* Receive a request. */
-    rc = ble_hs_test_util_rx_att_prep_write_req(conn_handle, 1, 0, 
+    rc = ble_hs_test_util_rx_att_prep_write_req(conn_handle, 1, 0,
                                                 ((uint8_t[1]){1}), 1);
     TEST_ASSERT_FATAL(rc == BLE_HS_ENOMEM);
 

--- a/nimble/host/test/src/ble_gap_test.c
+++ b/nimble/host/test/src/ble_gap_test.c
@@ -643,7 +643,7 @@ TEST_CASE(ble_gap_test_case_disc_ltd_mismatch)
         .rssi = 0,
         .addr = { BLE_ADDR_PUBLIC, { 1, 2, 3, 4, 5, 6 } },
         .data = (uint8_t[BLE_HS_ADV_MAX_SZ]){
-            2, 
+            2,
             BLE_HS_ADV_TYPE_FLAGS,
             BLE_HS_ADV_F_DISC_GEN,
         },

--- a/nimble/host/test/src/ble_gatt_conn_test.c
+++ b/nimble/host/test/src/ble_gatt_conn_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_gatt_disc_c_test.c
+++ b/nimble/host/test/src/ble_gatt_disc_c_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_gatt_disc_d_test.c
+++ b/nimble/host/test/src/ble_gatt_disc_d_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_gatt_disc_s_test.c
+++ b/nimble/host/test/src/ble_gatt_disc_s_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_gatt_find_s_test.c
+++ b/nimble/host/test/src/ble_gatt_find_s_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_gatt_read_test.c
+++ b/nimble/host/test/src/ble_gatt_read_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -662,7 +662,7 @@ TEST_CASE(ble_gatt_read_test_long)
     ble_gatt_read_test_misc_long_verify_bad(BLE_ATT_ERR_ATTR_NOT_FOUND,
         (struct ble_hs_test_util_flat_attr[]) { {
             .handle = 719,
-            .value = { 1, 2, 3, 4, 5, 6, 7 }, 
+            .value = { 1, 2, 3, 4, 5, 6, 7 },
             .value_len = 7
         } });
 }

--- a/nimble/host/test/src/ble_gatt_write_test.c
+++ b/nimble/host/test/src/ble_gatt_write_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_gatts_notify_test.c
+++ b/nimble/host/test/src/ble_gatts_notify_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -34,7 +34,7 @@ static uint8_t ble_gatts_notify_test_peer_addr[6] = {2,3,4,5,6,7};
 
 static int
 ble_gatts_notify_test_misc_access(uint16_t conn_handle,
-                                  uint16_t attr_handle, 
+                                  uint16_t attr_handle,
                                   struct ble_gatt_access_ctxt *ctxt,
                                   void *arg);
 static void

--- a/nimble/host/test/src/ble_gatts_reg_test.c
+++ b/nimble/host/test/src/ble_gatts_reg_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_hs_adv_test.c
+++ b/nimble/host/test/src/ble_hs_adv_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_hs_conn_test.c
+++ b/nimble/host/test/src/ble_hs_conn_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_hs_hci_test.c
+++ b/nimble/host/test/src/ble_hs_hci_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_hs_id_test.c
+++ b/nimble/host/test/src/ble_hs_id_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_hs_pvcy_test.c
+++ b/nimble/host/test/src/ble_hs_pvcy_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -37,7 +37,7 @@ ble_hs_pvcy_test_util_init(void)
 }
 
 static int
-ble_hs_pvcy_test_util_gap_event(struct ble_gap_event *event, void *arg) 
+ble_hs_pvcy_test_util_gap_event(struct ble_gap_event *event, void *arg)
 {
     TEST_ASSERT_FATAL(ble_hs_pvcy_test_num_gap_events <
                       BLE_HS_PVCY_TEST_MAX_GAP_EVENTS);
@@ -96,7 +96,7 @@ static void
 ble_hs_pvcy_test_util_add_irk_set_acks(void)
 {
     ble_hs_test_util_hci_ack_append(
-        BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST), 0); 
+        BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST), 0);
     ble_hs_test_util_hci_ack_append(
         BLE_HCI_OP(BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_PRIVACY_MODE), 0);
 }

--- a/nimble/host/test/src/ble_hs_test.c
+++ b/nimble/host/test/src/ble_hs_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_hs_test_util.c
+++ b/nimble/host/test/src/ble_hs_test_util.c
@@ -525,7 +525,7 @@ ble_hs_test_util_adv_start(uint8_t own_addr_type, const ble_addr_t *peer_addr,
     memset(acks + i, 0, sizeof acks[i]);
 
     ble_hs_test_util_hci_ack_set_seq(acks);
-    
+
     rc = ble_gap_adv_start(own_addr_type, peer_addr,
                            duration_ms, adv_params, cb, cb_arg);
 

--- a/nimble/host/test/src/ble_l2cap_test.c
+++ b/nimble/host/test/src/ble_l2cap_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_os_test.c
+++ b/nimble/host/test/src/ble_os_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_store_test.c
+++ b/nimble/host/test/src/ble_store_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/test/src/ble_uuid_test.c
+++ b/nimble/host/test/src/ble_uuid_test.c
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/host/tools/log2smtest.rb
+++ b/nimble/host/tools/log2smtest.rb
@@ -8,7 +8,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -389,7 +389,7 @@ end
 def parse_passkey_info(line)
     passkey_info = {}
 
-    case line 
+    case line
     when /passkey action event; action=4 numcmp=(\d+)/
         passkey_info[:action] = 4
         passkey_info[:numcmp] = $1.to_i(10)

--- a/nimble/host/util/pkg.yml
+++ b/nimble/host/util/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/include/nimble/ble_hci_trans.h
+++ b/nimble/include/nimble/ble_hci_trans.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/include/nimble/nimble_opt_auto.h
+++ b/nimble/include/nimble/nimble_opt_auto.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -15,7 +15,7 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- */ 
+ */
 
 #ifndef H_NIMBLE_OPT_AUTO_
 #define H_NIMBLE_OPT_AUTO_
@@ -28,7 +28,7 @@ extern "C" {
 
 /***
  * Automatic options.
- * 
+ *
  * These settings are generated automatically from the user-specified syscfg
  * settings.
  */
@@ -62,7 +62,7 @@ extern "C" {
      MYNEWT_VAL(BLE_GATT_DISC_ALL_CHRS) ||      \
      MYNEWT_VAL(BLE_GATT_DISC_CHRS_UUID) ||     \
      MYNEWT_VAL(BLE_GATT_READ_UUID))
-    
+
 #undef NIMBLE_BLE_ATT_CLT_READ
 #define NIMBLE_BLE_ATT_CLT_READ                 \
     (MYNEWT_VAL(BLE_GATT_READ) ||               \
@@ -97,7 +97,7 @@ extern "C" {
 #define NIMBLE_BLE_ATT_CLT_EXEC_WRITE           \
     (MYNEWT_VAL(BLE_GATT_WRITE_LONG))
 
-#undef NIMBLE_BLE_ATT_CLT_NOTIFY  
+#undef NIMBLE_BLE_ATT_CLT_NOTIFY
 #define NIMBLE_BLE_ATT_CLT_NOTIFY               \
     (MYNEWT_VAL(BLE_GATT_NOTIFY))
 

--- a/nimble/pkg.yml
+++ b/nimble/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/transport/emspi/pkg.yml
+++ b/nimble/transport/emspi/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/transport/pkg.yml
+++ b/nimble/transport/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/transport/ram/include/transport/ram/ble_hci_ram.h
+++ b/nimble/transport/ram/include/transport/ram/ble_hci_ram.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/nimble/transport/ram/pkg.yml
+++ b/nimble/transport/ram/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/transport/socket/pkg.yml
+++ b/nimble/transport/socket/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,

--- a/nimble/transport/uart/pkg.yml
+++ b/nimble/transport/uart/pkg.yml
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,


### PR DESCRIPTION
Implemented as below:

```
git grep -l '\s\+$' |grep -v tpg |xargs -r sed  -i 's/\s\+$//'
```

Files skipped: 

```
samveen@mynewt:~/workspace/sources/mynewt-nimble$ git grep -l '\s\+$' |grep  tpg
nimble/host/pts/tpg/94654-20170317-085122560.tpg
nimble/host/pts/tpg/94654-20170317-085441153.pts
````