### PR TITLE
nimble/ll: Fix mbuf leak in advertising on HCI Reset

### DIFF
--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -3372,13 +3372,18 @@ ble_ll_adv_reset(void)
     struct ble_ll_adv_sm *advsm;
 
     for (i = 0; i < BLE_ADV_INSTANCES; ++i) {
-        /* Stop advertising state machine */
         advsm = &g_ble_ll_adv_sm[i];
-        ble_ll_adv_sm_stop(advsm);
-    }
 
-    /* re-initialize the advertiser state machine */
-    ble_ll_adv_init();
+        /* Stop advertising state machine */
+        ble_ll_adv_sm_stop(advsm);
+
+        /* clear any data present */
+        os_mbuf_free_chain(advsm->adv_data);
+        os_mbuf_free_chain(advsm->scan_rsp_data);
+
+        /* re-initialize the advertiser state machine */
+        ble_ll_adv_sm_init(advsm);
+    }
 }
 
 /* Called to determine if advertising is enabled.


### PR DESCRIPTION
If advertising data or scan response is set for advertising instance it
must be free before re-initializing advertising state machine.