### PR TITLE
nimble/host: Improve BLE uuid comparison, handle invalid uuid's

### DIFF
--- a/nimble/host/include/host/ble_uuid.h
+++ b/nimble/host/include/host/ble_uuid.h
@@ -171,6 +171,15 @@ char *ble_uuid_to_str(const ble_uuid_t *uuid, char *dst);
  */
 uint16_t ble_uuid_u16(const ble_uuid_t *uuid);
 
+/** @brief Checks a UUID object for validity.
+ *
+ * @param uuid      The UUID object to check.
+ *
+ * @return          0 on success;
+ *                  BLE_HS_EBADDATA if the provided UUID object is not valid.
+ */
+int ble_uuid_check(const ble_uuid_t *uuid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -2453,7 +2453,8 @@ done:
     if (rc != 0) {
         /* Failure. */
         cbrc = ble_gattc_disc_chr_uuid_cb(proc, rc, 0, NULL);
-    } else if (ble_uuid_cmp(&chr.uuid.u, &proc->disc_chr_uuid.chr_uuid.u) == 0) {
+    } else if (ble_uuid_check(&chr.uuid.u) == 0 &&
+               ble_uuid_cmp(&chr.uuid.u, &proc->disc_chr_uuid.chr_uuid.u) == 0) {
         /* Requested characteristic discovered. */
         cbrc = ble_gattc_disc_chr_uuid_cb(proc, 0, 0, &chr);
     } else {

--- a/nimble/host/src/ble_uuid.c
+++ b/nimble/host/src/ble_uuid.c
@@ -32,8 +32,8 @@ static uint8_t ble_uuid_base[16] = {
     0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-#if MYNEWT_VAL(BLE_HS_DEBUG)
-static int verify_uuid(const ble_uuid_t *uuid)
+int
+ble_uuid_check(const ble_uuid_t *uuid)
 {
     switch (uuid->type) {
     case BLE_UUID_TYPE_16:
@@ -48,7 +48,6 @@ static int verify_uuid(const ble_uuid_t *uuid)
 
     return BLE_HS_EBADDATA;
 }
-#endif
 
 int
 ble_uuid_init_from_buf(ble_uuid_any_t *uuid, const void *buf, size_t len)
@@ -74,8 +73,8 @@ ble_uuid_init_from_buf(ble_uuid_any_t *uuid, const void *buf, size_t len)
 int
 ble_uuid_cmp(const ble_uuid_t *uuid1, const ble_uuid_t *uuid2)
 {
-    BLE_HS_DBG_ASSERT(verify_uuid(uuid1) == 0);
-    BLE_HS_DBG_ASSERT(verify_uuid(uuid2) == 0);
+    BLE_HS_DBG_ASSERT(ble_uuid_check(uuid1) == 0);
+    BLE_HS_DBG_ASSERT(ble_uuid_check(uuid2) == 0);
 
     if (uuid1->type != uuid2->type) {
       return uuid1->type - uuid2->type;
@@ -147,7 +146,7 @@ ble_uuid_to_str(const ble_uuid_t *uuid, char *dst)
 uint16_t
 ble_uuid_u16(const ble_uuid_t *uuid)
 {
-    BLE_HS_DBG_ASSERT(verify_uuid(uuid) == 0);
+    BLE_HS_DBG_ASSERT(ble_uuid_check(uuid) == 0);
 
     return uuid->type == BLE_UUID_TYPE_16 ? BLE_UUID16(uuid)->value : 0;
 }
@@ -174,7 +173,7 @@ ble_uuid_init_from_mbuf(ble_uuid_any_t *uuid, struct os_mbuf *om, int off,
 int
 ble_uuid_to_any(const ble_uuid_t *uuid, ble_uuid_any_t *uuid_any)
 {
-    BLE_HS_DBG_ASSERT(verify_uuid(uuid) == 0);
+    BLE_HS_DBG_ASSERT(ble_uuid_check(uuid) == 0);
 
     uuid_any->u.type = uuid->type;
 
@@ -203,7 +202,7 @@ ble_uuid_to_mbuf(const ble_uuid_t *uuid, struct os_mbuf *om)
     int len;
     void *buf;
 
-    BLE_HS_DBG_ASSERT(verify_uuid(uuid) == 0);
+    BLE_HS_DBG_ASSERT(ble_uuid_check(uuid) == 0);
 
     len = ble_uuid_length(uuid);
 
@@ -220,7 +219,7 @@ ble_uuid_to_mbuf(const ble_uuid_t *uuid, struct os_mbuf *om)
 int
 ble_uuid_flat(const ble_uuid_t *uuid, void *dst)
 {
-    BLE_HS_DBG_ASSERT(verify_uuid(uuid) == 0);
+    BLE_HS_DBG_ASSERT(ble_uuid_check(uuid) == 0);
 
     switch (uuid->type) {
     case BLE_UUID_TYPE_16:
@@ -243,7 +242,7 @@ ble_uuid_flat(const ble_uuid_t *uuid, void *dst)
 int
 ble_uuid_length(const ble_uuid_t *uuid)
 {
-    BLE_HS_DBG_ASSERT(verify_uuid(uuid) == 0);
+    BLE_HS_DBG_ASSERT(ble_uuid_check(uuid) == 0);
 
     return uuid->type >> 3;
 }

--- a/nimble/host/src/ble_uuid.c
+++ b/nimble/host/src/ble_uuid.c
@@ -91,7 +91,8 @@ ble_uuid_cmp(const ble_uuid_t *uuid1, const ble_uuid_t *uuid2)
 
     BLE_HS_DBG_ASSERT(0);
 
-    return 0;
+    /* If the UUID type is not recognised, compare as unequal. */
+    return BLE_HS_EBADDATA;
 }
 
 void


### PR DESCRIPTION
This PR contains a couple of changes to UUID checking and comparison to address issues we've seen with malformed UUID's in the field. We also needed to check UUID's in our application, so we made that function available externally.

Rename verify_uuid to ble_uuid_check and make it available to other files. Improve ble_uuid_cmp so that it returns unequal if the UUID type is unrecognized. Use UUID check in ble_gattc.c to resolve errors with invalid UUID's.