### PR TITLE
nimble/ll: Vendor error event on assert

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -26,6 +26,11 @@
 #include "nimble/nimble_npl.h"
 #include "controller/ble_phy.h"
 
+#ifdef MYNEWT
+#include "controller/ble_ll_ctrl.h"
+#include "hal/hal_system.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -34,6 +39,23 @@ extern "C" {
 #error 32.768kHz clock required
 #endif
 
+#ifdef MYNEWT
+#ifdef NDEBUG
+#define BLE_LL_ASSERT(cond) (void(0))
+#else
+#define BLE_LL_ASSERT(cond) \
+    if (!(cond)) { \
+        if (hal_debugger_connected()) { \
+            assert(0);\
+        } else {\
+            ble_ll_hci_ev_send_vendor_err(__FILE__, __LINE__); \
+            while(1) {}\
+        }\
+    }
+#endif
+#else
+#define BLE_LL_ASSERT(cond) assert(cond)
+#endif
 /*
  * XXX:
  * I guess this should not depend on the 32768 crystal to be honest. This

--- a/nimble/controller/include/controller/ble_ll_ctrl.h
+++ b/nimble/controller/include/controller/ble_ll_ctrl.h
@@ -279,6 +279,7 @@ int ble_ll_hci_ev_phy_update(struct ble_ll_conn_sm *connsm, uint8_t status);
 void ble_ll_calc_session_key(struct ble_ll_conn_sm *connsm);
 void ble_ll_ctrl_phy_update_proc_complete(struct ble_ll_conn_sm *connsm);
 void ble_ll_ctrl_initiate_dle(struct ble_ll_conn_sm *connsm);
+void ble_ll_hci_ev_send_vendor_err(char *file, uint32_t line);
 
 #ifdef __cplusplus
 }

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1043,7 +1043,7 @@ ble_ll_tx_mbuf_pducb(uint8_t *dptr, void *pducb_arg, uint8_t *hdr_byte)
     struct ble_mbuf_hdr *ble_hdr;
 
     txpdu = pducb_arg;
-    assert(txpdu);
+    BLE_LL_ASSERT(txpdu);
     ble_hdr = BLE_MBUF_HDR_PTR(txpdu);
 
     os_mbuf_copydata(txpdu, ble_hdr->txinfo.offset, ble_hdr->txinfo.pyld_len,
@@ -1342,7 +1342,7 @@ ble_ll_pdu_tx_time_get(uint16_t payload_len, int phy_mode)
         /* S=2 => 2 * 8 = 16 usecs per byte */
         usecs = payload_len << 4;
     } else {
-        assert(0);
+        BLE_LL_ASSERT(0);
     }
 
     usecs += g_ble_ll_pdu_header_tx_time[phy_mode];
@@ -1360,7 +1360,7 @@ ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode)
     uint32_t header_tx_time;
     uint16_t octets;
 
-    assert(phy_mode < BLE_PHY_NUM_MODE);
+    BLE_LL_ASSERT(phy_mode < BLE_PHY_NUM_MODE);
 
     header_tx_time = g_ble_ll_pdu_header_tx_time[phy_mode];
 
@@ -1395,7 +1395,7 @@ ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode)
         /* S=2 => 2 * 8 = 16 usecs per byte */
         octets = usecs >> 4;
     } else {
-        assert(0);
+        BLE_LL_ASSERT(0);
     }
 
     /* see comment at the beginning */
@@ -1436,7 +1436,7 @@ ble_ll_init(void)
 #ifdef BLE_XCVR_RFCLK
     /* Settling time of crystal, in ticks */
     xtal_ticks = MYNEWT_VAL(BLE_XTAL_SETTLE_TIME);
-    assert(xtal_ticks != 0);
+    BLE_LL_ASSERT(xtal_ticks != 0);
     g_ble_ll_data.ll_xtal_ticks = os_cputime_usecs_to_ticks(xtal_ticks);
 
     /* Initialize rf clock timer */

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -286,7 +286,7 @@ ble_ll_init_get_conn_comp_ev(void)
     uint8_t *evbuf;
 
     evbuf = g_ble_ll_conn_comp_ev;
-    assert(evbuf != NULL);
+    BLE_LL_ASSERT(evbuf != NULL);
     g_ble_ll_conn_comp_ev = NULL;
 
     return evbuf;
@@ -640,7 +640,7 @@ ble_ll_conn_remapped_channel(uint8_t remap_index, const uint8_t *chanmap)
     }
 
     /* we should never reach here */
-    assert(0);
+    BLE_LL_ASSERT(0);
     return 0;
 }
 
@@ -1431,7 +1431,7 @@ ble_ll_conn_event_start_cb(struct ble_ll_sched_item *sch)
     /* Set current connection state machine */
     connsm = (struct ble_ll_conn_sm *)sch->cb_arg;
     g_ble_ll_conn_cur_sm = connsm;
-    assert(connsm);
+    BLE_LL_ASSERT(connsm);
 
     /* Disable whitelisting as connections do not use it */
     ble_ll_whitelist_disable();
@@ -2138,8 +2138,8 @@ ble_ll_conn_end(struct ble_ll_conn_sm *connsm, uint8_t ble_err)
 #if MYNEWT_VAL(BLE_LL_STRICT_CONN_SCHEDULING)
     /* Remove from occupied periods */
     OS_ENTER_CRITICAL(sr);
-    assert(g_ble_ll_sched_data.sch_num_occ_periods > 0);
-    assert(g_ble_ll_sched_data.sch_occ_period_mask & connsm->period_occ_mask);
+    BLE_LL_ASSERT(g_ble_ll_sched_data.sch_num_occ_periods > 0);
+    BLE_LL_ASSERT(g_ble_ll_sched_data.sch_occ_period_mask & connsm->period_occ_mask);
     --g_ble_ll_sched_data.sch_num_occ_periods;
     g_ble_ll_sched_data.sch_occ_period_mask &= ~connsm->period_occ_mask;
     OS_EXIT_CRITICAL(sr);
@@ -2469,7 +2469,7 @@ ble_ll_conn_created(struct ble_ll_conn_sm *connsm, struct ble_mbuf_hdr *rxhdr)
                 usecs += 2500;
                 break;
             default:
-                assert(0);
+                BLE_LL_ASSERT(0);
                 break;
             }
         }
@@ -2563,7 +2563,7 @@ ble_ll_conn_event_end(struct ble_npl_event *ev)
 
     /* Better be a connection state machine! */
     connsm = (struct ble_ll_conn_sm *)ble_npl_event_get_arg(ev);
-    assert(connsm);
+    BLE_LL_ASSERT(connsm);
 
     /* Check if we need to resume scanning */
     ble_ll_scan_chk_resume();
@@ -2708,7 +2708,7 @@ ble_ll_conn_req_pdu_update(struct os_mbuf *m, uint8_t *adva, uint8_t addr_type,
     struct ble_ll_resolv_entry *rl;
 #endif
 
-    assert(m != NULL);
+    BLE_LL_ASSERT(m != NULL);
 
     /* clear txadd/rxadd bits only */
     ble_hdr = BLE_MBUF_HDR_PTR(m);
@@ -3589,7 +3589,7 @@ ble_ll_conn_rx_data_pdu(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *hdr)
                     STATS_INCN(ble_ll_conn_stats, rx_l2cap_bytes, acl_len);
 
                     /* NOTE: there should be at least two bytes available */
-                    assert(OS_MBUF_LEADINGSPACE(rxpdu) >= 2);
+                    BLE_LL_ASSERT(OS_MBUF_LEADINGSPACE(rxpdu) >= 2);
                     os_mbuf_prepend(rxpdu, 2);
                     rxbuf = rxpdu->om_data;
 
@@ -4286,7 +4286,7 @@ ble_ll_conn_module_init(void)
                             STATS_SIZE_INIT_PARMS(ble_ll_conn_stats, STATS_SIZE_32),
                             STATS_NAME_INIT_PARMS(ble_ll_conn_stats),
                             "ble_ll_conn");
-    assert(rc == 0);
+    BLE_LL_ASSERT(rc == 0);
 
     /* Call reset to finish reset of initialization */
     ble_ll_conn_module_reset();

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -136,7 +136,7 @@ ble_ll_conn_req_pdu_make(struct ble_ll_conn_sm *connsm, uint8_t chan)
     struct os_mbuf *m;
 
     m = ble_ll_scan_get_pdu();
-    assert(m != NULL);
+    BLE_LL_ASSERT(m != NULL);
 
     /* Construct first PDU header byte */
     pdu_type = BLE_ADV_PDU_TYPE_CONNECT_REQ;
@@ -1010,7 +1010,7 @@ done:
 static void
 ble_ll_conn_hci_cancel_conn_complete_event(void)
 {
-    assert(g_ble_ll_conn_comp_ev);
+    BLE_LL_ASSERT(g_ble_ll_conn_comp_ev);
 
     ble_ll_conn_comp_event_send(NULL, BLE_ERR_UNK_CONN_ID,
                                 g_ble_ll_conn_comp_ev, NULL);
@@ -1094,7 +1094,7 @@ ble_ll_conn_hci_disconnect_cmd(uint8_t *cmdbuf)
                     rc = BLE_ERR_CMD_DISALLOWED;
                 } else {
                     /* This control procedure better not be pending! */
-                    assert(CONN_F_TERMINATE_STARTED(connsm) == 0);
+                    BLE_LL_ASSERT(CONN_F_TERMINATE_STARTED(connsm) == 0);
 
                     /* Record the disconnect reason */
                     connsm->disconnect_reason = reason;

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -1232,7 +1232,7 @@ ble_ll_ctrl_conn_param_pdu_make(struct ble_ll_conn_sm *connsm, uint8_t *dptr,
     } else {
         hcu = &connsm->conn_param_req;
         /* The host should have provided the parameters! */
-        assert(hcu->handle != 0);
+        BLE_LL_ASSERT(hcu->handle != 0);
         put_le16(dptr, hcu->conn_itvl_min);
         put_le16(dptr + 2, hcu->conn_itvl_max);
         put_le16(dptr + 4, hcu->conn_latency);
@@ -1865,7 +1865,7 @@ ble_ll_ctrl_proc_init(struct ble_ll_conn_sm *connsm, int ctrl_proc)
             break;
 #endif
         default:
-            assert(0);
+            BLE_LL_ASSERT(0);
             break;
         }
 
@@ -1937,7 +1937,7 @@ ble_ll_ctrl_terminate_start(struct ble_ll_conn_sm *connsm)
     uint32_t usecs;
     struct os_mbuf *om;
 
-    assert(connsm->disconnect_reason != 0);
+    BLE_LL_ASSERT(connsm->disconnect_reason != 0);
 
     ctrl_proc = BLE_LL_CTRL_PROC_TERMINATE;
     om = ble_ll_ctrl_proc_init(connsm, ctrl_proc);
@@ -1965,7 +1965,7 @@ ble_ll_ctrl_proc_start(struct ble_ll_conn_sm *connsm, int ctrl_proc)
 {
     struct os_mbuf *om;
 
-    assert(ctrl_proc != BLE_LL_CTRL_PROC_TERMINATE);
+    BLE_LL_ASSERT(ctrl_proc != BLE_LL_CTRL_PROC_TERMINATE);
 
     om = NULL;
     if (connsm->cur_ctrl_proc == BLE_LL_CTRL_PROC_IDLE) {

--- a/nimble/controller/src/ble_ll_dtm.c
+++ b/nimble/controller/src/ble_ll_dtm.c
@@ -156,7 +156,7 @@ ble_ll_dtm_event(struct ble_npl_event *evt) {
 
     ble_ll_dtm_set_next(ctx);
     rc = ble_ll_sched_dtm(&ctx->sch);
-    assert(rc == 0);
+    BLE_LL_ASSERT(rc == 0);
 }
 
 static void
@@ -188,7 +188,7 @@ ble_ll_dtm_tx_sched_cb(struct ble_ll_sched_item *sch)
     rc = ble_phy_setchan(channel_rf_to_index[ctx->rf_channel],
                                             BLE_DTM_SYNC_WORD, BLE_DTM_CRC);
     if (rc != 0) {
-        assert(0);
+        BLE_LL_ASSERT(0);
         return BLE_LL_SCHED_STATE_DONE;
     }
 
@@ -202,10 +202,10 @@ ble_ll_dtm_tx_sched_cb(struct ble_ll_sched_item *sch)
 
     /*XXX Maybe reschedule if too late */
     rc = ble_phy_tx_set_start_time(sch->start_time, sch->remainder);
-    assert(rc == 0);
+    BLE_LL_ASSERT(rc == 0);
 
     rc = ble_phy_tx(ble_ll_tx_mbuf_pducb, ctx->om, BLE_PHY_TRANSITION_NONE);
-    assert(rc == 0);
+    BLE_LL_ASSERT(rc == 0);
 
     ble_ll_state_set(BLE_LL_STATE_DTM);
 
@@ -242,7 +242,7 @@ ble_ll_dtm_tx_create_ctx(uint8_t packet_payload, uint8_t len,
 
     /* MSYS is big enough to get continues memory */
     g_ble_ll_dtm_ctx.om = os_msys_get_pkthdr(len, sizeof(struct ble_mbuf_hdr));
-    assert(g_ble_ll_dtm_ctx.om);
+    BLE_LL_ASSERT(g_ble_ll_dtm_ctx.om);
 
     g_ble_ll_dtm_ctx.phy_mode = phy_mode;
     g_ble_ll_dtm_ctx.rf_channel = rf_channel;
@@ -297,7 +297,7 @@ schedule:
 
     /* Set some start point for TX packets */
     rc = ble_ll_sched_dtm(sch);
-    assert(rc == 0);
+    BLE_LL_ASSERT(rc == 0);
 
     ble_phy_enable_dtm();
 
@@ -345,7 +345,7 @@ ble_ll_dtm_rx_create_ctx(uint8_t rf_channel, uint8_t phy_mode)
     g_ble_ll_dtm_ctx.active = 1;
 
     if (ble_ll_dtm_rx_start() != 0) {
-        assert(0);
+        BLE_LL_ASSERT(0);
         return 1;
     }
 
@@ -489,7 +489,7 @@ ble_ll_dtm_rx_pkt_in(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *hdr)
     }
 
     if (ble_ll_dtm_rx_start() != 0) {
-        assert(0);
+        BLE_LL_ASSERT(0);
     }
 }
 
@@ -517,7 +517,7 @@ void
 ble_ll_dtm_wfr_timer_exp(void)
 {
     /* Should not be needed */
-    assert(0);
+    BLE_LL_ASSERT(0);
 }
 
 

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -82,7 +82,7 @@ ble_ll_hci_event_send(uint8_t *evbuf)
 {
     int rc;
 
-    assert(BLE_HCI_EVENT_HDR_LEN + evbuf[1] <= BLE_LL_MAX_EVT_LEN);
+    BLE_LL_ASSERT(BLE_HCI_EVENT_HDR_LEN + evbuf[1] <= BLE_LL_MAX_EVT_LEN);
 
     /* Count number of events sent */
     STATS_INC(ble_ll_stats, hci_events_sent);
@@ -1171,7 +1171,7 @@ ble_ll_hci_cmd_proc(struct ble_npl_event *ev)
 
     /* The command buffer is the event argument */
     cmdbuf = (uint8_t *)ble_npl_event_get_arg(ev);
-    assert(cmdbuf != NULL);
+    BLE_LL_ASSERT(cmdbuf != NULL);
 
     /* Get the opcode from the command buffer */
     opcode = get_le16(cmdbuf);
@@ -1204,7 +1204,7 @@ ble_ll_hci_cmd_proc(struct ble_npl_event *ev)
     }
 
     /* If no response is generated, we free the buffers */
-    assert(rc >= 0);
+    BLE_LL_ASSERT(rc >= 0);
     if (rc <= BLE_ERR_MAX) {
         /* Create a command complete event with status from command */
         cmdbuf[0] = BLE_HCI_EVCODE_COMMAND_COMPLETE;

--- a/nimble/controller/src/ble_ll_hci_ev.c
+++ b/nimble/controller/src/ble_ll_hci_ev.c
@@ -401,3 +401,23 @@ ble_ll_hci_ev_phy_update(struct ble_ll_conn_sm *connsm, uint8_t status)
     return rc;
 }
 #endif
+
+void
+ble_ll_hci_ev_send_vendor_err(char *file, uint32_t line)
+{
+    uint8_t *evbuf;
+    uint8_t file_len = strlen(file);
+
+    evbuf = ble_hci_trans_buf_alloc(BLE_HCI_TRANS_BUF_EVT_HI);
+    if (!evbuf) {
+        return;
+    }
+
+    evbuf[0] = BLE_HCI_EVCODE_VENDOR_DEBUG;
+    evbuf[1] = file_len + sizeof(line) + 1;
+    /* Debug id for future use */
+    evbuf[2] = 0x00;
+    memcpy(&evbuf[3], file, file_len);
+    put_le32(&evbuf[3] + file_len, line);
+    ble_ll_hci_event_send(evbuf);
+}

--- a/nimble/controller/src/ble_ll_resolv.c
+++ b/nimble/controller/src/ble_ll_resolv.c
@@ -87,7 +87,7 @@ ble_ll_resolv_gen_priv_addr(struct ble_ll_resolv_entry *rl, int local)
     struct ble_encryption_block ecb;
     uint8_t *addr;
 
-    assert(rl != NULL);
+    BLE_LL_ASSERT(rl != NULL);
 
     if (local) {
         addr = rl->rl_local_rpa;
@@ -307,7 +307,7 @@ ble_ll_resolv_list_add(uint8_t *cmdbuf)
      * already checked if there is room for it.
      */
     rc = ble_hw_resolv_list_add(rl->rl_peer_irk);
-    assert (rc == BLE_ERR_SUCCESS);
+    BLE_LL_ASSERT (rc == BLE_ERR_SUCCESS);
 
     /* generate a local and peer RPAs now, those will be updated by timer
      * when resolution is enabled
@@ -344,7 +344,7 @@ ble_ll_resolv_list_rmv(uint8_t *cmdbuf)
     /* Remove from IRK records */
     position = ble_ll_is_on_resolv_list(ident_addr, addr_type);
     if (position) {
-        assert(position <= g_ble_ll_resolv_data.rl_cnt);
+        BLE_LL_ASSERT(position <= g_ble_ll_resolv_data.rl_cnt);
 
         memmove(&g_ble_ll_resolv_list[position - 1],
                 &g_ble_ll_resolv_list[position],
@@ -521,8 +521,8 @@ ble_ll_resolv_get_priv_addr(struct ble_ll_resolv_entry *rl, int local,
 {
     os_sr_t sr;
 
-    assert(rl != NULL);
-    assert(addr != NULL);
+    BLE_LL_ASSERT(rl != NULL);
+    BLE_LL_ASSERT(addr != NULL);
 
     OS_ENTER_CRITICAL(sr);
     if (local) {

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -190,7 +190,7 @@ ble_ll_aux_scan_cb(struct ble_ll_sched_item *sch)
 
     /* When doing RX for AUX pkt, cur_aux_data keeps valid aux data */
     scansm->cur_aux_data = sch->cb_arg;
-    assert(scansm->cur_aux_data != NULL);
+    BLE_LL_ASSERT(scansm->cur_aux_data != NULL);
     scansm->cur_aux_data->scanning = 1;
 
     if (ble_ll_scan_start(scansm, sch)) {
@@ -260,7 +260,7 @@ ble_ll_scan_req_backoff(struct ble_ll_scan_sm *scansm, int success)
 
     scansm->backoff_count = rand() & (scansm->upper_limit - 1);
     ++scansm->backoff_count;
-    assert(scansm->backoff_count <= 256);
+    BLE_LL_ASSERT(scansm->backoff_count <= 256);
 }
 
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY) == 1)
@@ -312,7 +312,7 @@ ble_ll_scan_req_pdu_make(struct ble_ll_scan_sm *scansm, uint8_t *adv_addr,
 
     /* Get the advertising PDU */
     m = scansm->scan_req_pdu;
-    assert(m != NULL);
+    BLE_LL_ASSERT(m != NULL);
 
     /* Get pointer to our device address */
     if ((scansm->own_addr_type & 1) == 0) {
@@ -646,7 +646,7 @@ ble_ll_hci_send_legacy_ext_adv_report(uint8_t evtype,
         evt->evt_type = BLE_HCI_LEGACY_ADV_EVTYPE_ADV_SCAN_IND;
         break;
     default:
-        assert(0);
+        BLE_LL_ASSERT(0);
         break;
     }
 
@@ -707,7 +707,7 @@ ble_ll_hci_send_adv_report(uint8_t subev, uint8_t evtype,uint8_t event_len,
 
     tmp = &evbuf[12];
     if (subev == BLE_HCI_LE_SUBEV_DIRECT_ADV_RPT) {
-        assert(inita);
+        BLE_LL_ASSERT(inita);
         tmp[0] = BLE_HCI_ADV_OWN_ADDR_RANDOM;
         memcpy(tmp + 1, inita, BLE_DEV_ADDR_LEN);
         tmp += BLE_DEV_ADDR_LEN + 1;
@@ -716,7 +716,7 @@ ble_ll_hci_send_adv_report(uint8_t subev, uint8_t evtype,uint8_t event_len,
         os_mbuf_copydata(adv_data, 0, adv_data_len, tmp + 1);
         tmp += adv_data_len + 1;
     } else {
-        assert(0);
+        BLE_LL_ASSERT(0);
         return -1;
     }
 
@@ -886,7 +886,7 @@ ble_ll_scan_chk_filter_policy(uint8_t pdu_type, uint8_t *adv_addr,
         use_whitelist = 1;
         break;
     default:
-        assert(0);
+        BLE_LL_ASSERT(0);
         break;
     }
 
@@ -961,12 +961,12 @@ ble_ll_scan_start(struct ble_ll_scan_sm *scansm, struct ble_ll_sched_item *sch)
      *      scan just make sanity check that we have proper combination of
      *      sch and resulting scan_chan
      */
-    assert(!sch || scan_chan < BLE_PHY_ADV_CHAN_START);
-    assert(sch || scan_chan >= BLE_PHY_ADV_CHAN_START);
+    BLE_LL_ASSERT(!sch || scan_chan < BLE_PHY_ADV_CHAN_START);
+    BLE_LL_ASSERT(sch || scan_chan >= BLE_PHY_ADV_CHAN_START);
 
     /* Set channel */
     rc = ble_phy_setchan(scan_chan, BLE_ACCESS_ADDR_ADV, BLE_LL_CRCINIT_ADV);
-    assert(rc == 0);
+    BLE_LL_ASSERT(rc == 0);
 
     /*
      * Set transmit end callback to NULL in case we transmit a scan request.
@@ -1200,7 +1200,7 @@ ble_ll_scan_sm_start(struct ble_ll_scan_sm *scansm)
     scansm->scan_enabled = 1;
 
     /* Set first advertising channel */
-    assert(scansm->cur_phy != PHY_NOT_CONFIGURED);
+    BLE_LL_ASSERT(scansm->cur_phy != PHY_NOT_CONFIGURED);
     scansm->phy_data[scansm->cur_phy].scan_chan = BLE_PHY_ADV_CHAN_START;
 
     if (scansm->next_phy != PHY_NOT_CONFIGURED &&
@@ -1414,7 +1414,7 @@ ble_ll_scan_event_proc(struct ble_npl_event *ev)
     case BLE_LL_STATE_STANDBY:
         break;
     default:
-        assert(0);
+        BLE_LL_ASSERT(0);
         break;
     }
 
@@ -2070,7 +2070,7 @@ ble_ll_scan_rx_isr_end(struct os_mbuf *rxpdu, uint8_t crcok)
         /* If the ble_ll_scan_get_aux_data() succeed, scansm->cur_aux_data is NULL
          * and aux_data contains correct data
          */
-        assert(scansm->cur_aux_data == NULL);
+        BLE_LL_ASSERT(scansm->cur_aux_data == NULL);
         ble_hdr->rxinfo.user_data = aux_data;
         rc = -1;
     }
@@ -2158,7 +2158,7 @@ ble_ll_scan_rx_isr_end(struct os_mbuf *rxpdu, uint8_t crcok)
         }
 
         /* Better not be a scan response pending */
-        assert(scansm->scan_rsp_pending == 0);
+        BLE_LL_ASSERT(scansm->scan_rsp_pending == 0);
 
         /* We want to send a request. See if backoff allows us */
         --scansm->backoff_count;
@@ -2308,7 +2308,7 @@ ble_ll_hci_send_ext_adv_report(uint8_t ptype, struct os_mbuf *om,
     }
 
     if (!aux_data) {
-        assert(0);
+        BLE_LL_ASSERT(0);
         return;
     }
 
@@ -2365,7 +2365,7 @@ ble_ll_hci_send_ext_adv_report(uint8_t ptype, struct os_mbuf *om,
         evt = next_evt;
     } while (evt);
 
-    assert(offset <= datalen);
+    BLE_LL_ASSERT(offset <= datalen);
 }
 #endif
 /**
@@ -3190,7 +3190,7 @@ ble_ll_scan_common_init(void)
     /* Get a scan request mbuf (packet header) and attach to state machine */
     scansm->scan_req_pdu = os_msys_get_pkthdr(BLE_SCAN_LEGACY_MAX_PKT_LEN,
                                               sizeof(struct ble_mbuf_hdr));
-    assert(scansm->scan_req_pdu != NULL);
+    BLE_LL_ASSERT(scansm->scan_req_pdu != NULL);
 }
 
 /**
@@ -3253,7 +3253,7 @@ ble_ll_scan_init(void)
                           sizeof (struct ble_ll_aux_data),
                           ext_adv_mem,
                           "ble_ll_aux_scan_pool");
-    assert(err == 0);
+    BLE_LL_ASSERT(err == 0);
 #endif
 
     ble_ll_scan_common_init();

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -254,7 +254,7 @@ ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm *connsm)
                 break;
 #endif
             default:
-                assert(0);
+                BLE_LL_ASSERT(0);
                 break;
         }
 
@@ -282,7 +282,7 @@ ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm *connsm)
     OS_EXIT_CRITICAL(sr);
 
     /* Restart timer */
-    assert(sch != NULL);
+    BLE_LL_ASSERT(sch != NULL);
     os_cputime_timer_start(&g_ble_ll_sched_timer, sch->start_time);
 
     return rc;
@@ -323,7 +323,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
     struct ble_ll_sched_item *sch;
 
     /* Better have a connsm */
-    assert(connsm != NULL);
+    BLE_LL_ASSERT(connsm != NULL);
 
     /* Get schedule element from connection */
     rc = -1;
@@ -399,7 +399,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
             // 150 + 2896 + 3750 = 6796us = 222.69 ticks
             earliest_start = adv_rxend + 223;
         } else {
-            assert(0);
+            BLE_LL_ASSERT(0);
         }
     }
     earliest_start += MYNEWT_VAL(BLE_LL_CONN_INIT_MIN_WIN_OFFSET) *
@@ -629,7 +629,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
             // 150 + 2896 + 3750 = 6796us = 222.69 ticks
             earliest_start = adv_rxend + 223;
         } else {
-            assert(0);
+            BLE_LL_ASSERT(0);
         }
     }
     earliest_start += MYNEWT_VAL(BLE_LL_CONN_INIT_MIN_WIN_OFFSET) *
@@ -894,7 +894,7 @@ ble_ll_sched_adv_new(struct ble_ll_sched_item *sch, ble_ll_sched_adv_new_cb cb,
     OS_EXIT_CRITICAL(sr);
 
     /* Restart timer */
-    assert(sch != NULL);
+    BLE_LL_ASSERT(sch != NULL);
     os_cputime_timer_start(&g_ble_ll_sched_timer, sch->start_time);
 
     return rc;
@@ -999,7 +999,7 @@ ble_ll_sched_adv_reschedule(struct ble_ll_sched_item *sch, uint32_t *start,
                     break;
                 }
                 entry = next_sch;
-                assert(entry != NULL);
+                BLE_LL_ASSERT(entry != NULL);
             }
         }
     }
@@ -1157,7 +1157,7 @@ ble_ll_sched_execute_item(struct ble_ll_sched_item *sch)
     }
 
 sched:
-    assert(sch->sched_cb);
+    BLE_LL_ASSERT(sch->sched_cb);
     rc = sch->sched_cb(sch);
     return rc;
 }
@@ -1429,7 +1429,7 @@ done:
     OS_EXIT_CRITICAL(sr);
 
     /* Restart timer */
-    assert(sch != NULL);
+    BLE_LL_ASSERT(sch != NULL);
     os_cputime_timer_start(&g_ble_ll_sched_timer, sch->start_time);
 
     STATS_INC(ble_ll_stats, aux_scheduled);
@@ -1491,7 +1491,7 @@ done:
     OS_EXIT_CRITICAL(sr);
 
     /* Restart timer */
-    assert(sch != NULL);
+    BLE_LL_ASSERT(sch != NULL);
     os_cputime_timer_start(&g_ble_ll_sched_timer, sch->start_time);
 
     return rc;

--- a/nimble/controller/src/ble_ll_xcvr.c
+++ b/nimble/controller/src/ble_ll_xcvr.c
@@ -74,7 +74,7 @@ ble_ll_xcvr_rfclk_time_till_settled(void)
     rc = 0;
     if (g_ble_ll_data.ll_rfclk_state == BLE_RFCLK_STATE_ON) {
         dt = (int32_t)(os_cputime_get32() - g_ble_ll_data.ll_rfclk_start_time);
-        assert(dt >= 0);
+        BLE_LL_ASSERT(dt >= 0);
         if (dt < g_ble_ll_data.ll_xtal_ticks) {
             rc = g_ble_ll_data.ll_xtal_ticks - (uint32_t)dt;
         }

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -665,6 +665,7 @@ extern "C" {
 #define BLE_HCI_EVCODE_SLAVE_BCAST_CHAN_MAP (0x55)
 #define BLE_HCI_EVCODE_INQ_RSP_NOTIFY       (0x56)
 #define BLE_HCI_EVCODE_AUTH_PYLD_TMO        (0x57)
+#define BLE_HCI_EVCODE_VENDOR_DEBUG         (0xFF)
 
 /* LE sub-event codes */
 #define BLE_HCI_LE_SUBEV_CONN_COMPLETE          (0x01)


### PR DESCRIPTION
With this patch controller will send Vendor Debug event
on asserts.
First octet of this event is Debug event type
1) Debug event type (0x00 - assert information)
2) Assert information (file and line)

   Example below shows my test asser in ble_ll_hci.c line 764
    
    > HCI Event: Vendor (0xff) plen 66
       00 72 65 70 6f 73 2f 61 70 61 63 68 65 2d 6d 79 .repos/apache-my
       6e 65 77 74 2d 6e 69 6d 62 6c 65 2f 6e 69 6d 62 newt-nimble/nimb
       6c 65 2f 63 6f 6e 74 72 6f 6c 6c 65 72 2f 73 72 le/controller/sr
       63 2f 62 6c 65 5f 6c 6c 5f 68 63 69 2e 63 fc 02 c/ble_ll_hci.c..
       00 00