### PR TITLE
porting: Use real function pointer types for ISR functions

### DIFF
--- a/nimble/drivers/nrf52/src/ble_hw.c
+++ b/nimble/drivers/nrf52/src/ble_hw.c
@@ -334,7 +334,7 @@ ble_hw_rng_init(ble_rng_isr_cb_t cb, int bias)
 #if MYNEWT
         NVIC_SetVector(RNG_IRQn, (uint32_t)ble_rng_isr);
 #else
-        ble_npl_hw_set_isr(RNG_IRQn, (uint32_t)ble_rng_isr);
+        ble_npl_hw_set_isr(RNG_IRQn, ble_rng_isr);
 #endif
         NVIC_EnableIRQ(RNG_IRQn);
         g_ble_rng_isr_cb = cb;

--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -1428,7 +1428,7 @@ ble_phy_init(void)
 #if MYNEWT
     NVIC_SetVector(RADIO_IRQn, (uint32_t)ble_phy_isr);
 #else
-    ble_npl_hw_set_isr(RADIO_IRQn, (uint32_t)ble_phy_isr);
+    ble_npl_hw_set_isr(RADIO_IRQn, ble_phy_isr);
 #endif
     NVIC_EnableIRQ(RADIO_IRQn);
 

--- a/nimble/include/nimble/nimble_npl.h
+++ b/nimble/include/nimble/nimble_npl.h
@@ -157,7 +157,7 @@ void ble_npl_time_delay(ble_npl_time_t ticks);
 
 #if NIMBLE_CFG_CONTROLLER
 
-void ble_npl_hw_set_isr(int irqn, uint32_t addr);
+void ble_npl_hw_set_isr(int irqn, void (*addr)());
 
 #endif
 

--- a/nimble/include/nimble/nimble_npl.h
+++ b/nimble/include/nimble/nimble_npl.h
@@ -157,7 +157,7 @@ void ble_npl_time_delay(ble_npl_time_t ticks);
 
 #if NIMBLE_CFG_CONTROLLER
 
-void ble_npl_hw_set_isr(int irqn, void (*addr)());
+void ble_npl_hw_set_isr(int irqn, void (*addr)(void));
 
 #endif
 

--- a/porting/nimble/src/hal_timer.c
+++ b/porting/nimble/src/hal_timer.c
@@ -503,7 +503,7 @@ hal_timer_init(int timer_num, void *cfg)
 #if MYNEWT
     NVIC_SetVector(irq_num, (uint32_t)irq_isr);
 #else
-    ble_npl_hw_set_isr(irq_num, (uint32_t)irq_isr);
+    ble_npl_hw_set_isr(irq_num, irq_isr);
 #endif
 
     return 0;

--- a/porting/npl/freertos/include/nimble/nimble_npl_os.h
+++ b/porting/npl/freertos/include/nimble/nimble_npl_os.h
@@ -272,7 +272,7 @@ ble_npl_time_delay(ble_npl_time_t ticks)
 
 #if NIMBLE_CFG_CONTROLLER
 static inline void
-ble_npl_hw_set_isr(int irqn, void (*addr)())
+ble_npl_hw_set_isr(int irqn, void (*addr)(void))
 {
     npl_freertos_hw_set_isr(irqn, addr);
 }

--- a/porting/npl/freertos/include/nimble/nimble_npl_os.h
+++ b/porting/npl/freertos/include/nimble/nimble_npl_os.h
@@ -272,7 +272,7 @@ ble_npl_time_delay(ble_npl_time_t ticks)
 
 #if NIMBLE_CFG_CONTROLLER
 static inline void
-ble_npl_hw_set_isr(int irqn, uint32_t addr)
+ble_npl_hw_set_isr(int irqn, void (*addr)())
 {
     npl_freertos_hw_set_isr(irqn, addr);
 }

--- a/porting/npl/freertos/include/nimble/npl_freertos.h
+++ b/porting/npl/freertos/include/nimble/npl_freertos.h
@@ -65,7 +65,7 @@ ble_npl_error_t npl_freertos_time_ms_to_ticks(uint32_t ms,
 ble_npl_error_t npl_freertos_time_ticks_to_ms(ble_npl_time_t ticks,
                                               uint32_t *out_ms);
 
-void npl_freertos_hw_set_isr(int irqn, void (*addr)());
+void npl_freertos_hw_set_isr(int irqn, void (*addr)(void));
 
 uint32_t npl_freertos_hw_enter_critical(void);
 

--- a/porting/npl/freertos/include/nimble/npl_freertos.h
+++ b/porting/npl/freertos/include/nimble/npl_freertos.h
@@ -65,7 +65,7 @@ ble_npl_error_t npl_freertos_time_ms_to_ticks(uint32_t ms,
 ble_npl_error_t npl_freertos_time_ticks_to_ms(ble_npl_time_t ticks,
                                               uint32_t *out_ms);
 
-void npl_freertos_hw_set_isr(int irqn, uint32_t addr);
+void npl_freertos_hw_set_isr(int irqn, void (*addr)());
 
 uint32_t npl_freertos_hw_enter_critical(void);
 

--- a/porting/npl/riot/src/nrf5x_isr.c
+++ b/porting/npl/riot/src/nrf5x_isr.c
@@ -19,9 +19,9 @@
 
 #include "cpu.h"
 
-static void (*radio_isr_addr)();
-static void (*rng_isr_addr)();
-static void (*rtc0_isr_addr)();
+static void (*radio_isr_addr)(void);
+static void (*rng_isr_addr)(void);
+static void (*rtc0_isr_addr)(void);
 
 void
 isr_radio(void)
@@ -42,7 +42,7 @@ isr_rtc0(void)
 }
 
 void
-ble_npl_hw_set_isr(int irqn, void (*addr)())
+ble_npl_hw_set_isr(int irqn, void (*addr)(void))
 {
     switch (irqn) {
     case RADIO_IRQn:

--- a/porting/npl/riot/src/nrf5x_isr.c
+++ b/porting/npl/riot/src/nrf5x_isr.c
@@ -19,30 +19,30 @@
 
 #include "cpu.h"
 
-static uint32_t radio_isr_addr;
-static uint32_t rng_isr_addr;
-static uint32_t rtc0_isr_addr;
+static void (*radio_isr_addr)();
+static void (*rng_isr_addr)();
+static void (*rtc0_isr_addr)();
 
 void
 isr_radio(void)
 {
-    ((void (*)(void))radio_isr_addr)();
+    radio_isr_addr();
 }
 
 void
 isr_rng(void)
 {
-    ((void (*)(void))rng_isr_addr)();
+    rng_isr_addr();
 }
 
 void
 isr_rtc0(void)
 {
-    ((void (*)(void))rtc0_isr_addr)();
+    rtc0_isr_addr();
 }
 
 void
-ble_npl_hw_set_isr(int irqn, uint32_t addr)
+ble_npl_hw_set_isr(int irqn, void (*addr)())
 {
     switch (irqn) {
     case RADIO_IRQn:


### PR DESCRIPTION
It appears the only reason `uint32_t` was used, was because of the CMSIS `NVIC_SetVector` function which takes an address as an `uint32_t`. Clean this up for the porting layer.

To be honest, casting to `uint32_t` seems very non-portable to me so using function pointers directly should be better for the future.

Note: I haven't actually tested the FreeRTOS and RIOT changes, but I've used almost identical code in my own port (WIP) so it should be okay.