### PR TITLE
nimble: Fix tests build with NPL

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -23,6 +23,7 @@
 #include "os/os.h"
 #include "nimble/ble.h"
 #include "nimble/hci_common.h"
+#include "nimble/nimble_npl.h"
 #include "controller/ble_ll_sched.h"
 #include "controller/ble_ll_ctrl.h"
 #include "controller/ble_phy.h"

--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -127,7 +127,7 @@ ble_hs_locked_by_cur_task(void)
         return ble_hs_dbg_mutex_locked;
     }
 
-    owner = ble_hs_mutex.mu_owner;
+    owner = ble_hs_mutex.mu.mu_owner;
     return owner != NULL && owner == os_sched_get_current_task();
 }
 #endif


### PR DESCRIPTION
This fixes following build errors in tests missed during NPL
implementation:

Compiling repos/apache-mynewt-nimble/nimble/host/src/ble_hs_hci_evt.c
repos/apache-mynewt-nimble/nimble/host/src/ble_hs.c: In function ‘ble_hs_locked_by_cur_task’:
repos/apache-mynewt-nimble/nimble/host/src/ble_hs.c:130:25: error: ‘struct ble_npl_mutex’ has no member named ‘mu_owner’
     owner = ble_hs_mutex.mu_owner;
                         ^

Compiling repos/apache-mynewt-core/sys/log/full/src/log.c
In file included from repos/apache-mynewt-nimble/nimble/controller/test/src/ble_ll_csa2_test.c:24:0:
repos/apache-mynewt-nimble/nimble/controller/include/controller/ble_ll_conn.h:277:26: error: field ‘conn_ev_end’ has incomplete type
     struct ble_npl_event conn_ev_end;
                          ^~~~~~~~~~~
repos/apache-mynewt-nimble/nimble/controller/include/controller/ble_ll_conn.h:290:28: error: field ‘ctrl_proc_rsp_timer’ has incomplete type
     struct ble_npl_callout ctrl_proc_rsp_timer;
                            ^~~~~~~~~~~~~~~~~~~
repos/apache-mynewt-nimble/nimble/controller/include/controller/ble_ll_conn.h:296:28: error: field ‘auth_pyld_timer’ has incomplete type
     struct ble_npl_callout auth_pyld_timer;
                            ^~~~~~~~~~~~~~~