### PR TITLE
mesh: shell: Rename init function to avoid redefinition

### DIFF
--- a/nimble/host/mesh/include/mesh/testing.h
+++ b/nimble/host/mesh/include/mesh/testing.h
@@ -59,7 +59,7 @@ void bt_test_cb_unregister(struct bt_test_cb *cb);
 
 u8_t mod_bind(struct bt_mesh_model *model, u16_t key_idx);
 u8_t mod_unbind(struct bt_mesh_model *model, u16_t key_idx);
-int cmd_init(int argc, char *argv[]);
+int cmd_mesh_init(int argc, char *argv[]);
 
 int bt_test_shell_init(void);
 int bt_test_bind_app_key_to_model(struct bt_mesh_model *model, u16_t key_idx, u16_t id);

--- a/nimble/host/mesh/src/shell.c
+++ b/nimble/host/mesh/src/shell.c
@@ -633,7 +633,7 @@ static int check_pub_addr_unassigned(void)
 #endif
 }
 
-int cmd_init(int argc, char *argv[])
+int cmd_mesh_init(int argc, char *argv[])
 {
 	int err;
 	ble_addr_t addr;
@@ -2374,7 +2374,7 @@ static int cmd_print_composition_data(int argc, char *argv[])
 }
 
 static const struct shell_cmd mesh_commands[] = {
-	{ "init", cmd_init, NULL },
+	{ "init", cmd_mesh_init, NULL },
 #if MYNEWT_VAL(BLE_MESH_PB_ADV)
 	{ "pb-adv", cmd_pb_adv, &cmd_pb_help },
 #endif

--- a/nimble/host/mesh/src/testing.c
+++ b/nimble/host/mesh/src/testing.c
@@ -157,7 +157,7 @@ void bt_test_print_credentials(void)
 
 int bt_test_shell_init(void)
 {
-	return cmd_init(0, NULL);
+	return cmd_mesh_init(0, NULL);
 }
 
 int bt_test_bind_app_key_to_model(struct bt_mesh_model *model, u16_t key_idx, u16_t id)


### PR DESCRIPTION
This patch makes mesh shell init function name unique, since btshell
uses the same name function symbol.