### PR TITLE
porting: Delete non-existing file from Makefile.defs

### DIFF
--- a/porting/nimble/Makefile.defs
+++ b/porting/nimble/Makefile.defs
@@ -87,7 +87,6 @@ NIMBLE_SRC := \
 	$(NIMBLE_ROOT)/nimble/host/store/ram/src/ble_store_ram.c \
 	$(NIMBLE_ROOT)/nimble/host/util/src/addr.c \
 	$(NIMBLE_ROOT)/nimble/src/ble_util.c \
-	$(NIMBLE_ROOT)/nimble/src/hci_common.c \
 
 # Few utils and data structures copied from Mynewt
 NIMBLE_SRC += \


### PR DESCRIPTION
This file was deleted in 2fdca20f885c4c8341497696f08fcc5f92edd9b8.