### PR TITLE
nimble/ll: Request/release hfxo using mynewt API

### DIFF
--- a/nimble/controller/src/ble_ll_xcvr.c
+++ b/nimble/controller/src/ble_ll_xcvr.c
@@ -46,15 +46,19 @@ ble_ll_xcvr_rfclk_state(void)
 void
 ble_ll_xcvr_rfclk_enable(void)
 {
-    g_ble_ll_data.ll_rfclk_state = BLE_RFCLK_STATE_ON;
-    ble_phy_rfclk_enable();
+    if (g_ble_ll_data.ll_rfclk_state == BLE_RFCLK_STATE_OFF) {
+        g_ble_ll_data.ll_rfclk_state = BLE_RFCLK_STATE_ON;
+        ble_phy_rfclk_enable();
+    }
 }
 
 void
 ble_ll_xcvr_rfclk_disable(void)
 {
-    ble_phy_rfclk_disable();
-    g_ble_ll_data.ll_rfclk_state = BLE_RFCLK_STATE_OFF;
+    if (g_ble_ll_data.ll_rfclk_state != BLE_RFCLK_STATE_OFF) {
+        ble_phy_rfclk_disable();
+        g_ble_ll_data.ll_rfclk_state = BLE_RFCLK_STATE_OFF;
+    }
 }
 
 void

--- a/nimble/drivers/nrf51/src/ble_phy.c
+++ b/nimble/drivers/nrf51/src/ble_phy.c
@@ -30,7 +30,10 @@
 #include "controller/ble_phy_trace.h"
 #include "controller/ble_ll.h"
 #include "nrfx.h"
+
+#if MYNEWT
 #include "mcu/nrf51_clock.h"
+#endif
 
 /* XXX: 4) Make sure RF is higher priority interrupt than schedule */
 
@@ -817,7 +820,7 @@ ble_phy_init(void)
 
 #if !defined(BLE_XCVR_RFCLK)
     /* BLE wants the HFXO on all the time in this case */
-    nrf51_clock_hfxo_request();
+    ble_phy_rfclk_enable();
 
     /*
      * XXX: I do not think we need to wait for settling time here since
@@ -1474,12 +1477,20 @@ ble_phy_resolv_list_disable(void)
 void
 ble_phy_rfclk_enable(void)
 {
+#if MYNEWT
     nrf51_clock_hfxo_request();
+#else
+    NRF_CLOCK->TASKS_HFCLKSTART = 1;
+#endif
 }
 
 void
 ble_phy_rfclk_disable(void)
 {
+#if MYNEWT
     nrf51_clock_hfxo_release();
+#else
+    NRF_CLOCK->TASKS_HFCLKSTOP = 1;
+#endif
 }
 #endif

--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -30,8 +30,8 @@
 #include "controller/ble_phy_trace.h"
 #include "controller/ble_ll.h"
 #include "nrfx.h"
-#include "mcu/nrf52_clock.h"
 #if MYNEWT
+#include "mcu/nrf52_clock.h"
 #include "mcu/cmsis_nvic.h"
 #include "hal/hal_gpio.h"
 #else
@@ -1353,7 +1353,7 @@ ble_phy_init(void)
 
 #if !defined(BLE_XCVR_RFCLK)
     /* BLE wants the HFXO on all the time in this case */
-    nrf52_clock_hfxo_request();
+    ble_phy_rfclk_enable();
 
     /*
      * XXX: I do not think we need to wait for settling time here since
@@ -2035,12 +2035,20 @@ void ble_phy_disable_dtm(void)
 void
 ble_phy_rfclk_enable(void)
 {
+#if MYNEWT
     nrf52_clock_hfxo_request();
+#else
+    NRF_CLOCK->TASKS_HFCLKSTART = 1;
+#endif
 }
 
 void
 ble_phy_rfclk_disable(void)
 {
+#if MYNEWT
     nrf52_clock_hfxo_release();
+#else
+    NRF_CLOCK->TASKS_HFCLKSTOP = 1;
+#endif
 }
 #endif

--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -30,6 +30,7 @@
 #include "controller/ble_phy_trace.h"
 #include "controller/ble_ll.h"
 #include "nrfx.h"
+#include "mcu/nrf52_clock.h"
 #if MYNEWT
 #include "mcu/cmsis_nvic.h"
 #include "hal/hal_gpio.h"
@@ -1351,20 +1352,14 @@ ble_phy_init(void)
     g_ble_phy_data.phy_txtorx_phy_mode = BLE_PHY_MODE_1M;
 
 #if !defined(BLE_XCVR_RFCLK)
-    uint32_t os_tmo;
+    /* BLE wants the HFXO on all the time in this case */
+    nrf52_clock_hfxo_request();
 
-    /* Make sure HFXO is started */
-    NRF_CLOCK->EVENTS_HFCLKSTARTED = 0;
-    NRF_CLOCK->TASKS_HFCLKSTART = 1;
-    os_tmo = os_time_get() + (5 * (1000 / OS_TICKS_PER_SEC));
-    while (1) {
-        if (NRF_CLOCK->EVENTS_HFCLKSTARTED) {
-            break;
-        }
-        if ((int32_t)(os_time_get() - os_tmo) > 0) {
-            return BLE_PHY_ERR_INIT;
-        }
-    }
+    /*
+     * XXX: I do not think we need to wait for settling time here since
+     * we will probably not use the radio for longer than the settling time
+     * and it will only degrade performance. Might want to wait here though.
+     */
 #endif
 
     /* Set phy channel to an invalid channel so first set channel works */
@@ -2040,12 +2035,12 @@ void ble_phy_disable_dtm(void)
 void
 ble_phy_rfclk_enable(void)
 {
-    NRF_CLOCK->TASKS_HFCLKSTART = 1;
+    nrf52_clock_hfxo_request();
 }
 
 void
 ble_phy_rfclk_disable(void)
 {
-    NRF_CLOCK->TASKS_HFCLKSTOP = 1;
+    nrf52_clock_hfxo_release();
 }
 #endif


### PR DESCRIPTION
This change is to use a new API committed to mynewt core that
will request the hfxo to be turned on and release it when the
hfxo is no longer desired. One reason to do this is that an
application may desire the hfxo to be on and nimble would
blindly turn it on/off when it wanted to. Note that the API
requires that the request/release be paired; you cannot release
without a request and if you request without a release the hfxo
will be on continuously.

A final note: the nimble link layer assumes that when it requests
the hfxo it needs to settle. If the hfxo was already on the code
would not need to wait for the settling time. The code has not
been updated to handle that case. This is not going to cause
any issues; it will operate as it did before. However, future
improvements could be to check if the hfxo was already on and
settled and thus not have to wait for the settling time.