### PR TITLE
fix length comparison bug

### DIFF
--- a/nimble/host/src/ble_hs_dbg.c
+++ b/nimble/host/src/ble_hs_dbg.c
@@ -675,7 +675,7 @@ ble_hs_dbg_event_disp(uint8_t *evbuf)
         ble_hs_dbg_num_comp_pkts_disp(evdata, len);
         break;
     case BLE_HCI_EVCODE_LE_META:
-        ble_hs_dbg_le_event_disp(evdata[0], len, evdata + 1);
+        ble_hs_dbg_le_event_disp(evdata[0], len-1, evdata + 1);
         break;
     case BLE_HCI_EVCODE_AUTH_PYLD_TMO:
         ble_hs_dbg_auth_pyld_tmo_disp(evdata, len);

--- a/nimble/host/src/ble_hs_dbg.c
+++ b/nimble/host/src/ble_hs_dbg.c
@@ -319,7 +319,7 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
     {
         struct hci_le_subev_chan_sel_alg *data = (void *) evdata;
 
-        if (len != BLE_HCI_LE_SUBEV_CHAN_SEL_ALG_LEN) {
+        if (len != sizeof(*data)) {
             BLE_HS_LOG(DEBUG, "Corrupted LE Channel Selection Algorithm "
                        "len=%u\n", len);
             break;

--- a/nimble/host/src/ble_hs_dbg.c
+++ b/nimble/host/src/ble_hs_dbg.c
@@ -319,7 +319,7 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
     {
         struct hci_le_subev_chan_sel_alg *data = (void *) evdata;
 
-        if (len != sizeof(*data)) {
+        if (len != BLE_HCI_LE_SUBEV_CHAN_SEL_ALG_LEN) {
             BLE_HS_LOG(DEBUG, "Corrupted LE Channel Selection Algorithm "
                        "len=%u\n", len);
             break;


### PR DESCRIPTION
This looks like a bug. Fails consistently for me without this fix, and it looks like we are using this for the specified length for outgoing csa requests.