### PR TITLE
nimble/mesh: Add bt_mesh_register_gatt to pkg init

### DIFF
--- a/nimble/host/mesh/pkg.yml
+++ b/nimble/host/mesh/pkg.yml
@@ -41,4 +41,5 @@ pkg.req_apis:
     - stats
 
 pkg.init:
+    bt_mesh_register_gatt: 500
     ble_mesh_shell_init: 1000


### PR DESCRIPTION
Whenever mesh is initialized we need to make sure GATT services are
registered for GATT proxy