### PR TITLE
nimble host stack should not consider connection handle 0 as invalid.

### DIFF
--- a/nimble/host/mesh/src/prov.c
+++ b/nimble/host/mesh/src/prov.c
@@ -237,7 +237,9 @@ static void reset_link(void)
 
 	/* Clear everything except the retransmit delayed work config */
 	memset(&link, 0, offsetof(struct prov_link, tx.retransmit));
-
+#if (MYNEWT_VAL(BLE_MESH_PB_GATT))
+	link.conn_handle = BLE_HS_CONN_HANDLE_NONE;
+#endif
 	link.rx.prev_id = XACT_NVAL;
 
 	if (bt_pub_key_get()) {
@@ -449,7 +451,7 @@ static int prov_send_adv(struct os_mbuf *msg)
 #if (MYNEWT_VAL(BLE_MESH_PB_GATT))
 static int prov_send_gatt(struct os_mbuf *msg)
 {
-	if (!link.conn_handle) {
+	if (link.conn_handle == BLE_HS_CONN_HANDLE_NONE) {
 		BT_ERR("No connection handle!?");
 		return -ENOTCONN;
 	}
@@ -461,7 +463,7 @@ static int prov_send_gatt(struct os_mbuf *msg)
 static inline int prov_send(struct os_mbuf *buf)
 {
 #if (MYNEWT_VAL(BLE_MESH_PB_GATT))
-	if (link.conn_handle) {
+	if (link.conn_handle != BLE_HS_CONN_HANDLE_NONE) {
 		return prov_send_gatt(buf);
 	}
 #endif

--- a/nimble/host/mesh/src/proxy.c
+++ b/nimble/host/mesh/src/proxy.c
@@ -417,7 +417,7 @@ void bt_mesh_proxy_beacon_send(struct bt_mesh_subnet *sub)
 	}
 
 	for (i = 0; i < ARRAY_SIZE(clients); i++) {
-		if (clients[i].conn_handle) {
+		if (clients[i].conn_handle != BLE_HS_CONN_HANDLE_NONE) {
 			beacon_send(clients[i].conn_handle, sub);
 		}
 	}
@@ -607,7 +607,7 @@ static void proxy_connected(uint16_t conn_handle)
 	}
 
 	for (client = NULL, i = 0; i < ARRAY_SIZE(clients); i++) {
-		if (!clients[i].conn_handle) {
+		if (clients[i].conn_handle == BLE_HS_CONN_HANDLE_NONE) {
 			client = &clients[i];
 			break;
 		}
@@ -693,7 +693,7 @@ int bt_mesh_proxy_prov_enable(void)
 	prov_fast_adv = true;
 
 	for (i = 0; i < ARRAY_SIZE(clients); i++) {
-		if (clients[i].conn_handle) {
+		if (clients[i].conn_handle != BLE_HS_CONN_HANDLE_NONE) {
 			clients[i].filter_type = PROV;
 		}
 	}
@@ -721,7 +721,8 @@ int bt_mesh_proxy_prov_disable(void)
 	for (i = 0; i < ARRAY_SIZE(clients); i++) {
 		struct bt_mesh_proxy_client *client = &clients[i];
 
-		if (clients->conn_handle && client->filter_type == PROV) {
+        if ((client->conn_handle != BLE_HS_CONN_HANDLE_NONE)
+                && (client->filter_type == PROV)) {
 			bt_mesh_pb_gatt_close(client->conn_handle);
 			client->filter_type = NONE;
 		}
@@ -765,7 +766,7 @@ int bt_mesh_proxy_gatt_enable(void)
 	gatt_svc = MESH_GATT_PROXY;
 
 	for (i = 0; i < ARRAY_SIZE(clients); i++) {
-		if (clients[i].conn_handle) {
+		if (clients[i].conn_handle != BLE_HS_CONN_HANDLE_NONE) {
 			clients[i].filter_type = WHITELIST;
 		}
 	}
@@ -877,7 +878,7 @@ bool bt_mesh_proxy_relay(struct os_mbuf *buf, u16_t dst)
 		struct bt_mesh_proxy_client *client = &clients[i];
 		struct os_mbuf *msg;
 
-		if (!client->conn_handle) {
+		if (client->conn_handle == BLE_HS_CONN_HANDLE_NONE) {
 			continue;
 		}
 
@@ -1383,6 +1384,7 @@ int bt_mesh_proxy_init(void)
 		k_work_init(&clients[i].send_beacons, proxy_send_beacons);
 #endif
 		clients[i].buf = NET_BUF_SIMPLE(CLIENT_BUF_SIZE);
+		clients[i].conn_handle = BLE_HS_CONN_HANDLE_NONE;
 	}
 
 	resolve_svc_handles();


### PR DESCRIPTION
As per Bluetooth specification, connection handle can have value in the
range 0x000-0xEFF. So 0 can actually be a valid handle for a connection.
This change fixes the mesh code to not consider 0 as invalid handle.