### PR TITLE
nimble/ll: Fix peer address in LE Enhanced Connection Complete Event

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1737,6 +1737,17 @@ ble_ll_conn_master_init(struct ble_ll_conn_sm *connsm,
     if (hcc->filter_policy == 0) {
         memcpy(&connsm->peer_addr, &hcc->peer_addr, BLE_DEV_ADDR_LEN);
         connsm->peer_addr_type = hcc->peer_addr_type;
+
+        /* If device was added to resolve list peer type has different meaning
+         * and we need to adjust here. If device is on resolve list mark type as
+         * 'identity' as this means also RPA is allowed for connection.
+         */
+        if ((connsm->peer_addr_type < BLE_HCI_CONN_PEER_ADDR_PUBLIC_IDENT) &&
+                ble_ll_resolv_list_find(connsm->peer_addr,
+                                        connsm->peer_addr_type)) {
+            connsm->peer_addr_type += 2;
+        }
+
     }
 
     /* XXX: for now, just make connection interval equal to max */
@@ -1840,6 +1851,17 @@ ble_ll_conn_ext_master_init(struct ble_ll_conn_sm *connsm,
     if (hcc->filter_policy == 0) {
         memcpy(&connsm->peer_addr, &hcc->peer_addr, BLE_DEV_ADDR_LEN);
         connsm->peer_addr_type = hcc->peer_addr_type;
+
+        /* In LE Extended Create Connection peer type has different meaning
+         * than legacy LE Create Connection and since legacy values are used
+         * internally we need to adjust here. If device is on resolve list
+         * mark type as 'identity' as this means also RPA is allowed for
+         * connection.
+         */
+        if (ble_ll_resolv_list_find(connsm->peer_addr,
+                                    connsm->peer_addr_type)) {
+            connsm->peer_addr_type += 2;
+        }
     }
 
     connsm->initial_params = *hcc;


### PR DESCRIPTION
If device is already on resolve list address type in LE (Extended)
Connection Command need to be adjusted. Otherwise peer RPA won't be
added to LE Enhanced Connection Complete Event. This has fatal results
as eg. SMP is using OTA address for crypto calculations.