### PR TITLE
nimble/phy: Fix setting correct GPIO PORT

### DIFF
--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -1235,7 +1235,7 @@ ble_phy_dbg_time_setup_gpiote(int index, int pin)
                         (GPIOTE_CONFIG_MODE_Task << GPIOTE_CONFIG_MODE_Pos) |
                         ((pin & 0x1F) << GPIOTE_CONFIG_PSEL_Pos) |
 #if NRF52840_XXAA
-                        ((pin > 31) << GPIOTE_CONFIG_PORT_Pos);
+                        ((port == NRF_P1) << GPIOTE_CONFIG_PORT_Pos);
 #else
                         0;
 #endif


### PR DESCRIPTION
Pin is already masked in this place, so pin > 31 will always result in
0. Therefore check for already known port.