### PR TITLE
nimble/transport: Adjust BLE_HCI_EVT_BUF_SIZE default for ext scan

### DIFF
--- a/nimble/transport/emspi/syscfg.yml
+++ b/nimble/transport/emspi/syscfg.yml
@@ -93,4 +93,4 @@ syscfg.defs:
         value: 256
 
 syscfg.vals.BLE_EXT_ADV:
-    BLE_HCI_EVT_BUF_SIZE: 274
+    BLE_HCI_EVT_BUF_SIZE: 257

--- a/nimble/transport/ram/syscfg.yml
+++ b/nimble/transport/ram/syscfg.yml
@@ -40,3 +40,6 @@ syscfg.defs:
             This is the maximum size of the data portion of HCI ACL data
             packets. It does not include the HCI data header (of 4 bytes).
         value: 255
+
+syscfg.vals.BLE_EXT_ADV:
+    BLE_HCI_EVT_BUF_SIZE: 257

--- a/nimble/transport/socket/syscfg.yml
+++ b/nimble/transport/socket/syscfg.yml
@@ -21,7 +21,6 @@
 syscfg.defs:
     BLE_HCI_EVT_BUF_SIZE:
         description: 'The size of the allocated event buffers'
-        # The largest event the nimble controller will send is 70 bytes.
         value: 70
     BLE_HCI_EVT_HI_BUF_COUNT:
         description: 'The number of high priority event buffers'
@@ -72,3 +71,6 @@ syscfg.defs:
     BLE_SOCK_STACK_SIZE:
         description: 'Size of the HCI socket stack (units=words).'
         value: 80
+
+syscfg.vals.BLE_EXT_ADV:
+    BLE_HCI_EVT_BUF_SIZE: 257

--- a/nimble/transport/uart/syscfg.yml
+++ b/nimble/transport/uart/syscfg.yml
@@ -21,7 +21,6 @@
 syscfg.defs:
     BLE_HCI_EVT_BUF_SIZE:
         description: 'The size of the allocated event buffers'
-        # The largest event the nimble controller will send is 70 bytes.
         value: 70
     BLE_HCI_EVT_HI_BUF_COUNT:
         description: 'The number of high priority event buffers'
@@ -66,3 +65,6 @@ syscfg.defs:
     BLE_HCI_UART_FLOW_CTRL:
         description: 'Flow control used for HCI uart interface'
         value:       HAL_UART_FLOW_CTL_RTS_CTS
+
+syscfg.vals.BLE_EXT_ADV:
+    BLE_HCI_EVT_BUF_SIZE: 257


### PR DESCRIPTION
When Extended Advertising is enabled use 257 bytes for
BLE_HCI_EVT_BUF_SIZE to minimize HCI traffic when scanning. This also
fix invalid value in emspi transport that was exceeding maximum HCI
 event value defined by spec.