### PR TITLE
nimble/host: Change timeouts defs to ms instead of ticks

### DIFF
--- a/nimble/host/mesh/src/adv.c
+++ b/nimble/host/mesh/src/adv.c
@@ -159,7 +159,7 @@ adv_thread(void *args)
 
 			// FIXME: should we redefine K_SECONDS macro instead in glue?
 			if (timeout != K_FOREVER) {
-				timeout = OS_TICKS_PER_SEC * timeout / 1000;
+				timeout = os_time_ms_to_ticks32(timeout);
 			}
 
 			ev = os_eventq_poll(&eventq_pool, 1, timeout);

--- a/nimble/host/mesh/src/glue.c
+++ b/nimble/host/mesh/src/glue.c
@@ -376,8 +376,7 @@ k_delayed_work_remaining_get (struct k_delayed_work *w)
 
     OS_EXIT_CRITICAL(sr);
 
-    /* We should return ms */
-    return t / OS_TICKS_PER_SEC * 1000;
+    return os_time_ticks_to_ms32(t);
 }
 
 int64_t k_uptime_get(void)
@@ -393,7 +392,11 @@ u32_t k_uptime_get_32(void)
 
 void k_sleep(int32_t duration)
 {
-    os_time_delay(OS_TICKS_PER_SEC * duration / 1000);
+    uint32_t ticks;
+
+    ticks = os_time_ms_to_ticks32(duration);
+
+    os_time_delay(ticks);
 }
 
 static uint8_t pub[64];

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -79,9 +79,9 @@
  * If an attempt to cancel an active procedure fails, the attempt is retried
  * at this rate (ms).
  */
-#define BLE_GAP_CANCEL_RETRY_RATE               100 /* ms */
+#define BLE_GAP_CANCEL_RETRY_TIMEOUT_MS         100 /* ms */
 
-#define BLE_GAP_UPDATE_TIMEOUT                  (30 * OS_TICKS_PER_SEC)
+#define BLE_GAP_UPDATE_TIMEOUT_MS               30000 /* ms */
 
 #define BLE_GAP_MAX_UPDATE_ENTRIES      1
 
@@ -1525,7 +1525,7 @@ ble_gap_master_timer(void)
         rc = ble_gap_conn_cancel_tx();
         if (rc != 0) {
             /* Failed to stop connecting; try again in 100 ms. */
-            return BLE_GAP_CANCEL_RETRY_RATE;
+            return os_time_ms_to_ticks32(BLE_GAP_CANCEL_RETRY_TIMEOUT_MS);
         } else {
             /* Stop the timer now that the cancel command has been acked. */
             ble_gap_master.exp_set = 0;
@@ -1545,7 +1545,7 @@ ble_gap_master_timer(void)
         rc = ble_gap_disc_enable_tx(0, 0);
         if (rc != 0) {
             /* Failed to stop discovery; try again in 100 ms. */
-            return BLE_GAP_CANCEL_RETRY_RATE;
+            return os_time_ms_to_ticks32(BLE_GAP_CANCEL_RETRY_TIMEOUT_MS);
         }
 
         ble_gap_disc_complete();
@@ -4406,7 +4406,9 @@ ble_gap_update_params(uint16_t conn_handle,
 
     entry->conn_handle = conn_handle;
     entry->params = *params;
-    entry->exp_os_ticks = os_time_get() + BLE_GAP_UPDATE_TIMEOUT;
+
+    entry->exp_os_ticks = os_time_get() +
+                          os_time_ms_to_ticks32(BLE_GAP_UPDATE_TIMEOUT_MS);
 
     BLE_HS_LOG(INFO, "GAP procedure initiated: ");
     ble_gap_log_update(conn_handle, params);

--- a/nimble/host/src/ble_gatt_priv.h
+++ b/nimble/host/src/ble_gatt_priv.h
@@ -100,10 +100,6 @@ struct ble_gatts_conn {
 
 /*** @client. */
 
-/** Convert the resume rate from milliseconds to OS ticks. */
-#define BLE_GATT_RESUME_RATE_TICKS                \
-    (MYNEWT_VAL(BLE_GATT_RESUME_RATE) * OS_TICKS_PER_SEC / 1000)
-
 int ble_gattc_locked_by_cur_task(void);
 void ble_gatts_indicate_fail_notconn(uint16_t conn_handle);
 

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -68,7 +68,7 @@
  * The maximum time to wait for a single ATT response.  The spec defines this
  * as the ATT transaction time (Vol. 3, Part F, 3.3.3)
  */
-#define BLE_GATTC_UNRESPONSIVE_TIMEOUT          (30 * OS_TICKS_PER_SEC)
+#define BLE_GATTC_UNRESPONSIVE_TIMEOUT_MS       30000 /* ms */
 
 #define BLE_GATT_OP_NONE                        UINT8_MAX
 #define BLE_GATT_OP_MTU                         0
@@ -731,7 +731,8 @@ ble_gattc_proc_insert(struct ble_gattc_proc *proc)
 static void
 ble_gattc_proc_set_exp_timer(struct ble_gattc_proc *proc)
 {
-    proc->exp_os_ticks = os_time_get() + BLE_GATTC_UNRESPONSIVE_TIMEOUT;
+    proc->exp_os_ticks = os_time_get() +
+                         os_time_ms_to_ticks32(BLE_GATTC_UNRESPONSIVE_TIMEOUT_MS);
 }
 
 static void
@@ -743,7 +744,8 @@ ble_gattc_proc_set_resume_timer(struct ble_gattc_proc *proc)
      * instead.
      */
     if (ble_gattc_resume_at == 0) {
-        ble_gattc_resume_at = os_time_get() + BLE_GATT_RESUME_RATE_TICKS;
+        ble_gattc_resume_at = os_time_get() +
+                              os_time_ms_to_ticks32(MYNEWT_VAL(BLE_GATT_RESUME_RATE));
 
         /* A value of 0 indicates the timer is unset.  Disambiguate this. */
         if (ble_gattc_resume_at == 0) {

--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -61,7 +61,7 @@ static struct os_event ble_hs_ev_start = {
 uint8_t ble_hs_sync_state;
 static int ble_hs_reset_reason;
 
-#define BLE_HS_SYNC_RETRY_RATE          (OS_TICKS_PER_SEC / 10)
+#define BLE_HS_SYNC_RETRY_TIMEOUT_MS    100 /* ms */
 
 static struct os_task *ble_hs_parent_task;
 
@@ -327,6 +327,7 @@ ble_hs_synced(void)
 static int
 ble_hs_sync(void)
 {
+    uint32_t retry_tmo_ticks;
     int rc;
 
     /* Set the sync state to "bringup."  This allows the parent task to send
@@ -342,7 +343,8 @@ ble_hs_sync(void)
         ble_hs_sync_state = BLE_HS_SYNC_STATE_BAD;
     }
 
-    ble_hs_timer_sched(BLE_HS_SYNC_RETRY_RATE);
+    retry_tmo_ticks = os_time_ms_to_ticks32(BLE_HS_SYNC_RETRY_TIMEOUT_MS);
+    ble_hs_timer_sched(retry_tmo_ticks);
 
     if (rc == 0) {
         rc = ble_hs_misc_restore_irks();

--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -28,7 +28,7 @@
 #include "ble_hs_dbg_priv.h"
 #include "ble_monitor_priv.h"
 
-#define BLE_HCI_CMD_TIMEOUT     ((OS_TICKS_PER_SEC) * 2)
+#define BLE_HCI_CMD_TIMEOUT_MS  2000
 
 static struct os_mutex ble_hs_hci_mutex;
 static struct os_sem ble_hs_hci_sem;
@@ -243,6 +243,7 @@ ble_hs_hci_process_ack(uint16_t expected_opcode,
 static int
 ble_hs_hci_wait_for_ack(void)
 {
+    uint32_t cmd_tmo;
     int rc;
 
 #if MYNEWT_VAL(BLE_HS_PHONY_HCI_ACKS)
@@ -255,7 +256,8 @@ ble_hs_hci_wait_for_ack(void)
         rc = ble_hs_hci_phony_ack_cb(ble_hs_hci_ack, 260);
     }
 #else
-    rc = os_sem_pend(&ble_hs_hci_sem, BLE_HCI_CMD_TIMEOUT);
+    cmd_tmo = os_time_ms_to_ticks32(BLE_HCI_CMD_TIMEOUT_MS);
+    rc = os_sem_pend(&ble_hs_hci_sem, cmd_tmo);
     switch (rc) {
     case 0:
         BLE_HS_DBG_ASSERT(ble_hs_hci_ack != NULL);

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -52,7 +52,7 @@
 #if NIMBLE_BLE_SM
 
 /** Procedure timeout; 30 seconds. */
-#define BLE_SM_TIMEOUT_OS_TICKS             (30 * OS_TICKS_PER_SEC)
+#define BLE_SM_TIMEOUT_MS             (30000)
 
 STAILQ_HEAD(ble_sm_proc_list, ble_sm_proc);
 
@@ -353,8 +353,8 @@ ble_sm_gen_csrk(struct ble_sm_proc *proc, uint8_t *csrk)
 static void
 ble_sm_proc_set_timer(struct ble_sm_proc *proc)
 {
-    /* Set a timeout of 30 seconds. */
-    proc->exp_os_ticks = os_time_get() + BLE_SM_TIMEOUT_OS_TICKS;
+    proc->exp_os_ticks = os_time_get() +
+                         os_time_ms_to_ticks32(BLE_SM_TIMEOUT_MS);
     ble_hs_timer_resched();
 }
 


### PR DESCRIPTION
This is to make porting easier as we do not rely on OS_TICKS_PER_SEC.

Depends on https://github.com/apache/mynewt-core/pull/1049