### PR TITLE
mesh: Fix initializing connection handle for PB GATT

### DIFF
--- a/nimble/host/mesh/src/prov.c
+++ b/nimble/host/mesh/src/prov.c
@@ -1599,6 +1599,10 @@ int bt_mesh_prov_init(const struct bt_mesh_prov *prov_info)
 	rx_buf = NET_BUF_SIMPLE(65);
 #endif
 
+#if (MYNEWT_VAL(BLE_MESH_PB_GATT))
+	link.conn_handle = BLE_HS_CONN_HANDLE_NONE;
+#endif
+
 	if (!prov_info) {
 		BT_ERR("No provisioning context provided");
 		return -EINVAL;


### PR DESCRIPTION
Commit bf1ff83361edd5494637cac69b61a6bb228f9870 introduced a regression
due to not initialized conn handle. Provisioning code would use
GATT bearer even though there was no active connection.