### PR TITLE
Implemented Measured Power as an Argument

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1752,6 +1752,15 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         return rc;
     }
 
+    int8_t measured_power;
+    uint8_t measured_power_uint = parse_arg_uint8_dflt("measured_power", 0, rc);
+    if(rc == 0){
+        measured_power = -1 * measured_power_uint;
+    }else if(rc != ENOENT){
+        console_printf("invalid 'measured_power' parameter\n");
+        return rc;
+    }
+
     eddystone_url_full = parse_arg_extract("eddystone_url");
     if (eddystone_url_full != NULL) {
         rc = parse_eddystone_url(eddystone_url_full, &eddystone_url_scheme,
@@ -1765,7 +1774,8 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         rc = ble_eddystone_set_adv_data_url(&adv_fields, eddystone_url_scheme,
                                             eddystone_url_body,
                                             eddystone_url_body_len,
-                                            eddystone_url_suffix);
+                                            eddystone_url_suffix,
+                                            measured_power);
     } else {
 #if MYNEWT_VAL(BLE_EXT_ADV)
         /* Default to legacy PDUs size, mbuf chain will be increased if needed
@@ -1851,6 +1861,7 @@ static const struct shell_param set_adv_data_params[] = {
     {"service_data_uuid128", "usage: =[XX:XX...]"},
     {"uri", "usage: =[XX:XX...]"},
     {"mfg_data", "usage: =[XX:XX...]"},
+    {"measured_power", "usage: = [-100 to 0]"},
     {"eddystone_url", "usage: =[string]"},
 #if MYNEWT_VAL(BLE_EXT_ADV)
     {"extra_data_len", "usage: =[UINT16]"},

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1752,11 +1752,8 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         return rc;
     }
 
-    int8_t measured_power;
-    uint8_t measured_power_uint = parse_arg_uint8_dflt("measured_power", 0, rc);
-    if(rc == 0){
-        measured_power = -1 * measured_power_uint;
-    }else if(rc != ENOENT){
+    int8_t measured_power = (int8_t) parse_arg_long_bounds_dflt("measured_power", -100, 0, 0, rc)
+    if(rc != 0 && rc != ENOENT){
         console_printf("invalid 'measured_power' parameter\n");
         return rc;
     }

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1511,6 +1511,7 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
     uint8_t eddystone_url_body_len;
     uint8_t eddystone_url_suffix;
     uint8_t eddystone_url_scheme;
+    int8_t measured_power;
     char eddystone_url_body[BLE_EDDYSTONE_URL_MAX_LEN];
     char *eddystone_url_full;
     int svc_data_uuid16_len;
@@ -1752,8 +1753,10 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         return rc;
     }
 
-    int8_t measured_power = (int8_t) parse_arg_long_bounds_dflt("measured_power", -100, 0, 0, &rc);
-    if(rc != 0 && rc != ENOENT){
+    tmp = parse_arg_long_bounds("measured_power", -100, 0, &rc);
+    if (rc == 0) {
+        measured_power = tmp;
+    } else if (rc != ENOENT) {
         console_printf("invalid 'measured_power' parameter\n");
         return rc;
     }

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1752,7 +1752,7 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         return rc;
     }
 
-    int8_t measured_power = (int8_t) parse_arg_long_bounds_dflt("measured_power", -100, 0, 0, rc)
+    int8_t measured_power = (int8_t) parse_arg_long_bounds_dflt("measured_power", -100, 0, 0, &rc);
     if(rc != 0 && rc != ENOENT){
         console_printf("invalid 'measured_power' parameter\n");
         return rc;

--- a/nimble/host/include/host/ble_eddystone.h
+++ b/nimble/host/include/host/ble_eddystone.h
@@ -92,6 +92,7 @@ int ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
  *                                  BLE_EDDYSTONE_URL_SUFFIX values; use
  *                                  BLE_EDDYSTONE_URL_SUFFIX_NONE if the suffix
  *                                  is embedded in the body argument.
+ * @param measured_power        The Measured Power (RSSI value at 1 Meter).
  *
  * @return                      0 on success;
  *                              BLE_HS_EBUSY if advertising is in progress;
@@ -101,7 +102,8 @@ int ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
  */
 int ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
                                    uint8_t url_scheme, char *url_body,
-                                   uint8_t url_body_len, uint8_t suffix);
+                                   uint8_t url_body_len, uint8_t suffix,
+                                   int8_t measured_power);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/include/host/ble_ibeacon.h
+++ b/nimble/host/include/host/ble_ibeacon.h
@@ -24,7 +24,7 @@
 extern "C" {
 #endif
 
-int ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor);
+int ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor, int8_t measured_power);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/src/ble_eddystone.c
+++ b/nimble/host/src/ble_eddystone.c
@@ -140,10 +140,10 @@ ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields, void *uid)
 int
 ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
                                uint8_t url_scheme, char *url_body,
-                               uint8_t url_body_len, uint8_t url_suffix)
+                               uint8_t url_body_len, uint8_t url_suffix,
+                                int8_t measured_power)
 {
     uint8_t *svc_data;
-    int8_t tx_pwr;
     int url_len;
     int rc;
 
@@ -157,11 +157,7 @@ ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
 
     svc_data = ble_eddystone_set_svc_data_base(BLE_EDDYSTONE_FRAME_TYPE_URL);
 
-    rc = ble_hs_hci_util_read_adv_tx_pwr(&tx_pwr);
-    if (rc != 0) {
-        return rc;
-    }
-    svc_data[0] = tx_pwr;
+    svc_data[0] = measured_power;
     svc_data[1] = url_scheme;
     memcpy(svc_data + 2, url_body, url_body_len);
     if (url_suffix != BLE_EDDYSTONE_URL_SUFFIX_NONE) {

--- a/nimble/host/src/ble_eddystone.c
+++ b/nimble/host/src/ble_eddystone.c
@@ -141,7 +141,7 @@ int
 ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
                                uint8_t url_scheme, char *url_body,
                                uint8_t url_body_len, uint8_t url_suffix,
-                                int8_t measured_power)
+                               int8_t measured_power)
 {
     uint8_t *svc_data;
     int url_len;

--- a/nimble/host/src/ble_ibeacon.c
+++ b/nimble/host/src/ble_ibeacon.c
@@ -31,17 +31,17 @@
  *                                  iBeacons.
  * @param minor                 The minor version number to include in
  *                                  iBeacons.
+ * @param measured_power        The Measured Power (RSSI value at 1 Meter).
  *
  * @return                      0 on success;
  *                              BLE_HS_EBUSY if advertising is in progress;
  *                              Other nonzero on failure.
  */
 int
-ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor)
+ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor, int8_t measured_power)
 {
     struct ble_hs_adv_fields fields;
     uint8_t buf[BLE_IBEACON_MFG_DATA_SIZE];
-    int8_t tx_pwr;
     int rc;
 
     /** Company identifier (Apple). */
@@ -59,13 +59,8 @@ ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor)
     put_be16(buf + 20, major);
     put_be16(buf + 22, minor);
 
-    /** Last byte (tx power level) filled in after HCI exchange. */
-
-    rc = ble_hs_hci_util_read_adv_tx_pwr(&tx_pwr);
-    if (rc != 0) {
-        return rc;
-    }
-    buf[24] = tx_pwr;
+    /** Last byte (Measured Power level). */
+    buf[24] = measured_power;
 
     memset(&fields, 0, sizeof fields);
     fields.mfg_data = buf;


### PR DESCRIPTION
Measured Power was being generated automatically and appended into the advertising buffer in both Eddystone and iBeacon.
Changed it to take it as an argument from the User, as it depends on Antenna Hardware, Case design etc.

Modified btshell application to utilize the same.