### PR TITLE
nimble/gap: Improve connection parameter update

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -4016,15 +4016,17 @@ ble_gap_update_l2cap_cb(uint16_t conn_handle, int status, void *arg)
     /* Report failures and rejections.  Success gets reported when the
      * controller sends the connection update complete event.
      */
-    if (status != 0) {
-        ble_hs_lock();
-        entry = ble_gap_update_entry_remove(conn_handle);
-        ble_hs_unlock();
 
-        if (entry != NULL) {
-            ble_gap_update_entry_free(entry);
+    ble_hs_lock();
+    entry = ble_gap_update_entry_remove(conn_handle);
+    ble_hs_unlock();
+
+    if (entry != NULL) {
+        ble_gap_update_entry_free(entry);
+        if (status != 0) {
             ble_gap_update_notify(conn_handle, status);
         }
+        /* On success let's wait for the controller to notify about update */
     }
 }
 

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -1128,6 +1128,8 @@ ble_gap_rx_update_complete(struct hci_le_conn_upd_complete *evt)
             entry = ble_gap_update_entry_find(evt->connection_handle, NULL);
             if (entry != NULL && !(conn->bhc_flags & BLE_HS_CONN_F_MASTER)) {
                 ble_gap_update_to_l2cap(&entry->params, &l2cap_params);
+                entry->exp_os_ticks = ble_npl_time_get() +
+                                      ble_npl_time_ms_to_ticks32(BLE_GAP_UPDATE_TIMEOUT_MS);
             }
             break;
 

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -85,7 +85,7 @@
  */
 #define BLE_GAP_CANCEL_RETRY_TIMEOUT_MS         100 /* ms */
 
-#define BLE_GAP_UPDATE_TIMEOUT_MS               30000 /* ms */
+#define BLE_GAP_UPDATE_TIMEOUT_MS               40000 /* ms */
 
 static const struct ble_gap_conn_params ble_gap_conn_params_dflt = {
     .scan_itvl = 0x0010,


### PR DESCRIPTION
This should fix the scenario for Slave when connection parameter update takes longer than GAP_UPDATE_TIMEOUT ms due to connection interval and the instant chosen by the Master