### PR TITLE
Cache homebrew packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
 
 - newt version
 - gcc --version
-- arm-none-eabi-gcc --version
+- if [ "${TEST}" != "TEST_ALL" ]; then arm-none-eabi-gcc --version; fi
 
 script:
 - cp -R $HOME/ci/mynewt-nimble-project.yml project.yml
@@ -80,3 +80,4 @@ script:
 cache:
   directories:
   - $HOME/TOOLCHAIN
+  - $HOME/Library/Caches/Homebrew


### PR DESCRIPTION
This applied two changes already merged on mynewt-core:

* Enable caching of homebrew packages
* Only print arm-none-eabi-gcc version on targets that install it