### PR TITLE
mesh: Fix memory leaks

### DIFF
--- a/nimble/host/mesh/src/cfg_srv.c
+++ b/nimble/host/mesh/src/cfg_srv.c
@@ -725,7 +725,7 @@ static void beacon_set(struct bt_mesh_model *model,
 		}
 	} else {
 		BT_WARN("Invalid Config Beacon value 0x%02x", buf->om_data[0]);
-		return;
+		goto done;
 	}
 
 	bt_mesh_model_msg_init(msg, OP_BEACON_STATUS);
@@ -735,6 +735,7 @@ static void beacon_set(struct bt_mesh_model *model,
 		BT_ERR("Unable to send Config Beacon Status response");
 	}
 
+done:
 	os_mbuf_free_chain(msg);
 
 }
@@ -1698,7 +1699,7 @@ static void mod_sub_get(struct bt_mesh_model *model,
 	addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		goto done;
 	}
 
 	id = net_buf_simple_pull_le16(buf);
@@ -1739,6 +1740,7 @@ send_list:
 		BT_ERR("Unable to send Model Subscription List");
 	}
 
+done:
 	os_mbuf_free_chain(msg);
 
 }
@@ -1758,7 +1760,7 @@ static void mod_sub_get_vnd(struct bt_mesh_model *model,
 	addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		goto done;
 	}
 
 	company = net_buf_simple_pull_le16(buf);
@@ -1803,6 +1805,7 @@ send_list:
 		BT_ERR("Unable to send Vendor Model Subscription List");
 	}
 
+done:
 	os_mbuf_free_chain(msg);
 
 }
@@ -2534,7 +2537,7 @@ static void mod_app_bind(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		goto done;
 	}
 
 	key_app_idx = net_buf_simple_pull_le16(buf);
@@ -2576,6 +2579,7 @@ send_status:
 		BT_ERR("Unable to send Model App Bind Status response");
 	}
 
+done:
     os_mbuf_free_chain(msg);
 
 }
@@ -2594,7 +2598,7 @@ static void mod_app_unbind(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		goto done;
 	}
 
 	key_app_idx = net_buf_simple_pull_le16(buf);
@@ -2629,6 +2633,7 @@ send_status:
 		BT_ERR("Unable to send Model App Unbind Status response");
 	}
 
+done:
     os_mbuf_free_chain(msg);
 }
 
@@ -2648,7 +2653,7 @@ static void mod_app_get(struct bt_mesh_model *model,
 	elem_addr = net_buf_simple_pull_le16(buf);
 	if (!BT_MESH_ADDR_IS_UNICAST(elem_addr)) {
 		BT_WARN("Prohibited element address");
-		return;
+		goto done;
 	}
 
 	mod_id = buf->om_data;
@@ -2701,6 +2706,7 @@ send_list:
 		BT_ERR("Unable to send Model Application List message");
 	}
 
+done:
 	os_mbuf_free_chain(msg);
 }
 

--- a/nimble/host/mesh/src/friend.c
+++ b/nimble/host/mesh/src/friend.c
@@ -443,7 +443,7 @@ static void enqueue_sub_cfm(struct bt_mesh_friend *frnd, u8_t xact)
 	buf = encode_friend_ctl(frnd, TRANS_CTL_OP_FRIEND_SUB_CFM, sdu);
 	if (!buf) {
 		BT_ERR("Unable to encode Subscription List Confirmation");
-		return;
+		goto done;
 	}
 
 	if (frnd->last) {
@@ -453,6 +453,8 @@ static void enqueue_sub_cfm(struct bt_mesh_friend *frnd, u8_t xact)
 
 	frnd->last = buf;
 	frnd->send_last = 1;
+
+done:
 	os_mbuf_free_chain(sdu);
 }
 
@@ -749,7 +751,7 @@ static void enqueue_offer(struct bt_mesh_friend *frnd, s8_t rssi)
 	buf = encode_friend_ctl(frnd, TRANS_CTL_OP_FRIEND_OFFER, sdu);
 	if (!buf) {
 		BT_ERR("Unable to encode Friend Offer");
-		return;
+		goto done;
 	}
 
 	frnd->counter++;
@@ -760,6 +762,8 @@ static void enqueue_offer(struct bt_mesh_friend *frnd, s8_t rssi)
 
 	frnd->last = buf;
 	frnd->send_last = 1;
+
+done:
 	os_mbuf_free_chain(sdu);
 }
 

--- a/nimble/host/mesh/src/prov.c
+++ b/nimble/host/mesh/src/prov.c
@@ -788,6 +788,8 @@ static void send_input_complete(void)
 
 	prov_buf_init(buf, PROV_INPUT_COMPLETE);
 	prov_send(buf);
+
+	os_mbuf_free_chain(buf);
 }
 
 int bt_mesh_input_number(u32_t num)

--- a/nimble/host/mesh/src/transport.c
+++ b/nimble/host/mesh/src/transport.c
@@ -591,7 +591,8 @@ static int sdu_recv(struct bt_mesh_net_rx *rx, u32_t seq, u8_t hdr,
 	if (IS_ENABLED(CONFIG_BT_MESH_FRIEND) && !rx->local_match) {
 		BT_DBG("Ignoring PDU for LPN 0x%04x of this Friend",
 		       rx->ctx.recv_dst);
-		return 0;
+		err = 0;
+		goto done;
 	}
 
 	if (BT_MESH_ADDR_IS_VIRTUAL(rx->ctx.recv_dst)) {


### PR DESCRIPTION
Function return without os_mbuf_free_chain(buf) after buf = NET_BUF_SIMPLE(n)
will cause memory leaks