### PR TITLE
apps/blemesh: Fix Vendor Model opcode

### DIFF
--- a/apps/blemesh/src/main.c
+++ b/apps/blemesh/src/main.c
@@ -337,9 +337,37 @@ static struct bt_mesh_model root_models[] = {
               &gen_level_pub, NULL),
 };
 
+static struct bt_mesh_model_pub vnd_model_pub;
+
+static void vnd_model_recv(struct bt_mesh_model *model,
+                           struct bt_mesh_msg_ctx *ctx,
+                           struct os_mbuf *buf)
+{
+    struct os_mbuf *msg = NET_BUF_SIMPLE(3);
+
+    console_printf("#vendor-model-recv\n");
+
+    console_printf("data:%s len:%d\n", bt_hex(buf->om_data, buf->om_len),
+                   buf->om_len);
+
+    bt_mesh_model_msg_init(msg, BT_MESH_MODEL_OP_3(0x01, CID_VENDOR));
+    os_mbuf_append(msg, buf->om_data, buf->om_len);
+
+    if (bt_mesh_model_send(model, ctx, msg, NULL, NULL)) {
+        console_printf("#vendor-model-recv: send rsp failed\n");
+    }
+
+    os_mbuf_free_chain(msg);
+}
+
+static const struct bt_mesh_model_op vnd_model_op[] = {
+        { BT_MESH_MODEL_OP_3(0x01, CID_VENDOR), 0, vnd_model_recv },
+        BT_MESH_MODEL_OP_END,
+};
+
 static struct bt_mesh_model vnd_models[] = {
-    BT_MESH_MODEL_VND(CID_VENDOR, BT_MESH_MODEL_ID_GEN_ONOFF_SRV, gen_onoff_op,
-              &gen_onoff_pub, NULL),
+    BT_MESH_MODEL_VND(CID_VENDOR, BT_MESH_MODEL_ID_GEN_ONOFF_SRV, vnd_model_op,
+              &vnd_model_pub, NULL),
 };
 
 static struct bt_mesh_elem elements[] = {


### PR DESCRIPTION
Previously Vendor Model used Generic OnOff opcodes. According
to the spec, vendor models should use 3-octet opcodes.

Mesh Profile Specification, Section 2.3.3:
"An opcode may be a single octet (for special messages that require maximum
possible payload for parameters), 2 octets (for standard messages), or 3 octets
(for vendor-specific messages)."

This patch fixes that, by defining vendor specific opcode
and adds a callback, that reads the received message
and sends it back to the source.