### PR TITLE
Switch everything over to modlog

### DIFF
--- a/apps/blecent/pkg.yml
+++ b/apps/blecent/pkg.yml
@@ -26,6 +26,7 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - nimble/controller
     - nimble/host

--- a/apps/blecent/src/blecent.h
+++ b/apps/blecent/src/blecent.h
@@ -21,7 +21,7 @@
 #define H_BLECENT_
 
 #include "os/mynewt.h"
-#include "log/log.h"
+#include "modlog/modlog.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,15 +31,6 @@ struct ble_gap_conn_desc;
 struct ble_hs_cfg;
 union ble_store_value;
 union ble_store_key;
-
-extern struct log blecent_log;
-
-/* blecent uses the first "peruser" log module. */
-#define BLECENT_LOG_MODULE  (LOG_MODULE_PERUSER + 0)
-
-/* Convenience macro for logging to the blecent module. */
-#define BLECENT_LOG(lvl, ...) \
-    LOG_ ## lvl(&blecent_log, BLECENT_LOG_MODULE, __VA_ARGS__)
 
 #define BLECENT_SVC_ALERT_UUID              0x1811
 #define BLECENT_CHR_SUP_NEW_ALERT_CAT_UUID  0x2A47

--- a/apps/blecent/src/misc.c
+++ b/apps/blecent/src/misc.c
@@ -33,7 +33,7 @@ print_bytes(const uint8_t *bytes, int len)
     int i;
 
     for (i = 0; i < len; i++) {
-        BLECENT_LOG(DEBUG, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+        MODLOG_DFLT(DEBUG, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
     }
 }
 
@@ -45,7 +45,7 @@ print_mbuf(const struct os_mbuf *om)
     colon = 0;
     while (om != NULL) {
         if (colon) {
-            BLECENT_LOG(DEBUG, ":");
+            MODLOG_DFLT(DEBUG, ":");
         } else {
             colon = 1;
         }
@@ -72,7 +72,7 @@ print_uuid(const ble_uuid_t *uuid)
 {
     char buf[BLE_UUID_STR_LEN];
 
-    BLECENT_LOG(DEBUG, "%s", ble_uuid_to_str(uuid, buf));
+    MODLOG_DFLT(DEBUG, "%s", ble_uuid_to_str(uuid, buf));
 }
 
 /**
@@ -81,16 +81,16 @@ print_uuid(const ble_uuid_t *uuid)
 void
 print_conn_desc(const struct ble_gap_conn_desc *desc)
 {
-    BLECENT_LOG(DEBUG, "handle=%d our_ota_addr_type=%d our_ota_addr=%s ",
+    MODLOG_DFLT(DEBUG, "handle=%d our_ota_addr_type=%d our_ota_addr=%s ",
                 desc->conn_handle, desc->our_ota_addr.type,
                 addr_str(desc->our_ota_addr.val));
-    BLECENT_LOG(DEBUG, "our_id_addr_type=%d our_id_addr=%s ",
+    MODLOG_DFLT(DEBUG, "our_id_addr_type=%d our_id_addr=%s ",
                 desc->our_id_addr.type, addr_str(desc->our_id_addr.val));
-    BLECENT_LOG(DEBUG, "peer_ota_addr_type=%d peer_ota_addr=%s ",
+    MODLOG_DFLT(DEBUG, "peer_ota_addr_type=%d peer_ota_addr=%s ",
                 desc->peer_ota_addr.type, addr_str(desc->peer_ota_addr.val));
-    BLECENT_LOG(DEBUG, "peer_id_addr_type=%d peer_id_addr=%s ",
+    MODLOG_DFLT(DEBUG, "peer_id_addr_type=%d peer_id_addr=%s ",
                 desc->peer_id_addr.type, addr_str(desc->peer_id_addr.val));
-    BLECENT_LOG(DEBUG, "conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+    MODLOG_DFLT(DEBUG, "conn_itvl=%d conn_latency=%d supervision_timeout=%d "
                 "encrypted=%d authenticated=%d bonded=%d",
                 desc->conn_itvl, desc->conn_latency,
                 desc->supervision_timeout,
@@ -108,102 +108,102 @@ print_adv_fields(const struct ble_hs_adv_fields *fields)
     int i;
 
     if (fields->flags != 0) {
-        BLECENT_LOG(DEBUG, "    flags=0x%02x\n", fields->flags);
+        MODLOG_DFLT(DEBUG, "    flags=0x%02x\n", fields->flags);
     }
 
     if (fields->uuids16 != NULL) {
-        BLECENT_LOG(DEBUG, "    uuids16(%scomplete)=",
+        MODLOG_DFLT(DEBUG, "    uuids16(%scomplete)=",
                     fields->uuids16_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids16; i++) {
             print_uuid(&fields->uuids16[i].u);
-            BLECENT_LOG(DEBUG, " ");
+            MODLOG_DFLT(DEBUG, " ");
         }
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 
     if (fields->uuids32 != NULL) {
-        BLECENT_LOG(DEBUG, "    uuids32(%scomplete)=",
+        MODLOG_DFLT(DEBUG, "    uuids32(%scomplete)=",
                     fields->uuids32_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids32; i++) {
             print_uuid(&fields->uuids32[i].u);
-            BLECENT_LOG(DEBUG, " ");
+            MODLOG_DFLT(DEBUG, " ");
         }
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 
     if (fields->uuids128 != NULL) {
-        BLECENT_LOG(DEBUG, "    uuids128(%scomplete)=",
+        MODLOG_DFLT(DEBUG, "    uuids128(%scomplete)=",
                     fields->uuids128_is_complete ? "" : "in");
         for (i = 0; i < fields->num_uuids128; i++) {
             print_uuid(&fields->uuids128[i].u);
-            BLECENT_LOG(DEBUG, " ");
+            MODLOG_DFLT(DEBUG, " ");
         }
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 
     if (fields->name != NULL) {
         assert(fields->name_len < sizeof s - 1);
         memcpy(s, fields->name, fields->name_len);
         s[fields->name_len] = '\0';
-        BLECENT_LOG(DEBUG, "    name(%scomplete)=%s\n",
+        MODLOG_DFLT(DEBUG, "    name(%scomplete)=%s\n",
                     fields->name_is_complete ? "" : "in", s);
     }
 
     if (fields->tx_pwr_lvl_is_present) {
-        BLECENT_LOG(DEBUG, "    tx_pwr_lvl=%d\n", fields->tx_pwr_lvl);
+        MODLOG_DFLT(DEBUG, "    tx_pwr_lvl=%d\n", fields->tx_pwr_lvl);
     }
 
     if (fields->slave_itvl_range != NULL) {
-        BLECENT_LOG(DEBUG, "    slave_itvl_range=");
+        MODLOG_DFLT(DEBUG, "    slave_itvl_range=");
         print_bytes(fields->slave_itvl_range, BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN);
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 
     if (fields->svc_data_uuid16 != NULL) {
-        BLECENT_LOG(DEBUG, "    svc_data_uuid16=");
+        MODLOG_DFLT(DEBUG, "    svc_data_uuid16=");
         print_bytes(fields->svc_data_uuid16, fields->svc_data_uuid16_len);
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 
     if (fields->public_tgt_addr != NULL) {
-        BLECENT_LOG(DEBUG, "    public_tgt_addr=");
+        MODLOG_DFLT(DEBUG, "    public_tgt_addr=");
         u8p = fields->public_tgt_addr;
         for (i = 0; i < fields->num_public_tgt_addrs; i++) {
-            BLECENT_LOG(DEBUG, "public_tgt_addr=%s ", addr_str(u8p));
+            MODLOG_DFLT(DEBUG, "public_tgt_addr=%s ", addr_str(u8p));
             u8p += BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN;
         }
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 
     if (fields->appearance_is_present) {
-        BLECENT_LOG(DEBUG, "    appearance=0x%04x\n", fields->appearance);
+        MODLOG_DFLT(DEBUG, "    appearance=0x%04x\n", fields->appearance);
     }
 
     if (fields->adv_itvl_is_present) {
-        BLECENT_LOG(DEBUG, "    adv_itvl=0x%04x\n", fields->adv_itvl);
+        MODLOG_DFLT(DEBUG, "    adv_itvl=0x%04x\n", fields->adv_itvl);
     }
 
     if (fields->svc_data_uuid32 != NULL) {
-        BLECENT_LOG(DEBUG, "    svc_data_uuid32=");
+        MODLOG_DFLT(DEBUG, "    svc_data_uuid32=");
         print_bytes(fields->svc_data_uuid32, fields->svc_data_uuid32_len);
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 
     if (fields->svc_data_uuid128 != NULL) {
-        BLECENT_LOG(DEBUG, "    svc_data_uuid128=");
+        MODLOG_DFLT(DEBUG, "    svc_data_uuid128=");
         print_bytes(fields->svc_data_uuid128, fields->svc_data_uuid128_len);
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 
     if (fields->uri != NULL) {
-        BLECENT_LOG(DEBUG, "    uri=");
+        MODLOG_DFLT(DEBUG, "    uri=");
         print_bytes(fields->uri, fields->uri_len);
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 
     if (fields->mfg_data != NULL) {
-        BLECENT_LOG(DEBUG, "    mfg_data=");
+        MODLOG_DFLT(DEBUG, "    mfg_data=");
         print_bytes(fields->mfg_data, fields->mfg_data_len);
-        BLECENT_LOG(DEBUG, "\n");
+        MODLOG_DFLT(DEBUG, "\n");
     }
 }

--- a/apps/blecsc/pkg.yml
+++ b/apps/blecsc/pkg.yml
@@ -29,6 +29,7 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/sysinit"
     - "@apache-mynewt-core/sys/id"

--- a/apps/blecsc/src/blecsc_sens.h
+++ b/apps/blecsc/src/blecsc_sens.h
@@ -20,21 +20,12 @@
 #ifndef H_BLECSC_SENSOR_
 #define H_BLECSC_SENSOR_
 
-#include "log/log.h"
+#include "modlog/modlog.h"
 #include "nimble/ble.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-extern struct log blecsc_log;
-
-/* blecsc uses the first "peruser" log module */
-#define BLECSC_LOG_MODULE (LOG_MODULE_PERUSER + 0)
-
-/* Convenience macro for logging to the blerh module */
-#define BLECSC_LOG(lvl, ...) \
-    LOG_ ## lvl(&blecsc_log, BLECSC_LOG_MODULE, __VA_ARGS__)
 
 /* Cycling Speed and Cadence configuration */
 #define GATT_CSC_UUID                           0x1816

--- a/apps/blecsc/src/gatt_svr.c
+++ b/apps/blecsc/src/gatt_svr.c
@@ -178,8 +178,8 @@ gatt_svr_chr_access_sc_control_point(uint16_t conn_handle,
     assert(ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR);
 
     if (!csc_cp_indication_status) {
-        BLECSC_LOG(INFO, "SC Control Point; CCC descriptor "
-                         "improperly configured");
+        MODLOG_DFLT(INFO, "SC Control Point; CCC descriptor "
+                          "improperly configured");
         return CSC_ERR_CCC_DESC_IMPROPERLY_CONFIGURED;
     }
 
@@ -188,7 +188,7 @@ gatt_svr_chr_access_sc_control_point(uint16_t conn_handle,
     if (rc != 0){
         return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
     }
-    BLECSC_LOG(INFO, "SC Control Point; opcode=%d\n", op_code);
+    MODLOG_DFLT(INFO, "SC Control Point; opcode=%d\n", op_code);
 
     /* Allocate response buffer */
     om_indication = ble_hs_mbuf_att_pkt();
@@ -207,8 +207,8 @@ gatt_svr_chr_access_sc_control_point(uint16_t conn_handle,
         measurement_state->cumulative_wheel_rev =
                            get_le32(new_cumulative_wheel_rev_arr);
 
-        BLECSC_LOG(INFO, "SC Control Point; Set cumulative value = %d\n",
-                          measurement_state->cumulative_wheel_rev);
+        MODLOG_DFLT(INFO, "SC Control Point; Set cumulative value = %d\n",
+                    measurement_state->cumulative_wheel_rev);
 
         response = SC_CP_RESPONSE_SUCCESS;
         break;
@@ -222,8 +222,8 @@ gatt_svr_chr_access_sc_control_point(uint16_t conn_handle,
           return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
         }
 
-        BLECSC_LOG(INFO, "SC Control Point; Sensor location update = %d\n",
-                         new_sensor_location);
+        MODLOG_DFLT(INFO, "SC Control Point; Sensor location update = %d\n",
+                    new_sensor_location);
 
         /* Verify if requested new location is on supported locations list */
         response = SC_CP_RESPONSE_INVALID_PARAM;
@@ -338,13 +338,13 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
 
     switch (ctxt->op) {
     case BLE_GATT_REGISTER_OP_SVC:
-        BLECSC_LOG(DEBUG, "registered service %s with handle=%d\n",
+        MODLOG_DFLT(DEBUG, "registered service %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->svc.svc_def->uuid, buf),
                     ctxt->svc.handle);
         break;
 
     case BLE_GATT_REGISTER_OP_CHR:
-        BLECSC_LOG(DEBUG, "registering characteristic %s with "
+        MODLOG_DFLT(DEBUG, "registering characteristic %s with "
                            "def_handle=%d val_handle=%d\n",
                     ble_uuid_to_str(ctxt->chr.chr_def->uuid, buf),
                     ctxt->chr.def_handle,
@@ -352,7 +352,7 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
         break;
 
     case BLE_GATT_REGISTER_OP_DSC:
-        BLECSC_LOG(DEBUG, "registering descriptor %s with handle=%d\n",
+        MODLOG_DFLT(DEBUG, "registering descriptor %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->dsc.dsc_def->uuid, buf),
                     ctxt->dsc.handle);
         break;

--- a/apps/blecsc/src/main.c
+++ b/apps/blecsc/src/main.c
@@ -41,9 +41,6 @@
 /* Simulated speed upper limit */
 #define CSC_SIM_SPEED_KPH_MAX                     35
 
-/* Log data */
-struct log blecsc_log;
-
 /* Noticication status */
 static bool notify_state = false;
 
@@ -118,7 +115,7 @@ blecsc_advertise(void)
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        BLECSC_LOG(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        MODLOG_DFLT(ERROR, "error setting advertisement data; rc=%d\n", rc);
         return;
     }
 
@@ -129,7 +126,7 @@ blecsc_advertise(void)
     rc = ble_gap_adv_start(blecsc_addr_type, NULL, BLE_HS_FOREVER,
                            &adv_params, blecsc_gap_event, NULL);
     if (rc != 0) {
-        BLECSC_LOG(ERROR, "error enabling advertisement; rc=%d\n", rc);
+        MODLOG_DFLT(ERROR, "error enabling advertisement; rc=%d\n", rc);
         return;
     }
 }
@@ -180,8 +177,8 @@ blecsc_simulate_speed_and_cadence()
         csc_measurement_state.last_crank_evt_time += crank_rev_period;
     }
 
-    BLECSC_LOG(INFO, "CSC simulated values: speed = %d kph, cadence = %d \n",
-                    csc_sim_speed_kph, csc_sim_crank_rpm);
+    MODLOG_DFLT(INFO, "CSC simulated values: speed = %d kph, cadence = %d \n",
+                csc_sim_speed_kph, csc_sim_crank_rpm);
 }
 
 /* Run CSC measurement simulation and notify it to the client */
@@ -207,7 +204,7 @@ blecsc_gap_event(struct ble_gap_event *event, void *arg)
     switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
         /* A new connection was established or a connection attempt failed */
-        BLECSC_LOG(INFO, "connection %s; status=%d\n",
+        MODLOG_DFLT(INFO, "connection %s; status=%d\n",
                     event->connect.status == 0 ? "established" : "failed",
                     event->connect.status);
 
@@ -222,34 +219,34 @@ blecsc_gap_event(struct ble_gap_event *event, void *arg)
         break;
 
     case BLE_GAP_EVENT_DISCONNECT:
-        BLECSC_LOG(INFO, "disconnect; reason=%d\n", event->disconnect.reason);
+        MODLOG_DFLT(INFO, "disconnect; reason=%d\n", event->disconnect.reason);
         conn_handle = 0;
         /* Connection terminated; resume advertising */
         blecsc_advertise();
         break;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
-        BLECSC_LOG(INFO, "adv complete\n");
+        MODLOG_DFLT(INFO, "adv complete\n");
         break;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-        BLECSC_LOG(INFO, "subscribe event attr_handle=%d\n",
-                         event->subscribe.attr_handle);
+        MODLOG_DFLT(INFO, "subscribe event attr_handle=%d\n",
+                    event->subscribe.attr_handle);
 
         if (event->subscribe.attr_handle == csc_measurement_handle) {
             notify_state = event->subscribe.cur_notify;
-            BLECSC_LOG(INFO, "csc measurement notify state = %d\n",
-                              notify_state);
+            MODLOG_DFLT(INFO, "csc measurement notify state = %d\n",
+                        notify_state);
         }
         else if (event->subscribe.attr_handle == csc_control_point_handle) {
             gatt_svr_set_cp_indicate(event->subscribe.cur_indicate);
-            BLECSC_LOG(INFO, "csc control point indicate state = %d\n",
-                              event->subscribe.cur_indicate);
+            MODLOG_DFLT(INFO, "csc control point indicate state = %d\n",
+                        event->subscribe.cur_indicate);
         }
         break;
 
     case BLE_GAP_EVENT_MTU:
-        BLECSC_LOG(INFO, "mtu update event; conn_handle=%d mtu=%d\n",
+        MODLOG_DFLT(INFO, "mtu update event; conn_handle=%d mtu=%d\n",
                     event->mtu.conn_handle,
                     event->mtu.value);
         break;
@@ -288,13 +285,7 @@ main(void)
     /* Initialize OS */
     sysinit();
 
-    /* Initialize the blecsc log */
-    log_register("blecsc_sens_log", &blecsc_log, &log_console_handler, NULL,
-                    LOG_SYSLEVEL);
-
     /* Initialize the NimBLE host configuration */
-    log_register("blecsc_sens", &ble_hs_log, &log_console_handler, NULL,
-                    LOG_SYSLEVEL);
     ble_hs_cfg.sync_cb = blecsc_on_sync;
 
     /* Initialize measurement and notification timer */

--- a/apps/blehr/pkg.yml
+++ b/apps/blehr/pkg.yml
@@ -29,6 +29,7 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/sysinit"
     - "@apache-mynewt-core/sys/id"

--- a/apps/blehr/src/blehr_sens.h
+++ b/apps/blehr/src/blehr_sens.h
@@ -20,21 +20,12 @@
 #ifndef H_BLEHR_SENSOR_
 #define H_BLEHR_SENSOR_
 
-#include "log/log.h"
 #include "nimble/ble.h"
+#include "modlog/modlog.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-extern struct log blehr_log;
-
-/* blehr uses the first "peruser" log module */
-#define BLEHR_LOG_MODULE (LOG_MODULE_PERUSER + 0)
-
-/* Convenience macro for logging to the blerh module */
-#define BLEHR_LOG(lvl, ...) \
-    LOG_ ## lvl(&blehr_log, BLEHR_LOG_MODULE, __VA_ARGS__)
 
 /* Heart-rate configuration */
 #define GATT_HRS_UUID                           0x180D

--- a/apps/blehr/src/gatt_svr.c
+++ b/apps/blehr/src/gatt_svr.c
@@ -132,13 +132,13 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
 
     switch (ctxt->op) {
     case BLE_GATT_REGISTER_OP_SVC:
-        BLEHR_LOG(DEBUG, "registered service %s with handle=%d\n",
+        MODLOG_DFLT(DEBUG, "registered service %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->svc.svc_def->uuid, buf),
                     ctxt->svc.handle);
         break;
 
     case BLE_GATT_REGISTER_OP_CHR:
-        BLEHR_LOG(DEBUG, "registering characteristic %s with "
+        MODLOG_DFLT(DEBUG, "registering characteristic %s with "
                            "def_handle=%d val_handle=%d\n",
                     ble_uuid_to_str(ctxt->chr.chr_def->uuid, buf),
                     ctxt->chr.def_handle,
@@ -146,7 +146,7 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
         break;
 
     case BLE_GATT_REGISTER_OP_DSC:
-        BLEHR_LOG(DEBUG, "registering descriptor %s with handle=%d\n",
+        MODLOG_DFLT(DEBUG, "registering descriptor %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->dsc.dsc_def->uuid, buf),
                     ctxt->dsc.handle);
         break;

--- a/apps/blemesh/pkg.yml
+++ b/apps/blemesh/pkg.yml
@@ -26,6 +26,7 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/shell"
     - nimble/controller

--- a/apps/blemesh/src/main.c
+++ b/apps/blemesh/src/main.c
@@ -419,8 +419,6 @@ main(int argc, char **argv)
     sysinit();
 
     /* Initialize the NimBLE host configuration. */
-    log_register("ble_hs", &ble_hs_log, &log_console_handler, NULL,
-                 LOG_SYSLEVEL);
     ble_hs_cfg.reset_cb = blemesh_on_reset;
     ble_hs_cfg.sync_cb = blemesh_on_sync;
     ble_hs_cfg.store_status_cb = ble_store_util_status_rr;

--- a/apps/blemesh_light/pkg.yml
+++ b/apps/blemesh_light/pkg.yml
@@ -26,6 +26,7 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/shell"
     - nimble/controller

--- a/apps/blemesh_light/src/main.c
+++ b/apps/blemesh_light/src/main.c
@@ -109,8 +109,6 @@ main(void)
     sysinit();
 
     /* Initialize the NimBLE host configuration. */
-    log_register("ble_hs", &ble_hs_log, &log_console_handler, NULL,
-                 LOG_SYSLEVEL);
     ble_hs_cfg.reset_cb = blemesh_on_reset;
     ble_hs_cfg.sync_cb = blemesh_on_sync;
     ble_hs_cfg.store_status_cb = ble_store_util_status_rr;

--- a/apps/blemesh_shell/pkg.yml
+++ b/apps/blemesh_shell/pkg.yml
@@ -26,6 +26,7 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/shell"
     - nimble/controller

--- a/apps/blemesh_shell/src/main.c
+++ b/apps/blemesh_shell/src/main.c
@@ -99,8 +99,6 @@ main(void)
     sysinit();
 
     /* Initialize the NimBLE host configuration. */
-    log_register("ble_hs", &ble_hs_log, &log_console_handler, NULL,
-                 LOG_SYSLEVEL);
     ble_hs_cfg.reset_cb = blemesh_on_reset;
     ble_hs_cfg.sync_cb = blemesh_on_sync;
     ble_hs_cfg.store_status_cb = ble_store_util_status_rr;

--- a/apps/bleprph/pkg.yml
+++ b/apps/bleprph/pkg.yml
@@ -34,10 +34,10 @@ pkg.deps:
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/sysinit"
     - "@apache-mynewt-core/sys/id"
-    - net/nimble/host
-    - net/nimble/host/services/ans
-    - net/nimble/host/services/gap
-    - net/nimble/host/services/gatt
-    - net/nimble/host/store/config
-    - net/nimble/host/util
-    - net/nimble/transport
+    - nimble/host
+    - nimble/host/services/ans
+    - nimble/host/services/gap
+    - nimble/host/services/gatt
+    - nimble/host/store/config
+    - nimble/host/util
+    - nimble/transport

--- a/apps/bleprph/pkg.yml
+++ b/apps/bleprph/pkg.yml
@@ -31,6 +31,7 @@ pkg.deps:
     - "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/sysinit"
     - "@apache-mynewt-core/sys/id"

--- a/apps/bleprph/src/bleprph.h
+++ b/apps/bleprph/src/bleprph.h
@@ -21,23 +21,14 @@
 #define H_BLEPRPH_
 
 #include <stdbool.h>
-#include "log/log.h"
 #include "nimble/ble.h"
+#include "modlog/modlog.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct ble_hs_cfg;
 struct ble_gatt_register_ctxt;
-
-extern struct log bleprph_log;
-
-/* bleprph uses the first "peruser" log module. */
-#define BLEPRPH_LOG_MODULE  (LOG_MODULE_PERUSER + 0)
-
-/* Convenience macro for logging to the bleprph module. */
-#define BLEPRPH_LOG(lvl, ...) \
-    LOG_ ## lvl(&bleprph_log, BLEPRPH_LOG_MODULE, __VA_ARGS__)
 
 /** GATT server. */
 #define GATT_SVR_SVC_ALERT_UUID               0x1811

--- a/apps/bleprph/src/gatt_svr.c
+++ b/apps/bleprph/src/gatt_svr.c
@@ -160,13 +160,13 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
 
     switch (ctxt->op) {
     case BLE_GATT_REGISTER_OP_SVC:
-        BLEPRPH_LOG(DEBUG, "registered service %s with handle=%d\n",
+        MODLOG_DFLT(DEBUG, "registered service %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->svc.svc_def->uuid, buf),
                     ctxt->svc.handle);
         break;
 
     case BLE_GATT_REGISTER_OP_CHR:
-        BLEPRPH_LOG(DEBUG, "registering characteristic %s with "
+        MODLOG_DFLT(DEBUG, "registering characteristic %s with "
                            "def_handle=%d val_handle=%d\n",
                     ble_uuid_to_str(ctxt->chr.chr_def->uuid, buf),
                     ctxt->chr.def_handle,
@@ -174,7 +174,7 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
         break;
 
     case BLE_GATT_REGISTER_OP_DSC:
-        BLEPRPH_LOG(DEBUG, "registering descriptor %s with handle=%d\n",
+        MODLOG_DFLT(DEBUG, "registering descriptor %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->dsc.dsc_def->uuid, buf),
                     ctxt->dsc.handle);
         break;

--- a/apps/bleprph/src/main.c
+++ b/apps/bleprph/src/main.c
@@ -38,9 +38,6 @@
 /* Application-specified header. */
 #include "bleprph.h"
 
-/** Log data. */
-struct log bleprph_log;
-
 static int bleprph_gap_event(struct ble_gap_event *event, void *arg);
 
 /**
@@ -49,19 +46,19 @@ static int bleprph_gap_event(struct ble_gap_event *event, void *arg);
 static void
 bleprph_print_conn_desc(struct ble_gap_conn_desc *desc)
 {
-    BLEPRPH_LOG(INFO, "handle=%d our_ota_addr_type=%d our_ota_addr=",
+    MODLOG_DFLT(INFO, "handle=%d our_ota_addr_type=%d our_ota_addr=",
                 desc->conn_handle, desc->our_ota_addr.type);
     print_addr(desc->our_ota_addr.val);
-    BLEPRPH_LOG(INFO, " our_id_addr_type=%d our_id_addr=",
+    MODLOG_DFLT(INFO, " our_id_addr_type=%d our_id_addr=",
                 desc->our_id_addr.type);
     print_addr(desc->our_id_addr.val);
-    BLEPRPH_LOG(INFO, " peer_ota_addr_type=%d peer_ota_addr=",
+    MODLOG_DFLT(INFO, " peer_ota_addr_type=%d peer_ota_addr=",
                 desc->peer_ota_addr.type);
     print_addr(desc->peer_ota_addr.val);
-    BLEPRPH_LOG(INFO, " peer_id_addr_type=%d peer_id_addr=",
+    MODLOG_DFLT(INFO, " peer_id_addr_type=%d peer_id_addr=",
                 desc->peer_id_addr.type);
     print_addr(desc->peer_id_addr.val);
-    BLEPRPH_LOG(INFO, " conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+    MODLOG_DFLT(INFO, " conn_itvl=%d conn_latency=%d supervision_timeout=%d "
                 "encrypted=%d authenticated=%d bonded=%d\n",
                 desc->conn_itvl, desc->conn_latency,
                 desc->supervision_timeout,
@@ -87,7 +84,7 @@ bleprph_advertise(void)
     /* Figure out address to use while advertising (no privacy for now) */
     rc = ble_hs_id_infer_auto(0, &own_addr_type);
     if (rc != 0) {
-        BLEPRPH_LOG(ERROR, "error determining address type; rc=%d\n", rc);
+        MODLOG_DFLT(ERROR, "error determining address type; rc=%d\n", rc);
         return;
     }
 
@@ -128,7 +125,7 @@ bleprph_advertise(void)
 
     rc = ble_gap_adv_set_fields(&fields);
     if (rc != 0) {
-        BLEPRPH_LOG(ERROR, "error setting advertisement data; rc=%d\n", rc);
+        MODLOG_DFLT(ERROR, "error setting advertisement data; rc=%d\n", rc);
         return;
     }
 
@@ -139,7 +136,7 @@ bleprph_advertise(void)
     rc = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER,
                            &adv_params, bleprph_gap_event, NULL);
     if (rc != 0) {
-        BLEPRPH_LOG(ERROR, "error enabling advertisement; rc=%d\n", rc);
+        MODLOG_DFLT(ERROR, "error enabling advertisement; rc=%d\n", rc);
         return;
     }
 }
@@ -168,9 +165,9 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
     switch (event->type) {
     case BLE_GAP_EVENT_CONNECT:
         /* A new connection was established or a connection attempt failed. */
-        BLEPRPH_LOG(INFO, "connection %s; status=%d ",
-                       event->connect.status == 0 ? "established" : "failed",
-                       event->connect.status);
+        MODLOG_DFLT(INFO, "connection %s; status=%d ",
+                    event->connect.status == 0 ? "established" : "failed",
+                    event->connect.status);
         if (event->connect.status == 0) {
             rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
             assert(rc == 0);
@@ -180,7 +177,7 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
             phy_conn_changed(event->connect.conn_handle);
 #endif
         }
-        BLEPRPH_LOG(INFO, "\n");
+        MODLOG_DFLT(INFO, "\n");
 
         if (event->connect.status != 0) {
             /* Connection failed; resume advertising. */
@@ -189,9 +186,9 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_DISCONNECT:
-        BLEPRPH_LOG(INFO, "disconnect; reason=%d ", event->disconnect.reason);
+        MODLOG_DFLT(INFO, "disconnect; reason=%d ", event->disconnect.reason);
         bleprph_print_conn_desc(&event->disconnect.conn);
-        BLEPRPH_LOG(INFO, "\n");
+        MODLOG_DFLT(INFO, "\n");
 
 #if MYNEWT_VAL(BLEPRPH_LE_PHY_SUPPORT)
         phy_conn_changed(CONN_HANDLE_INVALID);
@@ -203,32 +200,32 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_CONN_UPDATE:
         /* The central has updated the connection parameters. */
-        BLEPRPH_LOG(INFO, "connection updated; status=%d ",
+        MODLOG_DFLT(INFO, "connection updated; status=%d ",
                     event->conn_update.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         bleprph_print_conn_desc(&desc);
-        BLEPRPH_LOG(INFO, "\n");
+        MODLOG_DFLT(INFO, "\n");
         return 0;
 
     case BLE_GAP_EVENT_ADV_COMPLETE:
-        BLEPRPH_LOG(INFO, "advertise complete; reason=%d",
+        MODLOG_DFLT(INFO, "advertise complete; reason=%d",
                     event->adv_complete.reason);
         bleprph_advertise();
         return 0;
 
     case BLE_GAP_EVENT_ENC_CHANGE:
         /* Encryption has been enabled or disabled for this connection. */
-        BLEPRPH_LOG(INFO, "encryption change event; status=%d ",
+        MODLOG_DFLT(INFO, "encryption change event; status=%d ",
                     event->enc_change.status);
         rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
         assert(rc == 0);
         bleprph_print_conn_desc(&desc);
-        BLEPRPH_LOG(INFO, "\n");
+        MODLOG_DFLT(INFO, "\n");
         return 0;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-        BLEPRPH_LOG(INFO, "subscribe event; conn_handle=%d attr_handle=%d "
+        MODLOG_DFLT(INFO, "subscribe event; conn_handle=%d attr_handle=%d "
                           "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
                     event->subscribe.conn_handle,
                     event->subscribe.attr_handle,
@@ -240,7 +237,7 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
         return 0;
 
     case BLE_GAP_EVENT_MTU:
-        BLEPRPH_LOG(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
+        MODLOG_DFLT(INFO, "mtu update event; conn_handle=%d cid=%d mtu=%d\n",
                     event->mtu.conn_handle,
                     event->mtu.channel_id,
                     event->mtu.value);
@@ -276,7 +273,7 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
 static void
 bleprph_on_reset(int reason)
 {
-    BLEPRPH_LOG(ERROR, "Resetting state; reason=%d\n", reason);
+    MODLOG_DFLT(ERROR, "Resetting state; reason=%d\n", reason);
 }
 
 static void
@@ -308,13 +305,7 @@ main(void)
     /* Initialize OS */
     sysinit();
 
-    /* Initialize the bleprph log. */
-    log_register("bleprph", &bleprph_log, &log_console_handler, NULL,
-                 LOG_SYSLEVEL);
-
     /* Initialize the NimBLE host configuration. */
-    log_register("ble_hs", &ble_hs_log, &log_console_handler, NULL,
-                 LOG_SYSLEVEL);
     ble_hs_cfg.reset_cb = bleprph_on_reset;
     ble_hs_cfg.sync_cb = bleprph_on_sync;
     ble_hs_cfg.gatts_register_cb = gatt_svr_register_cb;

--- a/apps/bleprph/src/misc.c
+++ b/apps/bleprph/src/misc.c
@@ -28,7 +28,7 @@ print_bytes(const uint8_t *bytes, int len)
     int i;
 
     for (i = 0; i < len; i++) {
-        BLEPRPH_LOG(INFO, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+        MODLOG_DFLT(INFO, "%s0x%02x", i != 0 ? ":" : "", bytes[i]);
     }
 }
 
@@ -38,6 +38,6 @@ print_addr(const void *addr)
     const uint8_t *u8p;
 
     u8p = addr;
-    BLEPRPH_LOG(INFO, "%02x:%02x:%02x:%02x:%02x:%02x",
+    MODLOG_DFLT(INFO, "%02x:%02x:%02x:%02x:%02x:%02x",
                 u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
 }

--- a/apps/bletest/pkg.yml
+++ b/apps/bletest/pkg.yml
@@ -33,5 +33,6 @@ pkg.deps:
     - sys/shell
     - sys/config
     - sys/log/full
+    - sys/log/modlog
     - sys/stats/full
 pkg.cflags: -DBLETEST

--- a/apps/bletest/src/main.c
+++ b/apps/bletest/src/main.c
@@ -1299,9 +1299,6 @@ main(void)
     g_bletest_cur_peer_addr[5] = 0x08;
 #endif
 
-    log_register("ble_hs", &ble_hs_log, &log_console_handler, NULL,
-                 LOG_SYSLEVEL);
-
     /* Set the led pin as an output */
     g_led_pin = LED_BLINK_PIN;
     hal_gpio_init_out(g_led_pin, 1);

--- a/apps/btshell/pkg.yml
+++ b/apps/btshell/pkg.yml
@@ -25,6 +25,7 @@ pkg.keywords:
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/shell"

--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -24,7 +24,7 @@
 #include "os/mynewt.h"
 #include "nimble/ble.h"
 #include "nimble/nimble_opt.h"
-#include "log/log.h"
+#include "modlog/modlog.h"
 
 #include "host/ble_gatt.h"
 #include "host/ble_gap.h"
@@ -89,7 +89,6 @@ struct btshell_scan_opts {
 extern struct btshell_conn btshell_conns[MYNEWT_VAL(BLE_MAX_CONNECTIONS)];
 extern int btshell_num_conns;
 
-extern struct log btshell_log;
 int btshell_exchange_mtu(uint16_t conn_handle);
 int btshell_disc_svcs(uint16_t conn_handle);
 int btshell_disc_svc_by_uuid(uint16_t conn_handle, const ble_uuid_t *uuid);
@@ -165,9 +164,6 @@ int btshell_l2cap_create_srv(uint16_t psm, int accept_response);
 int btshell_l2cap_connect(uint16_t conn, uint16_t psm);
 int btshell_l2cap_disconnect(uint16_t conn, uint16_t idx);
 int btshell_l2cap_send(uint16_t conn, uint16_t idx, uint16_t bytes);
-#define BTSHELL_LOG_MODULE  (LOG_MODULE_PERUSER + 0)
-#define BTSHELL_LOG(lvl, ...) \
-    LOG_ ## lvl(&btshell_log, BTSHELL_LOG_MODULE, __VA_ARGS__)
 
 /** GATT server. */
 #define GATT_SVR_SVC_ALERT_UUID               0x1811

--- a/apps/btshell/src/gatt_svr.c
+++ b/apps/btshell/src/gatt_svr.c
@@ -545,13 +545,13 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
 
     switch (ctxt->op) {
     case BLE_GATT_REGISTER_OP_SVC:
-        BTSHELL_LOG(DEBUG, "registered service %s with handle=%d\n",
+        MODLOG_DFLT(DEBUG, "registered service %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->svc.svc_def->uuid, buf),
                     ctxt->svc.handle);
         break;
 
     case BLE_GATT_REGISTER_OP_CHR:
-        BTSHELL_LOG(DEBUG, "registering characteristic %s with "
+        MODLOG_DFLT(DEBUG, "registering characteristic %s with "
                            "def_handle=%d val_handle=%d\n",
                     ble_uuid_to_str(ctxt->chr.chr_def->uuid, buf),
                     ctxt->chr.def_handle,
@@ -559,7 +559,7 @@ gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
         break;
 
     case BLE_GATT_REGISTER_OP_DSC:
-        BTSHELL_LOG(DEBUG, "registering descriptor %s with handle=%d\n",
+        MODLOG_DFLT(DEBUG, "registering descriptor %s with handle=%d\n",
                     ble_uuid_to_str(ctxt->dsc.dsc_def->uuid, buf),
                     ctxt->dsc.handle);
         break;

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -74,8 +74,6 @@
 #define PTR_TO_INT(x)     (int) ((intptr_t)(x))
 #endif
 
-struct log btshell_log;
-
 bssnz_t struct btshell_conn btshell_conns[MYNEWT_VAL(BLE_MAX_CONNECTIONS)];
 int btshell_num_conns;
 
@@ -390,7 +388,7 @@ btshell_svc_add(uint16_t conn_handle, const struct ble_gatt_svc *gatt_svc)
 
     conn = btshell_conn_find(conn_handle);
     if (conn == NULL) {
-        BTSHELL_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+        MODLOG_DFLT(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
                            "HANDLE=%d\n",
                     conn_handle);
         return NULL;
@@ -404,7 +402,7 @@ btshell_svc_add(uint16_t conn_handle, const struct ble_gatt_svc *gatt_svc)
 
     svc = os_memblock_get(&btshell_svc_pool);
     if (svc == NULL) {
-        BTSHELL_LOG(DEBUG, "OOM WHILE DISCOVERING SERVICE\n");
+        MODLOG_DFLT(DEBUG, "OOM WHILE DISCOVERING SERVICE\n");
         return NULL;
     }
     memset(svc, 0, sizeof *svc);
@@ -474,7 +472,7 @@ btshell_chr_add(uint16_t conn_handle,  uint16_t svc_start_handle,
 
     conn = btshell_conn_find(conn_handle);
     if (conn == NULL) {
-        BTSHELL_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+        MODLOG_DFLT(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
                            "HANDLE=%d\n",
                     conn_handle);
         return NULL;
@@ -482,7 +480,7 @@ btshell_chr_add(uint16_t conn_handle,  uint16_t svc_start_handle,
 
     svc = btshell_svc_find(conn, svc_start_handle, NULL);
     if (svc == NULL) {
-        BTSHELL_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED CHR; HANDLE=%d\n",
+        MODLOG_DFLT(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED CHR; HANDLE=%d\n",
                     conn_handle);
         return NULL;
     }
@@ -495,7 +493,7 @@ btshell_chr_add(uint16_t conn_handle,  uint16_t svc_start_handle,
 
     chr = os_memblock_get(&btshell_chr_pool);
     if (chr == NULL) {
-        BTSHELL_LOG(DEBUG, "OOM WHILE DISCOVERING CHARACTERISTIC\n");
+        MODLOG_DFLT(DEBUG, "OOM WHILE DISCOVERING CHARACTERISTIC\n");
         return NULL;
     }
     memset(chr, 0, sizeof *chr);
@@ -565,7 +563,7 @@ btshell_dsc_add(uint16_t conn_handle, uint16_t chr_val_handle,
 
     conn = btshell_conn_find(conn_handle);
     if (conn == NULL) {
-        BTSHELL_LOG(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
+        MODLOG_DFLT(DEBUG, "RECEIVED SERVICE FOR UNKNOWN CONNECTION; "
                            "HANDLE=%d\n",
                     conn_handle);
         return NULL;
@@ -573,14 +571,14 @@ btshell_dsc_add(uint16_t conn_handle, uint16_t chr_val_handle,
 
     svc = btshell_svc_find_range(conn, chr_val_handle);
     if (svc == NULL) {
-        BTSHELL_LOG(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED DSC; HANDLE=%d\n",
+        MODLOG_DFLT(DEBUG, "CAN'T FIND SERVICE FOR DISCOVERED DSC; HANDLE=%d\n",
                     conn_handle);
         return NULL;
     }
 
     chr = btshell_chr_find(svc, chr_val_handle, NULL);
     if (chr == NULL) {
-        BTSHELL_LOG(DEBUG, "CAN'T FIND CHARACTERISTIC FOR DISCOVERED DSC; "
+        MODLOG_DFLT(DEBUG, "CAN'T FIND CHARACTERISTIC FOR DISCOVERED DSC; "
                            "HANDLE=%d\n",
                     conn_handle);
         return NULL;
@@ -689,7 +687,7 @@ btshell_disc_full_dscs(uint16_t conn_handle)
 
     conn = btshell_conn_find(conn_handle);
     if (conn == NULL) {
-        BTSHELL_LOG(DEBUG, "Failed to discover descriptors for conn=%d; "
+        MODLOG_DFLT(DEBUG, "Failed to discover descriptors for conn=%d; "
                            "not connected\n", conn_handle);
         btshell_full_disc_complete(BLE_HS_ENOTCONN);
         return;
@@ -727,7 +725,7 @@ btshell_disc_full_chrs(uint16_t conn_handle)
 
     conn = btshell_conn_find(conn_handle);
     if (conn == NULL) {
-        BTSHELL_LOG(DEBUG, "Failed to discover characteristics for conn=%d; "
+        MODLOG_DFLT(DEBUG, "Failed to discover characteristics for conn=%d; "
                            "not connected\n", conn_handle);
         btshell_full_disc_complete(BLE_HS_ENOTCONN);
         return;
@@ -2080,13 +2078,7 @@ main(int argc, char **argv)
     assert(rc == 0);
 #endif
 
-    /* Initialize the logging system. */
-    log_register("btshell", &btshell_log, &log_console_handler, NULL,
-                 LOG_SYSLEVEL);
-
     /* Initialize the NimBLE host configuration. */
-    log_register("ble_hs", &ble_hs_log, &log_console_handler, NULL,
-                 LOG_SYSLEVEL);
     ble_hs_cfg.reset_cb = btshell_on_reset;
     ble_hs_cfg.gatts_register_cb = gatt_svr_register_cb;
     ble_hs_cfg.store_status_cb = ble_store_util_status_rr;

--- a/nimble/host/include/host/ble_hs_log.h
+++ b/nimble/host/include/host/ble_hs_log.h
@@ -20,17 +20,16 @@
 #ifndef H_BLE_HS_LOG_
 #define H_BLE_HS_LOG_
 
-#include "log/log.h"
+#include "modlog/modlog.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct os_mbuf;
 
-extern struct log ble_hs_log;
-
 #define BLE_HS_LOG(lvl, ...) \
-    LOG_ ## lvl(&ble_hs_log, LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+    MODLOG_ ## lvl(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
 
 #define BLE_HS_LOG_ADDR(lvl, addr)                      \
     BLE_HS_LOG(lvl, "%02x:%02x:%02x:%02x:%02x:%02x",    \

--- a/nimble/host/pkg.yml
+++ b/nimble/host/pkg.yml
@@ -27,6 +27,7 @@ pkg.keywords:
 
 pkg.deps:
     - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/util/mem"
     - nimble
 
@@ -45,7 +46,6 @@ pkg.deps.BLE_MESH:
 pkg.req_apis:
     - ble_transport
     - console
-    - log
     - stats
 
 pkg.init:


### PR DESCRIPTION
(Sibling PR: https://github.com/apache/mynewt-core/pull/1249)

This PR changes all existing packages to use the modlog facility rather than directly call into the `sys/log` API.  I think this is the right direction, but it is a somewhat major change, and I am certainly open to feedback.

The changes in this PR are as follows:

*`nimble/host`*
* Add `sys/log/modlog` dependency to `pkg.yml`.
* Remove `log` required API from `pkg.yml`.
* Replace `LOG_[...]` calls with `MODLOG_[...]` calls.
* Delete `ble_hs_log` object.

*App packages*
* Add `sys/log/modlog` dependency to `pkg.yml`.
* Delete `struct log` object; remove call to `log_register()`.
* Delete custom log macros (e.g., `BLEPRPH_LOG()`).
* Replace calls to custom log macro with calls to`MODLOG_DFLT()`.
* Remove registration of `ble_hs_log` and `oc_log`.  These logs don't exist anymore.