### PR TITLE
host: Unconditionally disable adv on controller

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -790,6 +790,18 @@ int ble_gap_adv_start(uint8_t own_addr_type, const ble_addr_t *direct_addr,
  * code indicates that advertising has been fully aborted and a new advertising
  * procedure can be initiated immediately.
  *
+ * NOTE: If the caller is running in the same task as the NimBLE host, or if it
+ * is running in a higher priority task than that of the host, care must be
+ * taken when restarting advertising.  Under these conditions, the following is
+ * *not* a reliable method to restart advertising:
+ *     ble_gap_adv_stop()
+ *     ble_gap_adv_start()
+ *
+ * Instead, the call to `ble_gap_adv_start()` must be made in a separate event
+ * context.  That is, `ble_gap_adv_start()` must be called asynchronously by
+ * enqueueing an event on the current task's event queue.  See
+ * https://github.com/apache/mynewt-nimble/pull/211 for more information.
+ *
  * @return  0 on success, BLE_HS_EALREADY if there is no active advertising
  *          procedure, other error code on failure.
  */

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -1817,12 +1817,6 @@ ble_gap_adv_stop_no_lock(void)
 
     STATS_INC(ble_gap_stats, adv_stop);
 
-    /* Do nothing if advertising is already disabled. */
-    if (!ble_gap_adv_active()) {
-        rc = BLE_HS_EALREADY;
-        goto done;
-    }
-
     BLE_HS_LOG(INFO, "GAP procedure initiated: stop advertising.\n");
 
     rc = ble_gap_adv_enable_tx(0);


### PR DESCRIPTION
This PR addresses a bug that has been observed occasionally.  The bug is: sometimes the controller thinks advertising is active while the host thinks it is not.  This bug causes all subsequent advertise attempts to fail.

The root cause of this bug is: the host does not process all HCI events in the order they are received.  Specifically, "ack" events (Command Status and Command Complete) are processed right when the controller sends them, whereas other events get put on a queue and processed when the host parent task runs through its event queue.

The reason for this discrepancy is that it allows the host to present a blocking HCI interface, even when the host and application run in the same task.  When the host sends an HCI command, it immediately pends on a semaphore.  When the controller acknowledges the command, it releases the semaphore, unlocking the host task.  If the controller sent other events to the host while it was blocked, they get processed *after* the ack, resulting in out of order event processing.

The specific sequence which triggers the bug:

1. Host advertises in connectable mode.
2. Peer connects to the local device.  Controller enqueues the Connection Complete event on the host's HCI queue.  As a consequence of the new connection, the controller is no longer advertising.
3. Before the host processes the event from step 2, it stops and starts advertising again (e.g., because it wants to advertise with different parameters).  The command to stop advertising has no effect on the controller since it is not advertising anyway.  The "start advertising" command does have an effect; the controller is now advertising.
4. The host finally processes the Connection Complete event from step 2; it is now under the impression that controller is no longer advertising.

After the above sequence, there is a mismatch among the host and controller state.  The host thinks advertising is not active, but the controller really is advertising.

This PR implements a workaround for this situation.  Prior to this PR, the host would only honor a request to stop advertising if its state indicated that advertising is active.  If advertising were not active, `ble_gap_adv_stop()` would abort early with the `BLE_HS_EALREADY` error code.

Now, the host always attempts to disable advertising when requested.  It does not inspect its own state at all.