### PR TITLE
nimble/gap: Fix assert on slave connection with ext advertising

### DIFF
--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -365,8 +365,23 @@ ble_hs_conn_addrs(const struct ble_hs_conn *conn,
     /* Determine our address information. */
     addrs->our_id_addr.type =
         ble_hs_misc_addr_type_to_id(conn->bhc_our_addr_type);
+
+#if MYNEWT_VAL(BLE_EXT_ADV)
+    /* With EA enabled random address for slave connection is per advertising
+     * instance and requires special handling here.
+     */
+
+    if (!(conn->bhc_flags & BLE_HS_CONN_F_MASTER) &&
+            addrs->our_id_addr.type == BLE_ADDR_RANDOM) {
+        our_id_addr_val = conn->bhc_our_rnd_addr;
+    } else {
+        rc = ble_hs_id_addr(addrs->our_id_addr.type, &our_id_addr_val, NULL);
+        assert(rc == 0);
+    }
+#else
     rc = ble_hs_id_addr(addrs->our_id_addr.type, &our_id_addr_val, NULL);
     assert(rc == 0);
+#endif
 
     memcpy(addrs->our_id_addr.val, our_id_addr_val, 6);
 

--- a/nimble/host/src/ble_hs_conn_priv.h
+++ b/nimble/host/src/ble_hs_conn_priv.h
@@ -42,6 +42,9 @@ struct ble_hs_conn {
     SLIST_ENTRY(ble_hs_conn) bhc_next;
     uint16_t bhc_handle;
     uint8_t bhc_our_addr_type;
+#if MYNEWT_VAL(BLE_EXT_ADV)
+    uint8_t bhc_our_rnd_addr[6];
+#endif
     ble_addr_t bhc_peer_addr;
     ble_addr_t bhc_our_rpa_addr;
     ble_addr_t bhc_peer_rpa_addr;


### PR DESCRIPTION
When extended advertising is enabled and advertising instance is
configured to own_address_type=random, it is using per instance
random address and not global random address. We need to store
address set in instance and pass it to connection object so that
it can be returned as ID address.