### PR TITLE
Modified iBeacon and Eddystone

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1752,6 +1752,12 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         return rc;
     }
 
+    int8_t measured_power = parse_arg_uint16("measured_power", &rc);
+    if (rc != 0 && rc != ENOENT) {
+        console_printf("invalid 'measured_power' parameter\n");
+        return rc;
+    }
+
     eddystone_url_full = parse_arg_extract("eddystone_url");
     if (eddystone_url_full != NULL) {
         rc = parse_eddystone_url(eddystone_url_full, &eddystone_url_scheme,
@@ -1765,7 +1771,8 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         rc = ble_eddystone_set_adv_data_url(&adv_fields, eddystone_url_scheme,
                                             eddystone_url_body,
                                             eddystone_url_body_len,
-                                            eddystone_url_suffix);
+                                            eddystone_url_suffix,
+                                            measured_power);
     } else {
 #if MYNEWT_VAL(BLE_EXT_ADV)
         /* Default to legacy PDUs size, mbuf chain will be increased if needed

--- a/nimble/host/include/host/ble_eddystone.h
+++ b/nimble/host/include/host/ble_eddystone.h
@@ -92,6 +92,8 @@ int ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
  *                                  BLE_EDDYSTONE_URL_SUFFIX values; use
  *                                  BLE_EDDYSTONE_URL_SUFFIX_NONE if the suffix
  *                                  is embedded in the body argument.
+ * @param tx_measure_power      The Measure Power value which is measured as RSSI
+ *                                  value at 1 Meter distance.
  *
  * @return                      0 on success;
  *                              BLE_HS_EBUSY if advertising is in progress;
@@ -101,7 +103,7 @@ int ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
  */
 int ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
                                    uint8_t url_scheme, char *url_body,
-                                   uint8_t url_body_len, uint8_t suffix);
+                                   uint8_t url_body_len, uint8_t suffix, int8_t tx_measure_power);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/include/host/ble_ibeacon.h
+++ b/nimble/host/include/host/ble_ibeacon.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-int ble_ibeacon_set_adv_data(struct ble_hs_adv_fields *adv_fields, void *uuid128, uint16_t major, uint16_t minor);
+int ble_ibeacon_set_adv_data(struct ble_hs_adv_fields *adv_fields, void *uuid128, uint16_t major, uint16_t minor, int8_t tx_measure_power);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/include/host/ble_ibeacon.h
+++ b/nimble/host/include/host/ble_ibeacon.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-int ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor);
+int ble_ibeacon_set_adv_data(struct ble_hs_adv_fields *adv_fields, void *uuid128, uint16_t major, uint16_t minor);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/src/ble_eddystone.c
+++ b/nimble/host/src/ble_eddystone.c
@@ -140,10 +140,9 @@ ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields, void *uid)
 int
 ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
                                uint8_t url_scheme, char *url_body,
-                               uint8_t url_body_len, uint8_t url_suffix)
+                               uint8_t url_body_len, uint8_t url_suffix, int8_t tx_measure_power)
 {
     uint8_t *svc_data;
-    int8_t tx_pwr;
     int url_len;
     int rc;
 
@@ -157,11 +156,9 @@ ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
 
     svc_data = ble_eddystone_set_svc_data_base(BLE_EDDYSTONE_FRAME_TYPE_URL);
 
-    rc = ble_hs_hci_util_read_adv_tx_pwr(&tx_pwr);
-    if (rc != 0) {
-        return rc;
-    }
-    svc_data[0] = tx_pwr;
+    /** Last byte (Measured Power) filled in as RSSI  measurement at 1Meter distance . */
+    svc_data[0] = tx_measure_power;
+    
     svc_data[1] = url_scheme;
     memcpy(svc_data + 2, url_body, url_body_len);
     if (url_suffix != BLE_EDDYSTONE_URL_SUFFIX_NONE) {

--- a/nimble/host/src/ble_ibeacon.c
+++ b/nimble/host/src/ble_ibeacon.c
@@ -35,16 +35,17 @@
  *                                  iBeacons.
  * @param minor                 The minor version number to include in
  *                                  iBeacons.
+ * @param tx_measure_power      The Measure Power value which is measured as RSSI
+ *                                  value at 1 Meter distance.
  *
  * @return                      0 on success;
  *                              BLE_HS_EBUSY if advertising is in progress;
  *                              Other nonzero on failure.
  */
 int
-ble_ibeacon_set_adv_data(struct ble_hs_adv_fields *adv_fields, void *uuid128, uint16_t major, uint16_t minor)
+ble_ibeacon_set_adv_data(struct ble_hs_adv_fields *adv_fields, void *uuid128, uint16_t major, uint16_t minor, int8_t tx_measure_power)
 {
     uint8_t buf[BLE_IBEACON_MFG_DATA_SIZE];
-    int8_t tx_pwr;
     int rc;
 
     /** Company identifier (Apple). */
@@ -62,13 +63,8 @@ ble_ibeacon_set_adv_data(struct ble_hs_adv_fields *adv_fields, void *uuid128, ui
     put_be16(buf + 20, major);
     put_be16(buf + 22, minor);
 
-    /** Last byte (tx power level) filled in after HCI exchange. */
-
-    rc = ble_hs_hci_util_read_adv_tx_pwr(&tx_pwr);
-    if (rc != 0) {
-        return rc;
-    }
-    buf[24] = tx_pwr;
+    /** Last byte (Measured Power) filled in as RSSI  measurement at 1Meter distance . */
+    buf[24] = tx_measure_power;
 
     adv_fields->mfg_data = buf;
     adv_fields->mfg_data_len = sizeof buf;

--- a/nimble/host/src/ble_ibeacon.c
+++ b/nimble/host/src/ble_ibeacon.c
@@ -26,6 +26,10 @@
 /**
  * Configures the device to advertise iBeacons.
  *
+ * @param adv_fields            The base advertisement fields to transform into
+ *                                  an eddystone beacon.  All configured fields
+ *                                  are preserved; you probably want to clear
+ *                                  this struct before calling this function.
  * @param uuid                  The 128-bit UUID to advertise.
  * @param major                 The major version number to include in
  *                                  iBeacons.
@@ -37,9 +41,8 @@
  *                              Other nonzero on failure.
  */
 int
-ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor)
+ble_ibeacon_set_adv_data(struct ble_hs_adv_fields *adv_fields, void *uuid128, uint16_t major, uint16_t minor)
 {
-    struct ble_hs_adv_fields fields;
     uint8_t buf[BLE_IBEACON_MFG_DATA_SIZE];
     int8_t tx_pwr;
     int rc;
@@ -67,17 +70,16 @@ ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor)
     }
     buf[24] = tx_pwr;
 
-    memset(&fields, 0, sizeof fields);
-    fields.mfg_data = buf;
-    fields.mfg_data_len = sizeof buf;
+    adv_fields->mfg_data = buf;
+    adv_fields->mfg_data_len = sizeof buf;
 
     /* Advertise two flags:
      *     o Discoverability in forthcoming advertisement (general)
      *     o BLE-only (BR/EDR unsupported).
      */
-    fields.flags = BLE_HS_ADV_F_DISC_GEN |
+    adv_fields->flags = BLE_HS_ADV_F_DISC_GEN |
                    BLE_HS_ADV_F_BREDR_UNSUP;
 
-    rc = ble_gap_adv_set_fields(&fields);
+    rc = ble_gap_adv_set_fields(&adv_fields);
     return rc;
 }

--- a/nimble/host/src/ble_ibeacon.c
+++ b/nimble/host/src/ble_ibeacon.c
@@ -76,6 +76,6 @@ ble_ibeacon_set_adv_data(struct ble_hs_adv_fields *adv_fields, void *uuid128, ui
     adv_fields->flags = BLE_HS_ADV_F_DISC_GEN |
                    BLE_HS_ADV_F_BREDR_UNSUP;
 
-    rc = ble_gap_adv_set_fields(&adv_fields);
+    rc = ble_gap_adv_set_fields(adv_fields);
     return rc;
 }


### PR DESCRIPTION
Modified ble_ibeacon_set_adv_data function to take in struct ble_hs_adv_fields as an argument, similar to ble_eddystone_set_adv_data_url function for Eddystone. This would enable users to set ble_hs_adv_fields with any additional parameters like name etc.