### PR TITLE
Add `version.yml` to master.

### DIFF
--- a/version.yml
+++ b/version.yml
@@ -1,0 +1,3 @@
+# Newt uses this file to determine the version of a checked out repo.
+# This should always be 0.0.0 in the master branch.
+repo.version: 0.0.0


### PR DESCRIPTION
Newt uses the `version.yml` file to determine the version of a checked out repo.  This should always be 0.0.0 in the master branch.

Please see https://github.com/apache/mynewt-newt/pull/165 for more information about newt uses this file.