### PR TITLE
Use syscfg settings for sysinit stage numbers

### DIFF
--- a/nimble/controller/pkg.yml
+++ b/nimble/controller/pkg.yml
@@ -35,4 +35,4 @@ pkg.deps:
     - nimble
 
 pkg.init:
-    ble_ll_init: 250
+    ble_ll_init: 'MYNEWT_VAL(BLE_LL_SYSINIT_STAGE)'

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -298,6 +298,11 @@ syscfg.defs:
             line number where assertion occured.
         value: 0
 
+    BLE_LL_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the NimBLE controller.
+        value: 250
+
 syscfg.vals.BLE_LL_CFG_FEAT_LL_EXT_ADV:
     BLE_LL_CFG_FEAT_LE_CSA2: 1
     BLE_HW_WHITELIST_ENABLE: 0

--- a/nimble/host/mesh/pkg.yml
+++ b/nimble/host/mesh/pkg.yml
@@ -45,5 +45,5 @@ pkg.req_apis:
     - stats
 
 pkg.init:
-    bt_mesh_register_gatt: 500
-    ble_mesh_shell_init: 1000
+    bt_mesh_register_gatt: 'MYNEWT_VAL(BLE_MESH_SYSINIT_STAGE)'
+    ble_mesh_shell_init: 'MYNEWT_VAL(BLE_MESH_SYSINIT_STAGE_2)'

--- a/nimble/host/mesh/pkg.yml
+++ b/nimble/host/mesh/pkg.yml
@@ -46,4 +46,4 @@ pkg.req_apis:
 
 pkg.init:
     bt_mesh_register_gatt: 'MYNEWT_VAL(BLE_MESH_SYSINIT_STAGE)'
-    ble_mesh_shell_init: 'MYNEWT_VAL(BLE_MESH_SYSINIT_STAGE_2)'
+    ble_mesh_shell_init: 'MYNEWT_VAL(BLE_MESH_SYSINIT_STAGE_SHELL)'

--- a/nimble/host/mesh/syscfg.yml
+++ b/nimble/host/mesh/syscfg.yml
@@ -514,6 +514,16 @@ syscfg.defs:
             This value defines BLE Mesh device/node name.
         value: '"nimble-mesh-node"'
 
+    BLE_MESH_SYSINIT_STAGE:
+        description: >
+            Primary sysinit stage for BLE mesh functionality.
+        value: 500
+
+    BLE_MESH_SYSINIT_STAGE_2:
+        description: >
+            Secondary sysinit stage for BLE mesh functionality.
+        value: 1000
+
 syscfg.vals.BLE_MESH_SHELL:
     BLE_MESH_CFG_CLI: 1
     BLE_MESH_HEALTH_CLI: 1

--- a/nimble/host/mesh/syscfg.yml
+++ b/nimble/host/mesh/syscfg.yml
@@ -519,7 +519,7 @@ syscfg.defs:
             Primary sysinit stage for BLE mesh functionality.
         value: 500
 
-    BLE_MESH_SYSINIT_STAGE_2:
+    BLE_MESH_SYSINIT_STAGE_SHELL:
         description: >
             Secondary sysinit stage for BLE mesh functionality.
         value: 1000

--- a/nimble/host/pkg.yml
+++ b/nimble/host/pkg.yml
@@ -49,7 +49,7 @@ pkg.req_apis:
     - stats
 
 pkg.init:
-    ble_hs_init: 200
+    ble_hs_init: 'MYNEWT_VAL(BLE_HS_SYSINIT_STAGE)'
 
 pkg.down.BLE_HS_STOP_ON_SHUTDOWN:
     ble_hs_shutdown: 200

--- a/nimble/host/services/ans/pkg.yml
+++ b/nimble/host/services/ans/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - nimble/host
 
 pkg.init:
-    ble_svc_ans_init: 303
+    ble_svc_ans_init: 'MYNEWT_VAL(BLE_SVC_ANS_SYSINIT_STAGE)'

--- a/nimble/host/services/ans/syscfg.yml
+++ b/nimble/host/services/ans/syscfg.yml
@@ -23,3 +23,8 @@ syscfg.defs:
     BLE_SVC_ANS_UNR_ALERT_CAT:
         description: "Initial supported unread alert category bitmask."
         value: 0
+
+    BLE_SVC_ANS_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the alert notification service.
+        value: 303

--- a/nimble/host/services/bas/pkg.yml
+++ b/nimble/host/services/bas/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - nimble/host
 
 pkg.init:
-    ble_svc_bas_init: 303
+    ble_svc_bas_init: 'MYNEWT_VAL(BLE_SVC_BAS_SYSINIT_STAGE)'

--- a/nimble/host/services/bleuart/pkg.yml
+++ b/nimble/host/services/bleuart/pkg.yml
@@ -34,4 +34,4 @@ pkg.req_apis:
     - console
 
 pkg.init:
-    bleuart_init: 500
+    bleuart_init: 'MYNEWT_VAL(BLEUART_SYSINIT_STAGE)'

--- a/nimble/host/services/bleuart/syscfg.yml
+++ b/nimble/host/services/bleuart/syscfg.yml
@@ -22,3 +22,7 @@ syscfg.defs:
             The size of the largest line that can be received over the UART
             service.
         value: 120
+    BLEUART_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the BLE UART service.
+        value: 500

--- a/nimble/host/services/dis/pkg.yml
+++ b/nimble/host/services/dis/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - nimble/host
 
 pkg.init:
-    ble_svc_dis_init: 303
+    ble_svc_dis_init: 'MYNEWT_VAL(BLE_SVC_DIS_SYSINIT_STAGE)'

--- a/nimble/host/services/dis/syscfg.yml
+++ b/nimble/host/services/dis/syscfg.yml
@@ -92,3 +92,7 @@ syscfg.defs:
             Defines a default value for "Manufacturer name" if not set with
             'ble_svc_dis_manufacturer_name_set'.
         value: NULL
+    BLE_SVC_DIS_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the device information BLE service.
+        value: 303

--- a/nimble/host/services/gap/pkg.yml
+++ b/nimble/host/services/gap/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - nimble/host
 
 pkg.init:
-    ble_svc_gap_init: 301
+    ble_svc_gap_init: 'MYNEWT_VAL(BLE_SVC_GAP_SYSINIT_STAGE)'

--- a/nimble/host/services/gap/syscfg.yml
+++ b/nimble/host/services/gap/syscfg.yml
@@ -76,3 +76,8 @@ syscfg.defs:
             by Core specification 5.0, Vol 3, Part C, section 12.
             Set to '-1' to disable.
         value: -1
+
+    BLE_SVC_GAP_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the GAP BLE service.
+        value: 301

--- a/nimble/host/services/gatt/pkg.yml
+++ b/nimble/host/services/gatt/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - nimble/host
 
 pkg.init:
-    ble_svc_gatt_init: 302
+    ble_svc_gatt_init: 'MYNEWT_VAL(BLE_SVC_GATT_SYSINIT_STAGE)'

--- a/nimble/host/services/gatt/syscfg.yml
+++ b/nimble/host/services/gatt/syscfg.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,21 +15,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
 syscfg.defs:
-    BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM:
+    BLE_SVC_GATT_SYSINIT_STAGE:
         description: >
-            Defines permissions for reading "Battery Level" characteristics. Can
-            be zero to allow read without extra permissions or combination of:
-                BLE_GATT_CHR_F_READ_ENC
-                BLE_GATT_CHR_F_READ_AUTHEN
-                BLE_GATT_CHR_F_READ_AUTHOR
-        value: 0
-    BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE:
-        description: >
-            Set to 1 to support notification or 0 to disable it.
-        value: 1
-    BLE_SVC_BAS_SYSINIT_STAGE:
-        description: >
-            Sysinit stage for the battery level service.
-        value: 303
+            Sysinit stage for the GATT BLE service
+        value: 302

--- a/nimble/host/services/ias/pkg.yml
+++ b/nimble/host/services/ias/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - nimble/host
 
 pkg.init:
-    ble_svc_ias_init: 303
+    ble_svc_ias_init: 'MYNEWT_VAL(BLE_SVC_IAS_SYSINIT_STAGE)'

--- a/nimble/host/services/ias/syscfg.yml
+++ b/nimble/host/services/ias/syscfg.yml
@@ -14,21 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
 syscfg.defs:
-    BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM:
+    BLE_SVC_IAS_SYSINIT_STAGE:
         description: >
-            Defines permissions for reading "Battery Level" characteristics. Can
-            be zero to allow read without extra permissions or combination of:
-                BLE_GATT_CHR_F_READ_ENC
-                BLE_GATT_CHR_F_READ_AUTHEN
-                BLE_GATT_CHR_F_READ_AUTHOR
-        value: 0
-    BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE:
-        description: >
-            Set to 1 to support notification or 0 to disable it.
-        value: 1
-    BLE_SVC_BAS_SYSINIT_STAGE:
-        description: >
-            Sysinit stage for the battery level service.
+            Sysinit stage for the immediate alert BLE service.
         value: 303

--- a/nimble/host/services/lls/pkg.yml
+++ b/nimble/host/services/lls/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - nimble/host
 
 pkg.init:
-    ble_svc_lls_init: 303
+    ble_svc_lls_init: 'MYNEWT_VAL(BLE_SVC_LLS_SYSINIT_STAGE)'

--- a/nimble/host/services/lls/syscfg.yml
+++ b/nimble/host/services/lls/syscfg.yml
@@ -16,19 +16,7 @@
 # under the License.
 
 syscfg.defs:
-    BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM:
+    BLE_SVC_LLS_SYSINIT_STAGE:
         description: >
-            Defines permissions for reading "Battery Level" characteristics. Can
-            be zero to allow read without extra permissions or combination of:
-                BLE_GATT_CHR_F_READ_ENC
-                BLE_GATT_CHR_F_READ_AUTHEN
-                BLE_GATT_CHR_F_READ_AUTHOR
-        value: 0
-    BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE:
-        description: >
-            Set to 1 to support notification or 0 to disable it.
-        value: 1
-    BLE_SVC_BAS_SYSINIT_STAGE:
-        description: >
-            Sysinit stage for the battery level service.
+            Sysinit stage for the link loss BLE service.
         value: 303

--- a/nimble/host/services/tps/pkg.yml
+++ b/nimble/host/services/tps/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - nimble/host
 
 pkg.init:
-    ble_svc_tps_init: 303
+    ble_svc_tps_init: 'MYNEWT_VAL(BLE_SVC_TPS_SYSINIT_STAGE)'

--- a/nimble/host/services/tps/syscfg.yml
+++ b/nimble/host/services/tps/syscfg.yml
@@ -16,19 +16,8 @@
 # under the License.
 
 syscfg.defs:
-    BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM:
+    BLE_SVC_TPS_SYSINIT_STAGE:
         description: >
-            Defines permissions for reading "Battery Level" characteristics. Can
-            be zero to allow read without extra permissions or combination of:
-                BLE_GATT_CHR_F_READ_ENC
-                BLE_GATT_CHR_F_READ_AUTHEN
-                BLE_GATT_CHR_F_READ_AUTHOR
-        value: 0
-    BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE:
-        description: >
-            Set to 1 to support notification or 0 to disable it.
-        value: 1
-    BLE_SVC_BAS_SYSINIT_STAGE:
-        description: >
-            Sysinit stage for the battery level service.
+            Sysinit stage for the transmit power BLE service.
         value: 303
+

--- a/nimble/host/store/config/pkg.yml
+++ b/nimble/host/store/config/pkg.yml
@@ -35,4 +35,4 @@ pkg.deps.BLE_STORE_CONFIG_PERSIST:
     - "@apache-mynewt-core/sys/config"
 
 pkg.init:
-    ble_store_config_init: 500
+    ble_store_config_init: 'MYNEWT_VAL(BLE_STORE_SYSINIT_STAGE)'

--- a/nimble/host/store/config/syscfg.yml
+++ b/nimble/host/store/config/syscfg.yml
@@ -21,3 +21,7 @@ syscfg.defs:
         description: >
             Whether to save data to sys/config, or just keep it in RAM.
         value: 1
+    BLE_STORE_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for BLE host store.
+        value: 500

--- a/nimble/host/store/ram/pkg.yml
+++ b/nimble/host/store/ram/pkg.yml
@@ -34,4 +34,4 @@ pkg.deps:
     - nimble/host
 
 pkg.init:
-    ble_store_ram_init: 500
+    ble_store_ram_init: 'MYNEWT_VAL(BLE_STORE_RAM_SYSINIT_STAGE)'

--- a/nimble/host/store/ram/syscfg.yml
+++ b/nimble/host/store/ram/syscfg.yml
@@ -16,19 +16,8 @@
 # under the License.
 
 syscfg.defs:
-    BLE_SVC_BAS_BATTERY_LEVEL_READ_PERM:
+    BLE_STORE_RAM_SYSINIT_STAGE:
         description: >
-            Defines permissions for reading "Battery Level" characteristics. Can
-            be zero to allow read without extra permissions or combination of:
-                BLE_GATT_CHR_F_READ_ENC
-                BLE_GATT_CHR_F_READ_AUTHEN
-                BLE_GATT_CHR_F_READ_AUTHOR
-        value: 0
-    BLE_SVC_BAS_BATTERY_LEVEL_NOTIFY_ENABLE:
-        description: >
-            Set to 1 to support notification or 0 to disable it.
-        value: 1
-    BLE_SVC_BAS_SYSINIT_STAGE:
-        description: >
-            Sysinit stage for the battery level service.
-        value: 303
+            Sysinit stage for the RAM BLE store.
+        value: 500
+

--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -428,6 +428,10 @@ syscfg.defs:
             entails aborting all GAP procedures and terminating open
             connections.
         value: 1
+    BLE_HS_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the NimBLE host.
+        value: 200
 
 syscfg.vals.BLE_MESH:
     BLE_SM_SC: 1

--- a/nimble/transport/emspi/pkg.yml
+++ b/nimble/transport/emspi/pkg.yml
@@ -33,4 +33,4 @@ pkg.apis:
     - ble_transport
 
 pkg.init:
-    ble_hci_emspi_init: 100
+    ble_hci_emspi_init: 'MYNEWT_VAL(BLE_HCI_EMSPI_SYSINIT_STAGE)'

--- a/nimble/transport/emspi/syscfg.yml
+++ b/nimble/transport/emspi/syscfg.yml
@@ -90,5 +90,10 @@ syscfg.defs:
         description: 'The size of the emspi task (units: 4-byte words).'
         value: 256
 
+    BLE_HCI_EMSPI_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the EMSPI BLE transport.
+        value: 100
+
 syscfg.vals.BLE_EXT_ADV:
     BLE_HCI_EVT_BUF_SIZE: 257

--- a/nimble/transport/ram/pkg.yml
+++ b/nimble/transport/ram/pkg.yml
@@ -33,4 +33,4 @@ pkg.apis:
     - ble_transport
 
 pkg.init:
-    ble_hci_ram_init: 100
+    ble_hci_ram_init: 'MYNEWT_VAL(BLE_TRANS_RAM_SYSINIT_STAGE)'

--- a/nimble/transport/ram/syscfg.yml
+++ b/nimble/transport/ram/syscfg.yml
@@ -39,5 +39,10 @@ syscfg.defs:
             packets. It does not include the HCI data header (of 4 bytes).
         value: 255
 
+    BLE_TRANS_RAM_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the RAM BLE transport.
+        value: 100
+
 syscfg.vals.BLE_EXT_ADV:
     BLE_HCI_EVT_BUF_SIZE: 257

--- a/nimble/transport/socket/pkg.yml
+++ b/nimble/transport/socket/pkg.yml
@@ -35,4 +35,4 @@ pkg.apis:
     - ble_transport
 
 pkg.init:
-    ble_hci_sock_init: 500
+    ble_hci_sock_init: 'MYNEWT_VAL(BLE_SOCK_CLI_SYSINIT_STAGE)'

--- a/nimble/transport/socket/syscfg.yml
+++ b/nimble/transport/socket/syscfg.yml
@@ -70,5 +70,10 @@ syscfg.defs:
         description: 'Size of the HCI socket stack (units=words).'
         value: 80
 
+    BLE_SOCK_CLI_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the socket BLE transport.
+        value: 500
+
 syscfg.vals.BLE_EXT_ADV:
     BLE_HCI_EVT_BUF_SIZE: 257

--- a/nimble/transport/uart/pkg.yml
+++ b/nimble/transport/uart/pkg.yml
@@ -35,4 +35,4 @@ pkg.apis:
     - ble_transport
 
 pkg.init:
-    ble_hci_uart_init: 500
+    ble_hci_uart_init: 'MYNEWT_VAL(BLE_TRANS_UART_SYSINIT_STAGE)'

--- a/nimble/transport/uart/syscfg.yml
+++ b/nimble/transport/uart/syscfg.yml
@@ -63,6 +63,10 @@ syscfg.defs:
     BLE_HCI_UART_FLOW_CTRL:
         description: 'Flow control used for HCI uart interface'
         value:       HAL_UART_FLOW_CTL_RTS_CTS
+    BLE_TRANS_UART_SYSINIT_STAGE:
+        description: >
+            Sysinit stage for the UART BLE transport.
+        value: 500
 
 syscfg.vals.BLE_EXT_ADV:
     BLE_HCI_EVT_BUF_SIZE: 257


### PR DESCRIPTION
This allows the app or target to rearrange package initialization order via syscfg overrides.

**Note: This requires an updated version of newt
(https://github.com/apache/mynewt-newt/pull/230).  Older versions of newt fail to parse the updated `pkg.yml` files.

I wanted to make this change backwards compatible via an injected newt syscfg setting, e.g.,
```
pkg.init.NEWT_FEATURE_SYSCFG_STAGES:
    log_init: 'MYNEWT_VAL(LOG_SYSINIT_STAGE)'

pkg.init.!NEWT_FEATURE_SYSCFG_STAGES:
    log_init: 100
```

Unfortunately, this is not possible, as the old newt does not allow conditionals to be applied to `pkg.init`.  So, as soon as this PR is merged, everything will break for users using older versions of newt.

I think it is still worth it to get this change in.  Before we merge, we can send a note to the dev list and the slack channel.  When 1.6.0 is released, we can make sure to add the appropriate newt version restriction.