### PR TITLE
BLE_L2CAP_EVENT_COC_DATA_RECEIVED and conn_handle

### DIFF
--- a/nimble/host/src/ble_l2cap_coc.c
+++ b/nimble/host/src/ble_l2cap_coc.c
@@ -124,6 +124,7 @@ ble_l2cap_event_coc_received_data(struct ble_l2cap_chan *chan,
     struct ble_l2cap_event event;
 
     event.type = BLE_L2CAP_EVENT_COC_DATA_RECEIVED;
+    event.receive.conn_handle = chan->conn_handle;
     event.receive.chan = chan;
     event.receive.sdu_rx = om;
 


### PR DESCRIPTION
It seems that the "ble_l2cap_event_coc_received_data" function does not assign the "conn_handle" member of the "event" variable before calling the channel callback.
I did not found any other function raising the "BLE_L2CAP_EVENT_COC_DATA_RECEIVED" event so I think this is the only place to make such a correction.