### PR TITLE
nimble/ll: Fix checking len of TERMINATE_IND

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -3908,7 +3908,7 @@ chk_rx_terminate_ind:
 
         /* If we received a terminate IND, we must set some flags */
         if (is_ctrl && (opcode == BLE_LL_CTRL_TERMINATE_IND)
-                    && (rx_pyld_len == BLE_LL_CTRL_TERMINATE_IND_LEN)) {
+                    && (rx_pyld_len == (1 + BLE_LL_CTRL_TERMINATE_IND_LEN))) {
             connsm->csmflags.cfbit.terminate_ind_rxd = 1;
             connsm->rxd_disconnect_reason = rxbuf[3];
             reply = 1;


### PR DESCRIPTION
BLE_LL_CTRL_TERMINATE_IND_LEN is 1 as it stands only for error code in
the TERMINATE_IND opcode. 'rx_pyld_len' contains aslo opcode which is
additional 1 octet.

This patch fixes it.