### PR TITLE
nimble/ll: Set BLE_LL_FEAT_DATA_LEN_EXT as initial feature

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -237,7 +237,7 @@ extern STATS_SECT_DECL(ble_ll_stats) ble_ll_stats;
  * succeed, feature bit will be cleared.
  * Look at LL Features above to find out what is allowed
  */
-#define BLE_LL_CONN_INITIAL_FEATURES    (0x00000002)
+#define BLE_LL_CONN_INITIAL_FEATURES    (0x00000022)
 
 #define BLE_LL_CONN_CLEAR_FEATURE(connsm, feature)   (connsm->conn_features &= ~(feature))
 


### PR DESCRIPTION
We use it in case when Master does not initiate feature exchange.
Note: When remote does not support it, then this bit will be cleared
when handling LL_UNKNOWN_RSP.

It fixes LL/CON/SLA/BV-79-C