### PR TITLE
nimble/ll: Fix encryption pause

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -3989,12 +3989,6 @@ chk_rx_terminate_ind:
         } else {
             /* A slave always replies */
             reply = 1;
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION)
-            if (is_ctrl && (opcode == BLE_LL_CTRL_PAUSE_ENC_REQ)
-                        && (rx_pyld_len == (1 + BLE_LL_CTRL_PAUSE_ENC_REQ_LEN))) {
-                connsm->enc_data.enc_state = CONN_ENC_S_PAUSED;
-            }
-#endif
         }
     }
 

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -1359,6 +1359,12 @@ ble_ll_ctrl_rx_pause_enc_rsp(struct ble_ll_conn_sm *connsm)
 
     if (connsm->conn_role == BLE_LL_CONN_ROLE_MASTER) {
         rc = BLE_LL_CTRL_PAUSE_ENC_RSP;
+    } else if (connsm->enc_data.enc_state == CONN_ENC_S_PAUSE_ENC_RSP_WAIT) {
+        /* Master sends back unencrypted LL_PAUSE_ENC_RSP.
+         * From this moment encryption is paused.
+         */
+        rc = BLE_ERR_MAX;
+        connsm->enc_data.enc_state = CONN_ENC_S_PAUSED;
     } else {
         rc = BLE_LL_CTRL_UNKNOWN_RSP;
     }


### PR DESCRIPTION
Patch: 479eceb5 nimble/ll: Fix handling LL_PAUSE_ENC_REQ
was incorrect because the intention was to handle LL_PAUSE_ENC_RSP as a
slave there. This patch fixes this but if moves handling it into
ble_ll_ctrl.c.

This fix regression on LL/SEC/SLA/BV-02-C