### PR TITLE
nimble/ll: Fix handling TERMINATE_IND as a Master

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -101,6 +101,7 @@ union ble_ll_conn_sm_flags {
         uint32_t pkt_rxd:1;
         uint32_t terminate_ind_txd:1;
         uint32_t terminate_ind_rxd:1;
+        uint32_t terminate_ind_rxd_acked:1;
         uint32_t allow_slave_latency:1;
         uint32_t slave_set_last_anchor:1;
         uint32_t awaiting_host_reply:1;

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1410,6 +1410,9 @@ conn_tx_pdu:
 
         /* Increment packets transmitted */
         if (CONN_F_EMPTY_PDU_TXD(connsm)) {
+            if (connsm->csmflags.cfbit.terminate_ind_rxd) {
+                    connsm->csmflags.cfbit.terminate_ind_rxd_acked = 1;
+            }
             STATS_INC(ble_ll_conn_stats, tx_empty_pdus);
         } else if ((hdr_byte & BLE_LL_DATA_HDR_LLID_MASK) == BLE_LL_LLID_CTRL) {
             STATS_INC(ble_ll_conn_stats, tx_ctrl_pdus);
@@ -2573,7 +2576,8 @@ ble_ll_conn_event_end(struct ble_npl_event *ev)
 
     /* If we have transmitted the terminate IND successfully, we are done */
     if ((connsm->csmflags.cfbit.terminate_ind_txd) ||
-        (connsm->csmflags.cfbit.terminate_ind_rxd)) {
+                    (connsm->csmflags.cfbit.terminate_ind_rxd &&
+                     connsm->csmflags.cfbit.terminate_ind_rxd_acked)) {
         if (connsm->csmflags.cfbit.terminate_ind_txd) {
             ble_err = BLE_ERR_CONN_TERM_LOCAL;
         } else {


### PR DESCRIPTION
When slave sends TERMINATE_IND and MD flag is set to 0, Nimble needs to
wait to next connection event to send Empty Packet to ACK this
TERMINATE_IND.
At the moment Nimble corretly checks MD flag but stop scheduling
connection event which leads to un acked TERMINATE_IND.

This patch fixes that.

This shall fix LL/CON/INI/BV-06-C