### PR TITLE
Remove misleading comments from .yml files

### DIFF
--- a/apps/blecent/syscfg.yml
+++ b/apps/blecent/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/blecent
-
 syscfg.vals:
     # DEBUG logging is a bit noisy; use INFO.
     LOG_LEVEL: 1

--- a/apps/blehci/syscfg.yml
+++ b/apps/blehci/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/blehci
-
 syscfg.vals:
     # Default task settings
     OS_MAIN_STACK_SIZE: 64

--- a/apps/blemesh/syscfg.yml
+++ b/apps/blemesh/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/blemesh
-
 syscfg.vals:
     # Enable the shell task.
     SHELL_TASK: 1

--- a/apps/blemesh_light/syscfg.yml
+++ b/apps/blemesh_light/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/blemesh_light
-
 syscfg.defs:
     USE_NEOPIXEL:
         value: 0

--- a/apps/blemesh_models_example_1/syscfg.yml
+++ b/apps/blemesh_models_example_1/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/blemesh
-
 syscfg.vals:
     # Set log level to info (disable debug logging).
     LOG_LEVEL: 1

--- a/apps/blemesh_models_example_2/syscfg.yml
+++ b/apps/blemesh_models_example_2/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/blemesh
-
 syscfg.vals:
     # Set log level to info (disable debug logging).
     LOG_LEVEL: 1

--- a/apps/blemesh_shell/syscfg.yml
+++ b/apps/blemesh_shell/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/blemesh_shell
-
 syscfg.vals:
     # Enable the shell task.
     SHELL_TASK: 1

--- a/apps/bleprph/syscfg.yml
+++ b/apps/bleprph/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/bleprph
-
 syscfg.defs:
     BLEPRPH_LE_PHY_SUPPORT:
         description: >

--- a/apps/bletest/syscfg.yml
+++ b/apps/bletest/syscfg.yml
@@ -16,7 +16,6 @@
 # under the License.
 #
 
-# Package: apps/bletest
 syscfg.defs:
     BLETEST_ROLE:
         description: >

--- a/apps/btshell/syscfg.yml
+++ b/apps/btshell/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: apps/btshell
-
 syscfg.defs:
     BTSHELL_ANS:
         description: Include support for the alert notification service.

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/controller
-
 syscfg.defs:
     BLE_DEVICE:
         description: >

--- a/nimble/controller/test/syscfg.yml
+++ b/nimble/controller/test/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/controller/test
-
 syscfg.vals:
     BLE_LL_CFG_FEAT_LE_CSA2: 1
 

--- a/nimble/drivers/nrf52/syscfg.yml
+++ b/nimble/drivers/nrf52/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: hw/drivers/nimble/nrf52
-
 syscfg.defs:
     BLE_PHY_SYSVIEW:
         description: >

--- a/nimble/host/mesh/syscfg.yml
+++ b/nimble/host/mesh/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/host/mesh
-
 syscfg.defs:
     BLE_MESH_PROV:
         description: >

--- a/nimble/host/services/bleuart/syscfg.yml
+++ b/nimble/host/services/bleuart/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/host/services/bleuart
-
 syscfg.defs:
     BLEUART_MAX_INPUT:
         description: >

--- a/nimble/host/services/dis/syscfg.yml
+++ b/nimble/host/services/dis/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: nimble/host/services/dis
-
 syscfg.defs:
     BLE_SVC_DIS_DEFAULT_READ_PERM:
         description: >

--- a/nimble/host/services/gap/syscfg.yml
+++ b/nimble/host/services/gap/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/host/services/gap
-
 syscfg.defs:
     BLE_SVC_GAP_DEVICE_NAME:
         description: >

--- a/nimble/host/store/config/syscfg.yml
+++ b/nimble/host/store/config/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/host
-
 syscfg.defs:
     BLE_STORE_CONFIG_PERSIST:
         description: >

--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/host
-
 syscfg.defs:
     BLE_HOST:
         description: 'Indicates that a BLE host is present.'

--- a/nimble/host/test/syscfg.yml
+++ b/nimble/host/test/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/host/test
-
 syscfg.vals:
     BLE_HS_DEBUG: 1
     BLE_HS_PHONY_HCI_ACKS: 1

--- a/nimble/host/util/syscfg.yml
+++ b/nimble/host/util/syscfg.yml
@@ -16,6 +16,4 @@
 # under the License.
 #
 
-# Package: net/nimble/host/util
-
 syscfg.defs:

--- a/nimble/syscfg.yml
+++ b/nimble/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble
-
 syscfg.defs:
     # Supported GAP roles.  By default, all four roles are enabled.
     BLE_ROLE_CENTRAL:

--- a/nimble/transport/emspi/syscfg.yml
+++ b/nimble/transport/emspi/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/transport/ram
-
 syscfg.defs:
     BLE_HCI_EMSPI:
         description: 'Indicates that the emspi host HCI transport is present.'

--- a/nimble/transport/ram/syscfg.yml
+++ b/nimble/transport/ram/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/transport/ram
-
 syscfg.defs:
     BLE_HCI_EVT_HI_BUF_COUNT:
         description: 'Number of high-priority event buffers.'

--- a/nimble/transport/socket/syscfg.yml
+++ b/nimble/transport/socket/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/transport/uart
-
 syscfg.defs:
     BLE_HCI_EVT_BUF_SIZE:
         description: 'The size of the allocated event buffers'

--- a/nimble/transport/syscfg.yml
+++ b/nimble/transport/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/transport
-
 syscfg.defs:
     BLE_HCI_TRANSPORT_NIMBLE_BUILTIN:
         description: >

--- a/nimble/transport/uart/syscfg.yml
+++ b/nimble/transport/uart/syscfg.yml
@@ -16,8 +16,6 @@
 # under the License.
 #
 
-# Package: net/nimble/transport/uart
-
 syscfg.defs:
     BLE_HCI_EVT_BUF_SIZE:
         description: 'The size of the allocated event buffers'


### PR DESCRIPTION
These comments were added by some old version of newt and are never
updated after c&p so they are just misleading and unnecessary.