### PR TITLE
host/util: doc improvements + typo fixes

### DIFF
--- a/nimble/host/util/include/host/util/util.h
+++ b/nimble/host/util/include/host/util/util.h
@@ -24,6 +24,19 @@
 extern "C" {
 #endif
 
+/**
+ * Tries to configure the device with at least one Bluetooth address.
+ * Addresses are restored in a hardware-specific fashion.
+ *
+ * @param prefer_random         Whether to attempt to restore a random address
+ *                                  before checking if a public address has
+ *                                  already been configured.
+ *
+ * @return                      0 on success;
+ *                              BLE_HS_ENOADDR if the device does not have any
+ *                                  available addresses.
+ *                              Other BLE host core code on error.
+ */
 int ble_hs_util_ensure_addr(int prefer_random);
 
 #ifdef __cplusplus

--- a/nimble/host/util/src/addr.c
+++ b/nimble/host/util/src/addr.c
@@ -99,7 +99,7 @@ ble_hs_util_ensure_addr(int prefer_random)
         /* Try to load a public address. */
         rc = ble_hs_id_copy_addr(BLE_ADDR_PUBLIC, NULL, NULL);
         if (rc == BLE_HS_ENOADDR) {
-            /* No random address; try to load a random address. */
+            /* No public address; try to load a random address. */
             rc = ble_hs_util_ensure_rand_addr();
         }
     }

--- a/nimble/host/util/src/addr.c
+++ b/nimble/host/util/src/addr.c
@@ -70,19 +70,6 @@ ble_hs_util_ensure_rand_addr(void)
     return 0;
 }
 
-/**
- * Tries to configure the device with at least one Bluetooth address.
- * Addresses are restored in a hardware-specific fasion.
- *
- * @param prefer_random         Whether to attempt to restore a random address
- *                                  before checking if a public address has
- *                                  already been configured.
- *
- * @return                      0 on success;
- *                              BLE_HS_ENOADDR if the device does not have any
- *                                  available addresses.
- *                              Other BLE host core code on error.
- */
 int
 ble_hs_util_ensure_addr(int prefer_random)
 {


### PR DESCRIPTION
The documentation for `ble_hs_util_ensure_addr()` was placed with the function implementation instead of the actual header file, so I moved it.

Also fixed a little typo in the function's inline doc...