### PR TITLE
nimble/ll: Make vnd event on assert configurable

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -39,7 +39,7 @@ extern "C" {
 #error 32.768kHz clock required
 #endif
 
-#ifdef MYNEWT
+#if defined(MYNEWT) && MYNEWT_VAL(BLE_LL_VND_EVENT_ON_ASSERT)
 #ifdef NDEBUG
 #define BLE_LL_ASSERT(cond) (void(0))
 #else

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -293,7 +293,19 @@ syscfg.defs:
              Enables HCI Test commands needed for Bluetooth SIG certification
         value: 0
 
+    BLE_LL_VND_EVENT_ON_ASSERT:
+        description: >
+            This options enables controller to send a vendor-specific event on
+            an assertion in controller code. The event contains file name and
+            line number where assertion occured.
+        value: 0
+
 syscfg.vals.BLE_LL_CFG_FEAT_LL_EXT_ADV:
     BLE_LL_CFG_FEAT_LE_CSA2: 1
     BLE_HW_WHITELIST_ENABLE: 0
     BLE_LL_EXT_ADV_AUX_PTR_CNT: 5
+
+# Enable vendor event on assert in standalone build to make failed assertions in
+# controller code visible when connected to external host
+syscfg.vals.!BLE_HOST:
+    BLE_LL_VND_EVENT_ON_ASSERT: 1


### PR DESCRIPTION
This event is only useful when talking to external hosts, so no need to
have it enabled in combined builds. Now it's configurable and disabled
by default on all builds except for builds without NimBLE host.