### PR TITLE
nimble/host: Allow auto-start to be disabled

### DIFF
--- a/nimble/host/include/host/ble_hs.h
+++ b/nimble/host/include/host/ble_hs.h
@@ -312,6 +312,18 @@ int ble_hs_synced(void);
 int ble_hs_start(void);
 
 /**
+ * Enqueues a host start event to the default event queue.  The actual host
+ * startup is performed in the host parent task, but using the default queue
+ * here ensures the event won't run until the end of main() when this is
+ * called during system initialization.  This allows the application to
+ * configure the host package in the meantime.
+ *
+ * If auto-start is disabled, the application should use this function to start
+ * the BLE stack.
+ */
+void ble_hs_sched_start(void);
+
+/**
  * Causes the host to reset the NimBLE stack as soon as possible.  The
  * application is notified when the reset occurs via the host reset callback.
  *

--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -455,6 +455,17 @@ ble_hs_timer_resched(void)
      */
     ble_hs_timer_reset(0);
 }
+ 
+void
+ble_hs_sched_start(void)
+{
+#ifdef MYNEWT
+    ble_npl_eventq_put((struct ble_npl_eventq *)os_eventq_dflt_get(),
+                       &ble_hs_ev_start);
+#else
+    ble_npl_eventq_put(nimble_port_get_dflt_eventq(), &ble_hs_ev_start);
+#endif
+}
 
 static void
 ble_hs_event_rx_hci_ev(struct ble_npl_event *ev)
@@ -698,10 +709,13 @@ ble_hs_init(void)
      * queue ensures the event won't run until the end of main().  This allows
      * the application to configure this package in the meantime.
      */
+#if MYNEWT_VAL(BLE_HS_AUTO_START)
 #ifdef MYNEWT
-    ble_npl_eventq_put((struct ble_npl_eventq *)os_eventq_dflt_get(), &ble_hs_ev_start);
+    ble_npl_eventq_put((struct ble_npl_eventq *)os_eventq_dflt_get(),
+                       &ble_hs_ev_start);
 #else
     ble_npl_eventq_put(nimble_port_get_dflt_eventq(), &ble_hs_ev_start);
+#endif
 #endif
 
 #if BLE_MONITOR

--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -21,6 +21,12 @@ syscfg.defs:
         description: 'Indicates that a BLE host is present.'
         value: 1
 
+    BLE_HS_AUTO_START:
+        description: >
+                Causes the BLE host to automatically start during system
+                initialization.
+        value: 1
+
     # Debug settings.
     BLE_HS_DEBUG:
         description: 'Enables extra runtime assertions.'

--- a/porting/examples/linux/include/syscfg/syscfg.h
+++ b/porting/examples/linux/include/syscfg/syscfg.h
@@ -585,6 +585,10 @@
 #define MYNEWT_VAL_BLE_HOST (1)
 #endif
 
+#ifndef MYNEWT_VAL_BLE_HS_AUTO_START
+#define MYNEWT_VAL_BLE_HS_AUTO_START (1)
+#endif
+
 #ifndef MYNEWT_VAL_BLE_HS_DEBUG
 #define MYNEWT_VAL_BLE_HS_DEBUG (0)
 #endif

--- a/porting/nimble/include/syscfg/syscfg.h
+++ b/porting/nimble/include/syscfg/syscfg.h
@@ -570,6 +570,10 @@
 #define MYNEWT_VAL_BLE_HOST (1)
 #endif
 
+#ifndef MYNEWT_VAL_BLE_HS_AUTO_START
+#define MYNEWT_VAL_BLE_HS_AUTO_START (1)
+#endif
+
 #ifndef MYNEWT_VAL_BLE_HS_DEBUG
 #define MYNEWT_VAL_BLE_HS_DEBUG (0)
 #endif

--- a/porting/npl/riot/include/syscfg/syscfg.h
+++ b/porting/npl/riot/include/syscfg/syscfg.h
@@ -777,6 +777,10 @@
 #define MYNEWT_VAL_BLE_HS_DEBUG (0)
 #endif
 
+#ifndef MYNEWT_VAL_BLE_HS_AUTO_START
+#define MYNEWT_VAL_BLE_HS_AUTO_START (1)
+#endif
+
 #ifndef MYNEWT_VAL_BLE_HS_FLOW_CTRL
 #define MYNEWT_VAL_BLE_HS_FLOW_CTRL (0)
 #endif


### PR DESCRIPTION
#### Before PR: 
The host always starts during system initialization.

#### After PR:
A Mynewt syscfg setting (`BLE_HS_AUTO_START`) was added. When this setting is disabled, the host does not start automatically. Instead, the application starts the host using the new
`ble_hs_sched_start()` function.

`BLE_HS_AUTO_START` is enabled by default.