### PR TITLE
fix os/os_trace_api and RIOT related compile warnings

### DIFF
--- a/nimble/controller/include/controller/ble_ll_trace.h
+++ b/nimble/controller/include/controller/ble_ll_trace.h
@@ -20,6 +20,8 @@
 #ifndef H_BLE_LL_TRACE_
 #define H_BLE_LL_TRACE_
 
+#include "os/os_trace_api.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/nimble/controller/include/controller/ble_phy_trace.h
+++ b/nimble/controller/include/controller/ble_phy_trace.h
@@ -20,6 +20,8 @@
 #ifndef H_BLE_PHY_TRACE_
 #define H_BLE_PHY_TRACE_
 
+#include "os/os_trace_api.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/porting/nimble/include/os/os_trace_api.h
+++ b/porting/nimble/include/os/os_trace_api.h
@@ -46,36 +46,6 @@ os_trace_isr_exit(void)
 }
 
 static inline void
-os_trace_task_info(const struct os_task *t)
-{
-}
-
-static inline void
-os_trace_task_create(const struct os_task *t)
-{
-}
-
-static inline void
-os_trace_task_start_exec(const struct os_task *t)
-{
-}
-
-static inline void
-os_trace_task_stop_exec(void)
-{
-}
-
-static inline void
-os_trace_task_start_ready(const struct os_task *t)
-{
-}
-
-static inline void
-os_trace_task_stop_ready(const struct os_task *t, unsigned reason)
-{
-}
-
-static inline void
 os_trace_idle(void)
 {
 }


### PR DESCRIPTION
When basing the NimBLE RIOT package to the current master after #111 was merged, I get compiler warnings regarding the `os/os_trace_api.h` file. This can be reproduced by building the `examples/nimble_gatt` example from https://github.com/haukepetersen/RIOT/tree/add_mynewt_nimble

While the added include in `ble_phy.h` seems to be straight forward to me, I am not sure if simply defining `struct os_task` in the 'trace' header is the way to go here...

Feel free to close this PR and fix the warnings in a more suitable way :-)