### PR TITLE
host: Clear addresses on reset

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -376,6 +376,9 @@ ble_hs_reset(void)
         ble_gap_conn_broken(conn_handle, ble_hs_reset_reason);
     }
 
+    /* Clear configured addresses. */
+    ble_hs_id_reset();
+
     if (ble_hs_cfg.reset_cb != NULL && ble_hs_reset_reason != 0) {
         ble_hs_cfg.reset_cb(ble_hs_reset_reason);
     }

--- a/nimble/host/src/ble_hs_id.c
+++ b/nimble/host/src/ble_hs_id.c
@@ -272,3 +272,14 @@ done:
     ble_hs_unlock();
     return rc;
 }
+
+/**
+ * Clears both the public and random addresses.  This function is necessary
+ * when the controller loses its random address (e.g., on a stack reset).
+ */
+void
+ble_hs_id_reset(void)
+{
+    memset(ble_hs_id_pub, 0, sizeof ble_hs_id_pub);
+    memset(ble_hs_id_rnd, 0, sizeof ble_hs_id_pub);
+}

--- a/nimble/host/src/ble_hs_id_priv.h
+++ b/nimble/host/src/ble_hs_id_priv.h
@@ -30,6 +30,7 @@ void ble_hs_id_set_pub(const uint8_t *pub_addr);
 int ble_hs_id_addr(uint8_t id_addr_type, const uint8_t **out_id_addr,
                    int *out_is_nrpa);
 int ble_hs_id_use_addr(uint8_t addr_type);
+void ble_hs_id_reset(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
A stack reset causes the controller to forget its random address.  Therefore, the host must reconfigure the controller with a random address.

Prior to this commit, the host did not clear its addresses on stack reset.  As a consequence, attempting to use a random address with `ble_hs_util_ensure_addr()` function following a reset would not work.  The host would think that it had already configured the controller with a random address, so this function would be a no-op.