### PR TITLE
nimble/host: Change default RTT buffer name for BLE monitor

### DIFF
--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -60,7 +60,7 @@ syscfg.defs:
         value: 0
     BLE_MONITOR_RTT_BUFFER_NAME:
         description: Monitor interface upstream buffer name
-        value: '"monitor"'
+        value: '"btmonitor"'
     BLE_MONITOR_RTT_BUFFER_SIZE:
         description: Monitor interface upstream buffer size
         value: 256


### PR DESCRIPTION
Let's make it "btmonitor" so it clearly states its purpose.