### PR TITLE
[linux] Stability fixes to linux port: npl mutex and task.

### DIFF
--- a/porting/npl/linux/src/os_mutex.c
+++ b/porting/npl/linux/src/os_mutex.c
@@ -28,14 +28,13 @@
 ble_npl_error_t
 ble_npl_mutex_init(struct ble_npl_mutex *mu)
 {
-    pthread_mutexattr_t mu_attr;
-
     if (!mu) {
         return BLE_NPL_INVALID_PARAM;
     }
 
-    pthread_mutexattr_settype(&mu_attr, PTHREAD_MUTEX_RECURSIVE_NP);
-    pthread_mutex_init(&mu->lock, &mu_attr);
+    pthread_mutexattr_init(&mu->attr);
+    pthread_mutexattr_settype(&mu->attr, PTHREAD_MUTEX_RECURSIVE_NP);
+    pthread_mutex_init(&mu->lock, &mu->attr);
 
     return BLE_NPL_OK;
 }
@@ -57,19 +56,17 @@ ble_npl_mutex_release(struct ble_npl_mutex *mu)
 ble_npl_error_t
 ble_npl_mutex_pend(struct ble_npl_mutex *mu, uint32_t timeout)
 {
-    struct timespec wait;
-
     if (!mu) {
         return BLE_NPL_INVALID_PARAM;
     }
 
     assert(&mu->lock);
 
-    wait.tv_sec  = timeout / 1000;
-    wait.tv_nsec = (timeout % 1000) * 1000000;
-    wait.tv_nsec %= 1000000000;
+    mu->wait.tv_sec  = timeout / 1000;
+    mu->wait.tv_nsec = (timeout % 1000) * 1000000;
+    mu->wait.tv_nsec %= 1000000000;
 
-    if (pthread_mutex_timedlock(&mu->lock, &wait)) {
+    if (pthread_mutex_timedlock(&mu->lock, &mu->wait)) {
         return BLE_NPL_TIMEOUT;
     }
 

--- a/porting/npl/linux/src/os_task.c
+++ b/porting/npl/linux/src/os_task.c
@@ -55,20 +55,18 @@ ble_npl_task_init(struct ble_npl_task *t, const char *name, ble_npl_task_func_t 
         return OS_INVALID_PARM;
     }
 
-    pthread_attr_t attr;
-    struct sched_param param;
-    err = pthread_attr_init(&attr);
+    err = pthread_attr_init(&t->attr);
     if (err) return err;
-    err = pthread_attr_getschedparam (&attr, &param);
+    err = pthread_attr_getschedparam (&t->attr, &t->param);
     if (err) return err;
-    err = pthread_attr_setschedpolicy(&attr, SCHED_RR);
+    err = pthread_attr_setschedpolicy(&t->attr, SCHED_RR);
     if (err) return err;
-    param.sched_priority = prio;
-    err = pthread_attr_setschedparam (&attr, &param);
+    t->param.sched_priority = prio;
+    err = pthread_attr_setschedparam (&t->attr, &t->param);
     if (err) return err;
 
     t->name = name;
-    err = pthread_create(&t->handle, &attr, func, arg);
+    err = pthread_create(&t->handle, &t->attr, func, arg);
 
     return err;
 }

--- a/porting/npl/linux/src/os_types.h
+++ b/porting/npl/linux/src/os_types.h
@@ -59,6 +59,8 @@ struct ble_npl_callout {
 
 struct ble_npl_mutex {
     pthread_mutex_t         lock;
+    pthread_mutexattr_t     attr;
+    struct timespec         wait;
 };
 
 struct ble_npl_sem {
@@ -67,6 +69,8 @@ struct ble_npl_sem {
 
 struct ble_npl_task {
     pthread_t               handle;
+    pthread_attr_t          attr;
+    struct sched_param      param;
     const char*             name;
 };
 

--- a/porting/npl/linux/src/wqueue.h
+++ b/porting/npl/linux/src/wqueue.h
@@ -29,16 +29,17 @@ using namespace std;
 
 template <typename T> class wqueue
 {
-    list<T>         m_queue;
-    pthread_mutex_t m_mutex;
-    pthread_cond_t  m_condv;
+    list<T>              m_queue;
+    pthread_mutex_t      m_mutex;
+    pthread_mutexattr_t  m_mutex_attr;
+    pthread_cond_t       m_condv;
 
 public:
     wqueue()
     {
-        pthread_mutexattr_t attr;
-        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-        pthread_mutex_init(&m_mutex, &attr);
+        pthread_mutexattr_init(&m_mutex_attr);
+        pthread_mutexattr_settype(&m_mutex_attr, PTHREAD_MUTEX_RECURSIVE);
+        pthread_mutex_init(&m_mutex, &m_mutex_attr);
         pthread_cond_init(&m_condv, NULL);
     }
 

--- a/porting/npl/linux/test/test_npl_eventq.c
+++ b/porting/npl/linux/test/test_npl_eventq.c
@@ -93,7 +93,8 @@ int test_get_no_wait()
 
 int test_get()
 {
-    struct ble_npl_event *ev = ble_npl_eventq_get(&s_eventq);
+    struct ble_npl_event *ev = ble_npl_eventq_get(&s_eventq,
+						  BLE_NPL_WAIT_FOREVER);
 
     VerifyOrQuit(ev == &s_event,
 		 "callout: wrong event passed");


### PR DESCRIPTION
Fixes to allow the npl unit tests to pass reliably on linux.  Also lower the set of 4.1 feature checks when running on linux so as not to hang when using btvirt virtual controller or older 4.0 controllers.