### PR TITLE
nimble/host: Stop ble_hs_timer on startup only in unit tests

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -644,10 +644,12 @@ ble_hs_start(void)
 
     ble_hs_parent_task = ble_npl_get_current_task_id();
 
+#if MYNEWT_VAL(SELFTEST)
     /* Stop the timer just in case the host was already running (e.g., unit
      * tests).
      */
     ble_npl_callout_stop(&ble_hs_timer);
+#endif
 
     ble_npl_callout_init(&ble_hs_timer, ble_hs_evq, ble_hs_timer_exp, NULL);
 


### PR DESCRIPTION
`ble_hs_start()` tries to stop `ble_hs_timer` before init to make it work in unit tests which can call `ble_hs_start()` multiple times. Without this extra stop call, callouts list will be corrupted when init is called on a callout which is already queued.

There's no easy way to fix unit tests since it's not quite possible to guarantee that each test case calls `ble_hs_start()` only once without refactoring some of them. To provide a quick fix for this, let's just
call extra stop only for unit tests.

This fixes issue with some NPL implementations which need to allocate some resources for callout on init and thus calling stop before init is not safe (like in Mynewt) and we do not really want to workaround this in NPL by adding checks everywhere.