### PR TITLE
call ble_gatts_chr_updated() on battery level change

### DIFF
--- a/nimble/host/services/bas/include/services/bas/ble_svc_bas.h
+++ b/nimble/host/services/bas/include/services/bas/ble_svc_bas.h
@@ -26,11 +26,6 @@
 /* 16 Bit Battery Service Characteristic UUIDs */
 #define BLE_SVC_BAS_CHR_UUID16_BATTERY_LEVEL                 0x2A19
 
-void ble_svc_bas_on_gap_connect(uint16_t conn_handle);
-
-void ble_svc_bas_init(void);
-
 int ble_svc_bas_battery_level_set(uint8_t level);
 
 #endif
-


### PR DESCRIPTION
This call doesn't require the connection handle, and thus doesn't
need an additional setup call to pass in that value.