### PR TITLE
Fix unit tests involving `ble_gap_preempt()`

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -555,6 +555,11 @@ ble_hs_start(void)
 
     ble_hs_parent_task = ble_npl_get_current_task_id();
 
+    /* Stop the timer just in case the host was already running (e.g., unit
+     * tests).
+     */
+    ble_npl_callout_stop(&ble_hs_timer_timer);
+
     ble_npl_callout_init(&ble_hs_timer_timer, ble_hs_evq,
                     ble_hs_timer_exp, NULL);
 

--- a/nimble/host/test/src/ble_hs_test_util.c
+++ b/nimble/host/test/src/ble_hs_test_util.c
@@ -619,16 +619,20 @@ ble_hs_test_util_set_our_irk(const uint8_t *irk, int fail_idx,
             ble_hs_test_util_hci_misc_exp_status(2, fail_idx, hci_status),
         },
         {
-            BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
+            BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_ADV_ENABLE),
             ble_hs_test_util_hci_misc_exp_status(3, fail_idx, hci_status),
         },
         {
-            BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_PRIVACY_MODE),
+            BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
             ble_hs_test_util_hci_misc_exp_status(4, fail_idx, hci_status),
         },
         {
             BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_PRIVACY_MODE),
-            ble_hs_test_util_hci_misc_exp_status(4, fail_idx, hci_status),
+            ble_hs_test_util_hci_misc_exp_status(5, fail_idx, hci_status),
+        },
+        {
+            BLE_HS_TEST_UTIL_LE_OPCODE(BLE_HCI_OCF_LE_SET_PRIVACY_MODE),
+            ble_hs_test_util_hci_misc_exp_status(6, fail_idx, hci_status),
         },
         {
             0
@@ -1984,6 +1988,7 @@ ble_hs_test_util_reg_svcs(const struct ble_gatt_svc_def *svcs,
     rc = ble_gatts_start();
     TEST_ASSERT_FATAL(rc == 0);
 }
+
 
 void
 ble_hs_test_util_init_no_start(void)

--- a/nimble/host/test/src/ble_hs_test_util_hci.c
+++ b/nimble/host/test/src/ble_hs_test_util_hci.c
@@ -290,6 +290,10 @@ static const struct ble_hs_test_util_hci_ack hci_startup_seq[] = {
     },
     {
         .opcode = ble_hs_hci_util_opcode_join(
+            BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADV_ENABLE),
+    },
+    {
+        .opcode = ble_hs_hci_util_opcode_join(
             BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
     },
     {
@@ -398,6 +402,7 @@ ble_hs_test_util_hci_verify_tx_add_irk(uint8_t addr_type,
 {
     uint8_t param_len;
     uint8_t *param;
+
 
     param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_ADD_RESOLV_LIST,

--- a/nimble/host/test/src/ble_sm_test_util.c
+++ b/nimble/host/test/src/ble_sm_test_util.c
@@ -1344,6 +1344,10 @@ ble_sm_test_util_verify_tx_add_resolve_list(uint8_t peer_id_addr_type,
     uint8_t param_len;
     uint8_t *param;
 
+    ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
+                                   BLE_HCI_OCF_LE_SET_ADV_ENABLE,
+                                   NULL);
+
     param = ble_hs_test_util_hci_verify_tx(BLE_HCI_OGF_LE,
                                            BLE_HCI_OCF_LE_ADD_RESOLV_LIST,
                                            &param_len);
@@ -2038,8 +2042,12 @@ ble_sm_test_util_rx_keys(struct ble_sm_test_params *params,
         ble_hs_test_util_hci_ack_set_seq(((struct ble_hs_test_util_hci_ack[]) {
             {
                 .opcode = ble_hs_hci_util_opcode_join(
+                                BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_ADV_ENABLE),
+            },
+            {
+                .opcode = ble_hs_hci_util_opcode_join(
                                 BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_ADD_RESOLV_LIST),
-            } ,
+            },
             {
                 .opcode = ble_hs_hci_util_opcode_join(
                                 BLE_HCI_OGF_LE, BLE_HCI_OCF_LE_SET_PRIVACY_MODE),


### PR DESCRIPTION
Now that `ble_gap_adv_stop()` always sends a `BLE_HCI_OCF_LE_SET_ADV_ENABLE` command (even if the host doesn't think it is currently advertising), unit tests need to simulate additional
Command Complete events.  In particular, tests which call `ble_gap_preempt()` now need this additional ack.