### PR TITLE
nimble/host: Remove spurious conn-update callback

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -1004,8 +1004,10 @@ ble_gap_conn_broken(uint16_t conn_handle, int reason)
     entry = ble_gap_update_entry_remove(conn_handle);
     ble_hs_unlock();
 
-    ble_gap_update_notify(conn_handle, reason);
-    ble_gap_update_entry_free(entry);
+    if (entry != NULL) {
+        ble_gap_update_notify(conn_handle, reason);
+        ble_gap_update_entry_free(entry);
+    }
 
     /* Indicate the connection termination to each module.  The order matters
      * here: gatts must come before gattc to ensure the application does not


### PR DESCRIPTION
The GAP callback was incorrectly being called with an event type of `BLE_GAP_EVENT_CONN_UPDATE` each time a connection was terminated.  For example, a typical disconnect event might look like this in the log:
```
023276 [ts=181843696us, mod=82 level=1] connection update; rc=531
023277 [ts=181921816us, mod=82 level=1] disconnect; reason=531
```

In most cases, only the second line should be present.  The "connection update" event should only be signaled on termination if an update procedure for the connection happened to be in progress at the time. In that case, the connection termination causes the update procedure to
fail.