### PR TITLE
nimble/host: Remove log_init call

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -660,8 +660,6 @@ ble_hs_init(void)
     /* Ensure this function only gets called by sysinit. */
     SYSINIT_ASSERT_ACTIVE();
 
-    log_init();
-
     /* Create memory pool of OS events */
     rc = os_mempool_init(&ble_hs_hci_ev_pool, BLE_HS_HCI_EVT_COUNT,
                          sizeof (struct os_event), ble_hs_hci_os_event_buf,


### PR DESCRIPTION
log_init() is already called by sysinit with prio 100, so before
ble_hs_init() is called so this does not seem to be necessary here.