### PR TITLE
net/nimble/drivers: Fix compile error if BLE_XTAL_SETTLE_TIME = 0

### DIFF
--- a/nimble/drivers/nrf51/src/ble_phy.c
+++ b/nimble/drivers/nrf51/src/ble_phy.c
@@ -1473,7 +1473,6 @@ ble_phy_resolv_list_disable(void)
 }
 #endif
 
-#ifdef BLE_XCVR_RFCLK
 void
 ble_phy_rfclk_enable(void)
 {
@@ -1493,4 +1492,3 @@ ble_phy_rfclk_disable(void)
     NRF_CLOCK->TASKS_HFCLKSTOP = 1;
 #endif
 }
-#endif

--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -2031,7 +2031,7 @@ void ble_phy_disable_dtm(void)
     NRF_RADIO->PCNF1 |= RADIO_PCNF1_WHITEEN_Msk;
 }
 #endif
-#ifdef BLE_XCVR_RFCLK
+
 void
 ble_phy_rfclk_enable(void)
 {
@@ -2051,4 +2051,3 @@ ble_phy_rfclk_disable(void)
     NRF_CLOCK->TASKS_HFCLKSTOP = 1;
 #endif
 }
-#endif


### PR DESCRIPTION
The ble_phy_rfclk_enable function is called even when the settle
time is set to 0 (to turn the HFXO on all the time). That function
was getting compiled out (erroneously) when the settle time gets
set to 0.