### PR TITLE
hal/timer: do not assing ISR prio building for RIOT

### DIFF
--- a/porting/nimble/src/hal_timer.c
+++ b/porting/nimble/src/hal_timer.c
@@ -499,7 +499,9 @@ hal_timer_init(int timer_num, void *cfg)
 
     /* Disable IRQ, set priority and set vector in table */
     NVIC_DisableIRQ(irq_num);
+#ifndef RIOT_VERSION
     NVIC_SetPriority(irq_num, (1 << __NVIC_PRIO_BITS) - 1);
+#endif
 #if MYNEWT
     NVIC_SetVector(irq_num, (uint32_t)irq_isr);
 #else


### PR DESCRIPTION
I was recently debugging an issue running NimBLE in `observer` mode on top of RIOT (using a `nrf52dk`): every time triggering `ble_gap_disc()`, the application would hard-fault.

It turned out, that this was caused to contradicting ISR priorities expected by RIOT and assigned by NimBLE (thanks to @andrzej-kaczmarek for pinpointing this). RIOT only uses a single, constant (`2`) interrupt priority for every ISR on Cortex-M platforms, but NimBLE is assigning the lowest possible priority to the `rtc` ISR. This leads to the `PendSV` ISR interrupting the rtc ISR, consequently leading to an invalid return value (`0xFFFFFFFD`) instead of (`0xFFFFFFF1`) read from the stack.

So as an (possible intermediate) fix, I propose not to touch interrupt priorities when building for RIOT.

Additional note: RIOT initializes the priority of every available vector to the mentioned constant value at boot time.