### PR TITLE
Refactor RPA handling in controller

### DIFF
--- a/nimble/controller/include/controller/ble_ll_adv.h
+++ b/nimble/controller/include/controller/ble_ll_adv.h
@@ -185,6 +185,9 @@ int ble_ll_adv_ext_set_adv_data(uint8_t *cmdbuf, uint8_t cmdlen);
 int ble_ll_adv_ext_set_scan_rsp(uint8_t *cmdbuf, uint8_t cmdlen);
 int ble_ll_adv_ext_set_enable(uint8_t *cmdbuf, uint8_t len);
 
+/* Called to notify adv code about RPA rotation */
+void ble_ll_adv_rpa_timeout(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/nimble/controller/include/controller/ble_ll_resolv.h
+++ b/nimble/controller/include/controller/ble_ll_resolv.h
@@ -33,13 +33,13 @@ extern "C" {
 struct ble_ll_resolv_entry
 {
     uint8_t rl_addr_type;
-    uint8_t rl_local_rpa_set;
     uint8_t rl_reserved;
     uint8_t rl_priv_mode;
     uint8_t rl_local_irk[16];
     uint8_t rl_peer_irk[16];
     uint8_t rl_identity_addr[BLE_DEV_ADDR_LEN];
     uint8_t rl_local_rpa[BLE_DEV_ADDR_LEN];
+    uint8_t rl_peer_rpa[BLE_DEV_ADDR_LEN];
 };
 
 extern struct ble_ll_resolv_entry g_ble_ll_resolv_list[];
@@ -76,7 +76,7 @@ uint8_t ble_ll_resolv_enabled(void);
 /* Reset private address resolution */
 void ble_ll_resolv_list_reset(void);
 
-void ble_ll_resolv_gen_priv_addr(struct ble_ll_resolv_entry *rl, int local,
+void ble_ll_resolv_get_priv_addr(struct ble_ll_resolv_entry *rl, int local,
                                  uint8_t *addr);
 
 /* Generate a resolvable private address. */

--- a/nimble/controller/include/controller/ble_ll_resolv.h
+++ b/nimble/controller/include/controller/ble_ll_resolv.h
@@ -59,9 +59,10 @@ int ble_ll_resolv_list_rmv(uint8_t *cmdbuf);
 /* Address resolution enable command */
 int ble_ll_resolv_enable_cmd(uint8_t *cmdbuf);
 
-/* XXX: implement */
-int ble_ll_resolv_peer_addr_rd(uint8_t *cmdbuf);
-void ble_ll_resolv_local_addr_rd(uint8_t *cmdbuf);
+int ble_ll_resolv_peer_addr_rd(uint8_t *cmdbuf, uint8_t *rspbuf,
+                               uint8_t *rsplen);
+int ble_ll_resolv_local_addr_rd(uint8_t *cmdbuf, uint8_t *rspbuf,
+                                uint8_t *rsplen);
 
 /* Finds 'addr' in resolving list. Doesnt check if address resolution enabled */
 struct ble_ll_resolv_entry *

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -2753,7 +2753,7 @@ ble_ll_conn_req_pdu_update(struct os_mbuf *m, uint8_t *adva, uint8_t addr_type,
          */
         if (rl) {
             hdr |= BLE_ADV_PDU_HDR_TXADD_RAND;
-            ble_ll_resolv_gen_priv_addr(rl, 1, dptr);
+            ble_ll_resolv_get_priv_addr(rl, 1, dptr);
             addr = NULL;
         }
     }

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -851,10 +851,10 @@ ble_ll_hci_le_cmd_proc(uint8_t *cmdbuf, uint16_t ocf, uint8_t *rsplen,
         rc = ble_ll_resolv_list_read_size(rspbuf, rsplen);
         break;
     case BLE_HCI_OCF_LE_RD_PEER_RESOLV_ADDR:
-        rc = ble_ll_resolv_peer_addr_rd(cmdbuf);
+        rc = ble_ll_resolv_peer_addr_rd(cmdbuf, rspbuf, rsplen);
         break;
     case BLE_HCI_OCF_LE_RD_LOCAL_RESOLV_ADDR:
-        ble_ll_resolv_local_addr_rd(cmdbuf);
+        rc = ble_ll_resolv_local_addr_rd(cmdbuf, rspbuf, rsplen);
         break;
     case BLE_HCI_OCF_LE_SET_ADDR_RES_EN:
         rc = ble_ll_resolv_enable_cmd(cmdbuf);

--- a/nimble/controller/src/ble_ll_resolv.c
+++ b/nimble/controller/src/ble_ll_resolv.c
@@ -153,6 +153,8 @@ ble_ll_resolv_rpa_timer_cb(struct ble_npl_event *ev)
     }
     ble_npl_callout_reset(&g_ble_ll_resolv_data.rpa_timer,
                      (int32_t)g_ble_ll_resolv_data.rpa_tmo);
+
+    ble_ll_adv_rpa_timeout();
 }
 
 /**

--- a/nimble/controller/src/ble_ll_resolv.c
+++ b/nimble/controller/src/ble_ll_resolv.c
@@ -356,7 +356,9 @@ ble_ll_resolv_list_rmv(uint8_t *cmdbuf)
 
     /* Remove from IRK records */
     position = ble_ll_is_on_resolv_list(ident_addr, addr_type);
-    if (position && (position < g_ble_ll_resolv_data.rl_cnt)) {
+    if (position) {
+        assert(position <= g_ble_ll_resolv_data.rl_cnt);
+
         memmove(&g_ble_ll_resolv_list[position - 1],
                 &g_ble_ll_resolv_list[position],
                 g_ble_ll_resolv_data.rl_cnt - position);
@@ -364,9 +366,10 @@ ble_ll_resolv_list_rmv(uint8_t *cmdbuf)
 
         /* Remove from HW list */
         ble_hw_resolv_list_rmv(position - 1);
+        return BLE_ERR_SUCCESS;
     }
 
-    return BLE_ERR_SUCCESS;
+    return BLE_ERR_UNK_CONN_ID;
 }
 
 /**

--- a/nimble/controller/src/ble_ll_resolv.c
+++ b/nimble/controller/src/ble_ll_resolv.c
@@ -72,11 +72,68 @@ ble_ll_resolv_list_chg_allowed(void)
     return rc;
 }
 
+
+/**
+ * Called to generate a resolvable private address in rl structure
+ *
+ * @param rl
+ * @param local
+ */
+static void
+ble_ll_resolv_gen_priv_addr(struct ble_ll_resolv_entry *rl, int local)
+{
+    uint8_t *irk;
+    uint8_t *prand;
+    uint32_t *irk32;
+    uint32_t *key32;
+    uint32_t *pt32;
+    struct ble_encryption_block ecb;
+    uint8_t *addr;
+
+    assert(rl != NULL);
+
+    if (local) {
+        addr = rl->rl_local_rpa;
+        irk = rl->rl_local_irk;
+    } else {
+        addr = rl->rl_peer_rpa;
+        irk = rl->rl_peer_irk;
+    }
+
+    /* Get prand */
+    prand = addr + 3;
+    ble_ll_rand_prand_get(prand);
+
+    /* Calculate hash, hash = ah(local IRK, prand) */
+
+    irk32 = (uint32_t *)irk;
+    key32 = (uint32_t *)&ecb.key[0];
+    key32[0] = irk32[0];
+    key32[1] = irk32[1];
+    key32[2] = irk32[2];
+    key32[3] = irk32[3];
+    pt32 = (uint32_t *)&ecb.plain_text[0];
+    pt32[0] = 0;
+    pt32[1] = 0;
+    pt32[2] = 0;
+    ecb.plain_text[12] = 0;
+    ecb.plain_text[13] = prand[2];
+    ecb.plain_text[14] = prand[1];
+    ecb.plain_text[15] = prand[0];
+
+    /* Calculate hash */
+    ble_hw_encrypt_block(&ecb);
+
+    addr[0] = ecb.cipher_text[15];
+    addr[1] = ecb.cipher_text[14];
+    addr[2] = ecb.cipher_text[13];
+}
+
 /**
  * Called when the Resolvable private address timer expires. This timer
- * is used to regenerate local RPA's in the resolving list.
+ * is used to regenerate local and peers RPA's in the resolving list.
  */
-void
+static void
 ble_ll_resolv_rpa_timer_cb(struct ble_npl_event *ev)
 {
     int i;
@@ -86,9 +143,11 @@ ble_ll_resolv_rpa_timer_cb(struct ble_npl_event *ev)
     rl = &g_ble_ll_resolv_list[0];
     for (i = 0; i < g_ble_ll_resolv_data.rl_cnt; ++i) {
         OS_ENTER_CRITICAL(sr);
-        rl->rl_local_rpa_set = 0;
-        ble_ll_resolv_gen_priv_addr(rl, 1, rl->rl_local_rpa);
-        rl->rl_local_rpa_set = 1;
+        ble_ll_resolv_gen_priv_addr(rl, 1);
+        OS_EXIT_CRITICAL(sr);
+
+        OS_ENTER_CRITICAL(sr);
+        ble_ll_resolv_gen_priv_addr(rl, 0);
         OS_EXIT_CRITICAL(sr);
         ++rl;
     }
@@ -237,29 +296,36 @@ ble_ll_resolv_list_add(uint8_t *cmdbuf)
     addr_type = cmdbuf[0];
     ident_addr = cmdbuf + 1;
 
-    rc = BLE_ERR_SUCCESS;
-    if (!ble_ll_is_on_resolv_list(ident_addr, addr_type)) {
-        rl = &g_ble_ll_resolv_list[g_ble_ll_resolv_data.rl_cnt];
-        rl->rl_addr_type = addr_type;
-        rl->rl_local_rpa_set = 0;
-        memcpy(&rl->rl_identity_addr[0], ident_addr, BLE_DEV_ADDR_LEN);
-        swap_buf(rl->rl_peer_irk, cmdbuf + 7, 16);
-        swap_buf(rl->rl_local_irk, cmdbuf + 23, 16);
-
-        /* By default use ptivacy network mode */
-        rl->rl_priv_mode = BLE_HCI_PRIVACY_NETWORK;
-
-        /*
-         * Add peer IRK to HW resolving list. If we can add it, also
-         * generate a local RPA now to save time later.
-         */
-        rc = ble_hw_resolv_list_add(rl->rl_peer_irk);
-        if (!rc) {
-            ble_ll_resolv_gen_priv_addr(rl, 1, rl->rl_local_rpa);
-            rl->rl_local_rpa_set = 1;
-        }
-        ++g_ble_ll_resolv_data.rl_cnt;
+    /* spec is not clear on how to handle this but make sure host is aware
+     * that new keys are not used in that case
+     */
+    if (ble_ll_is_on_resolv_list(ident_addr, addr_type)) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
     }
+
+    rl = &g_ble_ll_resolv_list[g_ble_ll_resolv_data.rl_cnt];
+    memset (rl, 0, sizeof(*rl));
+
+    rl->rl_addr_type = addr_type;
+    memcpy(&rl->rl_identity_addr[0], ident_addr, BLE_DEV_ADDR_LEN);
+    swap_buf(rl->rl_peer_irk, cmdbuf + 7, 16);
+    swap_buf(rl->rl_local_irk, cmdbuf + 23, 16);
+
+    /* By default use privacy network mode */
+    rl->rl_priv_mode = BLE_HCI_PRIVACY_NETWORK;
+
+    /* Add peer IRK to HW resolving list. Should always succeed since we
+     * already checked if there is room for it.
+     */
+    rc = ble_hw_resolv_list_add(rl->rl_peer_irk);
+    assert (rc == BLE_ERR_SUCCESS);
+
+    /* generate a local and peer RPAs now, those will be updated by timer
+     * when resolution is enabled
+     */
+    ble_ll_resolv_gen_priv_addr(rl, 1);
+    ble_ll_resolv_gen_priv_addr(rl, 0);
+    ++g_ble_ll_resolv_data.rl_cnt;
 
     return rc;
 }
@@ -421,65 +487,23 @@ ble_ll_resolv_get_rpa_tmo(void)
     return g_ble_ll_resolv_data.rpa_tmo;
 }
 
-/**
- * Called to generate a resolvable private address
- *
- * @param rl
- * @param local
- * @param addr Pointer to resolvable private address
- */
 void
-ble_ll_resolv_gen_priv_addr(struct ble_ll_resolv_entry *rl, int local,
+ble_ll_resolv_get_priv_addr(struct ble_ll_resolv_entry *rl, int local,
                             uint8_t *addr)
 {
-    uint8_t *irk;
-    uint8_t *prand;
-    uint32_t *irk32;
-    uint32_t *key32;
-    uint32_t *pt32;
-    struct ble_encryption_block ecb;
+    os_sr_t sr;
 
     assert(rl != NULL);
     assert(addr != NULL);
 
-    /* If the local rpa has already been generated, just copy it */
-    if (local && rl->rl_local_rpa_set) {
-        memcpy(addr, rl->rl_local_rpa, BLE_DEV_ADDR_LEN);
-        return;
-    }
-
-    /* Get prand */
-    prand = addr + 3;
-    ble_ll_rand_prand_get(prand);
-
-    /* Calculate hash, hash = ah(local IRK, prand) */
+    OS_ENTER_CRITICAL(sr);
     if (local) {
-        irk = rl->rl_local_irk;
+        memcpy(addr, rl->rl_local_rpa, BLE_DEV_ADDR_LEN);
     } else {
-        irk = rl->rl_peer_irk;
+        memcpy(addr, rl->rl_peer_rpa, BLE_DEV_ADDR_LEN);
     }
 
-    irk32 = (uint32_t *)irk;
-    key32 = (uint32_t *)&ecb.key[0];
-    key32[0] = irk32[0];
-    key32[1] = irk32[1];
-    key32[2] = irk32[2];
-    key32[3] = irk32[3];
-    pt32 = (uint32_t *)&ecb.plain_text[0];
-    pt32[0] = 0;
-    pt32[1] = 0;
-    pt32[2] = 0;
-    ecb.plain_text[12] = 0;
-    ecb.plain_text[13] = prand[2];
-    ecb.plain_text[14] = prand[1];
-    ecb.plain_text[15] = prand[0];
-
-    /* Calculate hash */
-    ble_hw_encrypt_block(&ecb);
-
-    addr[0] = ecb.cipher_text[15];
-    addr[1] = ecb.cipher_text[14];
-    addr[2] = ecb.cipher_text[13];
+    OS_EXIT_CRITICAL(sr);
 }
 
 /**
@@ -507,7 +531,7 @@ ble_ll_resolv_gen_rpa(uint8_t *addr, uint8_t addr_type, uint8_t *rpa, int local)
             irk = rl->rl_peer_irk;
         }
         if (ble_ll_resolv_irk_nonzero(irk)) {
-            ble_ll_resolv_gen_priv_addr(rl, local, rpa);
+            ble_ll_resolv_get_priv_addr(rl, local, rpa);
             rc = 1;
         }
     }

--- a/nimble/controller/src/ble_ll_resolv.c
+++ b/nimble/controller/src/ble_ll_resolv.c
@@ -406,15 +406,51 @@ ble_ll_resolv_enable_cmd(uint8_t *cmdbuf)
 }
 
 int
-ble_ll_resolv_peer_addr_rd(uint8_t *cmdbuf)
+ble_ll_resolv_peer_addr_rd(uint8_t *cmdbuf, uint8_t *rspbuf, uint8_t *rsplen)
 {
-    /* XXX */
-    return 0;
+    struct ble_ll_resolv_entry *rl;
+    uint8_t addr_type;
+    uint8_t *ident_addr;
+    int rc;
+
+    addr_type = cmdbuf[0];
+    ident_addr = cmdbuf + 1;
+
+    rl = ble_ll_resolv_list_find(ident_addr, addr_type);
+    if (rl) {
+        memcpy(rspbuf, rl->rl_peer_rpa, BLE_DEV_ADDR_LEN);
+        rc = BLE_ERR_SUCCESS;
+    } else {
+        memset(rspbuf, 0, BLE_DEV_ADDR_LEN);
+        rc = BLE_ERR_UNK_CONN_ID;
+    }
+
+    *rsplen = BLE_DEV_ADDR_LEN;
+    return rc;
 }
 
-void
-ble_ll_resolv_local_addr_rd(uint8_t *cmdbuf)
+int
+ble_ll_resolv_local_addr_rd(uint8_t *cmdbuf, uint8_t *rspbuf, uint8_t *rsplen)
 {
+    struct ble_ll_resolv_entry *rl;
+    uint8_t addr_type;
+    uint8_t *ident_addr;
+    int rc;
+
+    addr_type = cmdbuf[0];
+    ident_addr = cmdbuf + 1;
+
+    rl = ble_ll_resolv_list_find(ident_addr, addr_type);
+    if (rl) {
+        memcpy(rspbuf, rl->rl_local_rpa, BLE_DEV_ADDR_LEN);
+        rc = BLE_ERR_SUCCESS;
+    } else {
+        memset(rspbuf, 0, BLE_DEV_ADDR_LEN);
+        rc = BLE_ERR_UNK_CONN_ID;
+    }
+
+    *rsplen = BLE_DEV_ADDR_LEN;
+    return rc;
 }
 
 /**

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -344,7 +344,7 @@ ble_ll_scan_req_pdu_make(struct ble_ll_scan_sm *scansm, uint8_t *adv_addr,
          * section 6.3).
          */
         if (rl) {
-            ble_ll_resolv_gen_priv_addr(rl, 1, rpa);
+            ble_ll_resolv_get_priv_addr(rl, 1, rpa);
             scana = rpa;
         } else {
             ble_ll_scan_refresh_nrpa(scansm);


### PR DESCRIPTION
This set do a bit of refactoring on how peer RPAs are handled. How those are similar to local RPA when it is regenerated only from timer and user are taking current RPA. Advertising code is also adjusted to make use of that.

This is needed to implement LE Read Peer Resolvable Address Command where test spec assumes address read after LE Connection Complete Event (within RPA timeout) is same as one used over the radio.