### PR TITLE
Connection request rx while already connected

### DIFF
--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -2674,11 +2674,6 @@ ble_ll_adv_rx_req(uint8_t pdu_type, struct os_mbuf *rxpdu)
     }
 #endif
 
-    /* See if the device is already connected */
-    if (ble_ll_adv_already_connected(peer, peer_addr_type)) {
-        return -1;
-    }
-
     /* Set device match bit if we are whitelisting */
     if (chk_wl && !ble_ll_whitelist_match(peer, peer_addr_type, resolved)) {
         return -1;
@@ -2723,6 +2718,11 @@ ble_ll_adv_rx_req(uint8_t pdu_type, struct os_mbuf *rxpdu)
             STATS_INC(ble_ll_stats, scan_rsp_txg);
         }
     } else if (pdu_type == BLE_ADV_PDU_TYPE_AUX_CONNECT_REQ) {
+        /* See if the device is already connected */
+        if (ble_ll_adv_already_connected(peer, peer_addr_type)) {
+            return -1;
+        }
+
         /*
          * Only accept connect requests from the desired address if we
          * are doing directed advertising

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -2572,6 +2572,34 @@ ble_ll_adv_clear_all(void)
 }
 #endif
 
+/**
+ * Says whether the specified address is already connected or not.
+ * @param   [in]    addr        The peer address.
+ * @param   [in]    addr_type   Public address (0) or random address (1).
+ * @return  Return 1 if already connected, 0 otherwise.
+ */
+static int
+ble_ll_adv_already_connected(const uint8_t* addr, uint8_t addr_type)
+{
+    struct ble_ll_conn_sm *connsm;
+
+    /* extracted from ble_ll_conn_slave_start function */
+    SLIST_FOREACH(connsm, &g_ble_ll_conn_active_list, act_sle) {
+        if (!memcmp(&connsm->peer_addr, addr, BLE_DEV_ADDR_LEN)) {
+            if (addr_type == BLE_ADDR_RANDOM) {
+                if (connsm->peer_addr_type & 1) {
+                    return 1;
+                }
+            } else {
+                if ((connsm->peer_addr_type & 1) == 0) {
+                    return 1;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
 
 /**
  * Called when the LL receives a scan request or connection request
@@ -2645,6 +2673,11 @@ ble_ll_adv_rx_req(uint8_t pdu_type, struct os_mbuf *rxpdu)
         }
     }
 #endif
+
+    /* See if the device is already connected */
+    if (ble_ll_adv_already_connected(peer, peer_addr_type)) {
+        return -1;
+    }
 
     /* Set device match bit if we are whitelisting */
     if (chk_wl && !ble_ll_whitelist_match(peer, peer_addr_type, resolved)) {


### PR DESCRIPTION
Hi,
In the situation I have to face, my slave allows several masters to create a connection with it.
The slave uses extended advertising and sends it continuously until a connection request is received.
A first connection is created and the slave transmits a new extended advertising. The master is reset (to simulate an issue) and restarts before the slave detects the disconnection. The master sends a new connection request as it receives the extended advertising and the slave stops the advertising state to enter the connection state. From the slave point of view, the connection already exists so the connection creation (done in the ble_ll_conn_slave_start function) fails but the advertising does not restart.
The update I propose is to ignore the connection request if the connection is already created before trying to create the connection. This way, the advertising state continues as if the frame was reject by the white list.
According to me, this update conforms with the Bluetooth Core Specification Version 5.0, Volume 6, Part B, Section 4.5, page 2637 "If an advertiser receives a connection request from an initiator it is already connected to, it shall ignore that request".
What do you think ?

Note : The code I insert in my "ble_ll_adv_already_connected" function is very similar from the one in the start of the "ble_ll_conn_slave_start" function, so it would perhaps be better to create this new function in the "ble_ll_conn.c" and to call it from the "ble_ll_conn_slave_start" and "ble_ll_adv_rx_req" functions.

Best regards,
Cedric