### PR TITLE
porting: Fix Tinycrypt port build

### DIFF
--- a/porting/examples/dummy/Makefile
+++ b/porting/examples/dummy/Makefile
@@ -39,14 +39,18 @@ SRC = \
 	$(NIMBLE_ROOT)/porting/npl/dummy/src/npl_os_dummy.c \
 	$(NIMBLE_ROOT)/porting/npl/dummy/src/hci_dummy.c \
 	$(NIMBLE_SRC) \
+	$(TINYCRYPT_SRC) \
 	main.c \
 
 # Add dummy NPL and all NimBLE directories to include paths
 INC = \
 	$(NIMBLE_ROOT)/porting/npl/dummy/include \
 	$(NIMBLE_INCLUDE) \
+	$(TINYCRYPT_INCLUDE) \
+	$(INCLUDE) \
 
 OBJ := $(SRC:.c=.o)
+TINYCRYPT_OBJ := $(TINYCRYPT_SRC:.c=.o)
 
 CFLAGS := $(NIMBLE_CFLAGS)
 
@@ -59,8 +63,10 @@ clean:
 	rm $(OBJ) -f
 	rm dummy -f
 
+$(TINYCRYPT_OBJ): CFLAGS+=$(TINYCRYPT_CFLAGS)
+
 %.o: %.c
 	$(CC) -c $(addprefix -I, $(INC)) $(CFLAGS) -o $@ $<
 
-dummy: $(OBJ)
+dummy: $(OBJ) $(TINYCRYPT_OBJ)
 	$(CC) -o $@ $^

--- a/porting/examples/linux/Makefile
+++ b/porting/examples/linux/Makefile
@@ -27,6 +27,7 @@ SRC += \
 	$(NIMBLE_ROOT)/porting/npl/linux/src/os_task.c     \
 	$(NIMBLE_ROOT)/porting/npl/linux/src/os_time.c     \
 	$(NIMBLE_ROOT)/nimble/transport/socket/src/ble_hci_socket.c \
+	$(TINYCRYPT_SRC) \
 	$(NULL)
 
 # Source files for demo app
@@ -42,6 +43,7 @@ INC = \
 	$(NIMBLE_ROOT)/porting/npl/linux/src \
 	$(NIMBLE_ROOT)/nimble/transport/socket/include \
 	$(NIMBLE_INCLUDE) \
+	$(TINYCRYPT_INCLUDE) \
 	$(NULL)
 
 INCLUDES := $(addprefix -I, $(INC))
@@ -51,6 +53,8 @@ SRC_CC = $(filter %.cc, $(SRC))
 
 OBJ := $(SRC_C:.c=.o)
 OBJ += $(SRC_CC:.cc=.o)
+
+TINYCRYPT_OBJ := $(TINYCRYPT_SRC:.c=.o)
 
 CFLAGS =                    \
     $(NIMBLE_CFLAGS)        \
@@ -70,12 +74,14 @@ clean:
 	rm $(OBJ) -f
 	rm dummy -f
 
+$(TINYCRYPT_OBJ): CFLAGS+=$(TINYCRYPT_CFLAGS)
+
 %.o: %.c
 	$(CC) -c $(INCLUDES) $(CFLAGS) -o $@ $<
 
 %.o: %.cc
 	$(CXX) -c $(INCLUDES) $(CFLAGS) -o $@ $<
 
-nimble-linux: $(OBJ)
+nimble-linux: $(OBJ) $(TINYCRYPT_OBJ)
 	$(LD) -o $@ $^ $(LIBS)
 	$(SIZE) $@

--- a/porting/nimble/Makefile.tinycrypt
+++ b/porting/nimble/Makefile.tinycrypt
@@ -15,10 +15,12 @@
 # under the License.
 #
 
-NIMBLE_INCLUDE += \
+TINYCRYPT_CFLAGS := -std=c99
+
+TINYCRYPT_INCLUDE := \
 	$(NIMBLE_ROOT)/ext/tinycrypt/include \
 
-NIMBLE_SRC += \
+TINYCRYPT_SRC := \
 	$(NIMBLE_ROOT)/ext/tinycrypt/src/aes_decrypt.c \
 	$(NIMBLE_ROOT)/ext/tinycrypt/src/aes_encrypt.c \
 	$(NIMBLE_ROOT)/ext/tinycrypt/src/cmac_mode.c \


### PR DESCRIPTION
Tinycrypt requires -std=c99 flag to build.