### PR TITLE
Beacon's Measured Power as an argument

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1511,6 +1511,7 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
     uint8_t eddystone_url_body_len;
     uint8_t eddystone_url_suffix;
     uint8_t eddystone_url_scheme;
+    int8_t measured_power;
     char eddystone_url_body[BLE_EDDYSTONE_URL_MAX_LEN];
     char *eddystone_url_full;
     int svc_data_uuid16_len;
@@ -1752,6 +1753,14 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         return rc;
     }
 
+    tmp = parse_arg_long_bounds("measured_power", -100, 20, &rc);
+    if (rc == 0) {
+        measured_power = tmp;
+    } else if (rc != ENOENT) {
+        console_printf("invalid 'measured_power' parameter\n");
+        return rc;
+    }
+
     eddystone_url_full = parse_arg_extract("eddystone_url");
     if (eddystone_url_full != NULL) {
         rc = parse_eddystone_url(eddystone_url_full, &eddystone_url_scheme,
@@ -1765,7 +1774,8 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         rc = ble_eddystone_set_adv_data_url(&adv_fields, eddystone_url_scheme,
                                             eddystone_url_body,
                                             eddystone_url_body_len,
-                                            eddystone_url_suffix);
+                                            eddystone_url_suffix,
+                                            measured_power);
     } else {
 #if MYNEWT_VAL(BLE_EXT_ADV)
         /* Default to legacy PDUs size, mbuf chain will be increased if needed
@@ -1851,6 +1861,7 @@ static const struct shell_param set_adv_data_params[] = {
     {"service_data_uuid128", "usage: =[XX:XX...]"},
     {"uri", "usage: =[XX:XX...]"},
     {"mfg_data", "usage: =[XX:XX...]"},
+    {"measured_power", "usage: =[-100-20]"},
     {"eddystone_url", "usage: =[string]"},
 #if MYNEWT_VAL(BLE_EXT_ADV)
     {"extra_data_len", "usage: =[UINT16]"},

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1511,7 +1511,7 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
     uint8_t eddystone_url_body_len;
     uint8_t eddystone_url_suffix;
     uint8_t eddystone_url_scheme;
-    int8_t measured_power;
+    int8_t measured_power = 0;
     char eddystone_url_body[BLE_EDDYSTONE_URL_MAX_LEN];
     char *eddystone_url_full;
     int svc_data_uuid16_len;

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1511,7 +1511,7 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
     uint8_t eddystone_url_body_len;
     uint8_t eddystone_url_suffix;
     uint8_t eddystone_url_scheme;
-    int8_t measured_power = 0;
+    int8_t eddystone_measured_power = 0;
     char eddystone_url_body[BLE_EDDYSTONE_URL_MAX_LEN];
     char *eddystone_url_full;
     int svc_data_uuid16_len;
@@ -1753,11 +1753,11 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
         return rc;
     }
 
-    tmp = parse_arg_long_bounds("measured_power", -100, 20, &rc);
+    tmp = parse_arg_long_bounds("eddystone_measured_power", -100, 20, &rc);
     if (rc == 0) {
-        measured_power = tmp;
+        eddystone_measured_power = tmp;
     } else if (rc != ENOENT) {
-        console_printf("invalid 'measured_power' parameter\n");
+        console_printf("invalid 'eddystone_measured_power' parameter\n");
         return rc;
     }
 
@@ -1775,7 +1775,7 @@ cmd_set_adv_data_or_scan_rsp(int argc, char **argv, bool scan_rsp)
                                             eddystone_url_body,
                                             eddystone_url_body_len,
                                             eddystone_url_suffix,
-                                            measured_power);
+                                            eddystone_measured_power);
     } else {
 #if MYNEWT_VAL(BLE_EXT_ADV)
         /* Default to legacy PDUs size, mbuf chain will be increased if needed

--- a/nimble/host/include/host/ble_eddystone.h
+++ b/nimble/host/include/host/ble_eddystone.h
@@ -66,6 +66,7 @@ struct ble_hs_adv_fields;
  *                                  are preserved; you probably want to clear
  *                                  this struct before calling this function.
  * @param uid                   The 16-byte UID to advertise.
+ * @param measured_power        The Measured Power (RSSI value at 1 Meter).
  *
  * @return                      0 on success;
  *                              BLE_HS_EBUSY if advertising is in progress;
@@ -74,7 +75,7 @@ struct ble_hs_adv_fields;
  *                              Other nonzero on failure.
  */
 int ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
-                                   void *uid);
+                                   void *uid, int8_t measured_power);
 
 /**
  * Configures the device to advertise Eddystone URL beacons.
@@ -92,6 +93,7 @@ int ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
  *                                  BLE_EDDYSTONE_URL_SUFFIX values; use
  *                                  BLE_EDDYSTONE_URL_SUFFIX_NONE if the suffix
  *                                  is embedded in the body argument.
+ * @param measured_power        The Measured Power (RSSI value at 1 Meter).
  *
  * @return                      0 on success;
  *                              BLE_HS_EBUSY if advertising is in progress;
@@ -101,7 +103,8 @@ int ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
  */
 int ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
                                    uint8_t url_scheme, char *url_body,
-                                   uint8_t url_body_len, uint8_t suffix);
+                                   uint8_t url_body_len, uint8_t suffix,
+                                   int8_t measured_power);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/include/host/ble_eddystone.h
+++ b/nimble/host/include/host/ble_eddystone.h
@@ -66,7 +66,7 @@ struct ble_hs_adv_fields;
  *                                  are preserved; you probably want to clear
  *                                  this struct before calling this function.
  * @param uid                   The 16-byte UID to advertise.
- * @param measured_power        The Measured Power (RSSI value at 1 Meter).
+ * @param measured_power        The Measured Power (RSSI value at 0 Meter).
  *
  * @return                      0 on success;
  *                              BLE_HS_EBUSY if advertising is in progress;
@@ -93,7 +93,7 @@ int ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
  *                                  BLE_EDDYSTONE_URL_SUFFIX values; use
  *                                  BLE_EDDYSTONE_URL_SUFFIX_NONE if the suffix
  *                                  is embedded in the body argument.
- * @param measured_power        The Measured Power (RSSI value at 1 Meter).
+ * @param measured_power        The Measured Power (RSSI value at 0 Meter).
  *
  * @return                      0 on success;
  *                              BLE_HS_EBUSY if advertising is in progress;

--- a/nimble/host/include/host/ble_ibeacon.h
+++ b/nimble/host/include/host/ble_ibeacon.h
@@ -24,7 +24,8 @@
 extern "C" {
 #endif
 
-int ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor);
+int ble_ibeacon_set_adv_data(void *uuid128, uint16_t major,
+                             uint16_t minor, int8_t measured_power);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/src/ble_eddystone.c
+++ b/nimble/host/src/ble_eddystone.c
@@ -106,21 +106,20 @@ ble_eddystone_set_adv_data_gen(struct ble_hs_adv_fields *adv_fields,
 }
 
 int
-ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields, void *uid)
+ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
+                               void *uid, int8_t measured_power)
 {
     uint8_t *svc_data;
-    int8_t tx_pwr;
     int rc;
 
     /* Eddystone UUID and frame type (0). */
     svc_data = ble_eddystone_set_svc_data_base(BLE_EDDYSTONE_FRAME_TYPE_UID);
 
-    /* Ranging data (Calibrated tx power at 0 meters). */
-    rc = ble_hs_hci_util_read_adv_tx_pwr(&tx_pwr);
-    if (rc != 0) {
-        return rc;
+    /* Measured Power ranging data (Calibrated tx power at 1 meters). */
+    if (measured_power < -100 || measured_power > 20) {
+        return BLE_HS_EINVAL;
     }
-    svc_data[0] = tx_pwr;
+    svc_data[0] = measured_power;
 
     /* UID. */
     memcpy(svc_data + 1, uid, 16);
@@ -140,10 +139,10 @@ ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields, void *uid)
 int
 ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
                                uint8_t url_scheme, char *url_body,
-                               uint8_t url_body_len, uint8_t url_suffix)
+                               uint8_t url_body_len, uint8_t url_suffix,
+                               int8_t measured_power)
 {
     uint8_t *svc_data;
-    int8_t tx_pwr;
     int url_len;
     int rc;
 
@@ -157,11 +156,12 @@ ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
 
     svc_data = ble_eddystone_set_svc_data_base(BLE_EDDYSTONE_FRAME_TYPE_URL);
 
-    rc = ble_hs_hci_util_read_adv_tx_pwr(&tx_pwr);
-    if (rc != 0) {
-        return rc;
+    /* Measured Power ranging data (Calibrated tx power at 1 meters). */
+    if (measured_power < -100 || measured_power > 20) {
+        return BLE_HS_EINVAL;
     }
-    svc_data[0] = tx_pwr;
+    svc_data[0] = measured_power;
+
     svc_data[1] = url_scheme;
     memcpy(svc_data + 2, url_body, url_body_len);
     if (url_suffix != BLE_EDDYSTONE_URL_SUFFIX_NONE) {

--- a/nimble/host/src/ble_eddystone.c
+++ b/nimble/host/src/ble_eddystone.c
@@ -115,7 +115,7 @@ ble_eddystone_set_adv_data_uid(struct ble_hs_adv_fields *adv_fields,
     /* Eddystone UUID and frame type (0). */
     svc_data = ble_eddystone_set_svc_data_base(BLE_EDDYSTONE_FRAME_TYPE_UID);
 
-    /* Measured Power ranging data (Calibrated tx power at 1 meters). */
+    /* Measured Power ranging data (Calibrated tx power at 0 meters). */
     if (measured_power < -100 || measured_power > 20) {
         return BLE_HS_EINVAL;
     }
@@ -156,7 +156,7 @@ ble_eddystone_set_adv_data_url(struct ble_hs_adv_fields *adv_fields,
 
     svc_data = ble_eddystone_set_svc_data_base(BLE_EDDYSTONE_FRAME_TYPE_URL);
 
-    /* Measured Power ranging data (Calibrated tx power at 1 meters). */
+    /* Measured Power ranging data (Calibrated tx power at 0 meters). */
     if (measured_power < -100 || measured_power > 20) {
         return BLE_HS_EINVAL;
     }

--- a/nimble/host/src/ble_ibeacon.c
+++ b/nimble/host/src/ble_ibeacon.c
@@ -31,17 +31,18 @@
  *                                  iBeacons.
  * @param minor                 The minor version number to include in
  *                                  iBeacons.
+ * @param measured_power        The Measured Power (RSSI value at 1 Meter).
  *
  * @return                      0 on success;
  *                              BLE_HS_EBUSY if advertising is in progress;
  *                              Other nonzero on failure.
  */
 int
-ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor)
+ble_ibeacon_set_adv_data(void *uuid128, uint16_t major,
+                         uint16_t minor, int8_t measured_power)
 {
     struct ble_hs_adv_fields fields;
     uint8_t buf[BLE_IBEACON_MFG_DATA_SIZE];
-    int8_t tx_pwr;
     int rc;
 
     /** Company identifier (Apple). */
@@ -59,13 +60,11 @@ ble_ibeacon_set_adv_data(void *uuid128, uint16_t major, uint16_t minor)
     put_be16(buf + 20, major);
     put_be16(buf + 22, minor);
 
-    /** Last byte (tx power level) filled in after HCI exchange. */
-
-    rc = ble_hs_hci_util_read_adv_tx_pwr(&tx_pwr);
-    if (rc != 0) {
-        return rc;
+    /* Measured Power ranging data (Calibrated tx power at 1 meters). */
+    if (measured_power < -100 || measured_power > 20) {
+        return BLE_HS_EINVAL;
     }
-    buf[24] = tx_pwr;
+    buf[24] = measured_power;
 
     memset(&fields, 0, sizeof fields);
     fields.mfg_data = buf;

--- a/nimble/host/src/ble_ibeacon.c
+++ b/nimble/host/src/ble_ibeacon.c
@@ -61,7 +61,7 @@ ble_ibeacon_set_adv_data(void *uuid128, uint16_t major,
     put_be16(buf + 22, minor);
 
     /* Measured Power ranging data (Calibrated tx power at 1 meters). */
-    if (measured_power < -100 || measured_power > 20) {
+    if (measured_power < -126 || measured_power > 20) {
         return BLE_HS_EINVAL;
     }
     buf[24] = measured_power;


### PR DESCRIPTION
Took Measured Power as an argument from the user instead of generating automatically. Also checked whether the value is as per BLE specifications.

Modified btshell app to use the new argument while setting eddystone beacon.