### PR TITLE
nimble/ll: Add API to set controller public address

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -483,6 +483,15 @@ void ble_ll_event_send(struct ble_npl_event *ev);
 /* Hand received pdu's to LL task  */
 void ble_ll_rx_pdu_in(struct os_mbuf *rxpdu);
 
+/*
+ * Set public address
+ *
+ * This can be used to set controller public address from vendor specific storage,
+ * usually should be done in hal_bsp_init().
+ * Shall be *only* called before LL is initialized, i.e. before sysinit stage.
+ */
+int ble_ll_set_public_addr(const uint8_t *addr);
+
 /* Set random address */
 int ble_ll_set_random_addr(uint8_t *addr, bool hci_adv_ext);
 

--- a/nimble/drivers/nrf51/src/ble_hw.c
+++ b/nimble/drivers/nrf51/src/ble_hw.c
@@ -60,33 +60,17 @@ uint8_t g_nrf_num_irks;
 int
 ble_hw_get_public_addr(ble_addr_t *addr)
 {
-    int rc;
-    uint32_t addr_high;
-    uint32_t addr_low;
-
     /* Does FICR have a public address */
-    rc = -1;
-    if ((NRF_FICR->DEVICEADDRTYPE & 1) == 0) {
-        addr_low = NRF_FICR->DEVICEADDR[0];
-        addr_high = NRF_FICR->DEVICEADDR[1];
-        rc = 0;
-    } else {
-        /* See if programmed in UICR. Upper 16 bits must all be zero */
-        addr_high = NRF_UICR->CUSTOMER[1];
-        if (addr_high < 65536) {
-            addr_low = NRF_UICR->CUSTOMER[0];
-            rc = 0;
-        }
+    if ((NRF_FICR->DEVICEADDRTYPE & 1) != 0) {
+        return -1;
     }
 
-    if (!rc) {
-        /* Copy into device address. We can do this because we know platform */
-        memcpy(addr->val, &addr_low, 4);
-        memcpy(&addr->val[4], &addr_high, 2);
-        addr->type = BLE_ADDR_PUBLIC;
-    }
+    /* Copy into device address. We can do this because we know platform */
+    memcpy(addr->val, &NRF_FICR->DEVICEADDR[0], 4);
+    memcpy(&addr->val[4], &NRF_FICR->DEVICEADDR[1], 2);
+    addr->type = BLE_ADDR_PUBLIC;
 
-    return rc;
+    return 0;
 }
 
 /* Returns random static address or -1 if not present */

--- a/nimble/drivers/nrf52/src/ble_hw.c
+++ b/nimble/drivers/nrf52/src/ble_hw.c
@@ -66,33 +66,22 @@ uint8_t g_nrf_num_irks;
 int
 ble_hw_get_public_addr(ble_addr_t *addr)
 {
-    int rc;
     uint32_t addr_high;
     uint32_t addr_low;
 
     /* Does FICR have a public address */
-    rc = -1;
-    if ((NRF_FICR->DEVICEADDRTYPE & 1) == 0) {
-        addr_low = NRF_FICR->DEVICEADDR[0];
-        addr_high = NRF_FICR->DEVICEADDR[1];
-        rc = 0;
-    } else {
-        /* See if programmed in UICR. Upper 16 bits must all be zero */
-        addr_high = NRF_UICR->CUSTOMER[1];
-        if (addr_high < 65536) {
-            addr_low = NRF_UICR->CUSTOMER[0];
-            rc = 0;
-        }
+    if ((NRF_FICR->DEVICEADDRTYPE & 1) != 0) {
+        return -1;
     }
 
-    if (!rc) {
-        /* Copy into device address. We can do this because we know platform */
-        memcpy(addr->val, &addr_low, 4);
-        memcpy(&addr->val[4], &addr_high, 2);
-        addr->type = BLE_ADDR_PUBLIC;
-    }
+    /* Copy into device address. We can do this because we know platform */
+    addr_low = NRF_FICR->DEVICEADDR[0];
+    addr_high = NRF_FICR->DEVICEADDR[1];
+    memcpy(addr->val, &addr_low, 4);
+    memcpy(&addr->val[4], &addr_high, 2);
+    addr->type = BLE_ADDR_PUBLIC;
 
-    return rc;
+    return 0;
 }
 
 /* Returns random static address or -1 if not present */


### PR DESCRIPTION
ble_ll_set_public_addr() can be used to set controller public address.
This API can be called in e.g. hal_bsp_init() to set public address
loaded from some vendor specific location. Address set in this way will
take precedence over address configured in syscfg or stored in HW.

NOTE: This is *NOT* intended to be used to modify public address on
already running device. Using it for such purpose may yield unknown
results.