### PR TITLE
nimble/ll: Fix access address computation

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -511,6 +511,7 @@ ble_ll_conn_calc_access_addr(void)
     uint8_t consecutive;
     uint8_t transitions;
     uint8_t ones;
+    int tmp;
 
     /* Calculate a random access address */
     aa = 0;
@@ -525,8 +526,8 @@ ble_ll_conn_calc_access_addr(void)
         }
 
         /* Upper 6 bits must have 2 transitions */
-        temp = aa_high & 0xFC00;
-        if ((temp == 0) || (temp == 0xFC00)) {
+        tmp = (int16_t)aa_high >> 10;
+        if (__builtin_popcount(tmp ^ (tmp >> 1)) < 2) {
             continue;
         }
 


### PR DESCRIPTION
Core 5.0, Vol 6, Part B, section 2.1.2:
    The Access Address shall be a 32-bit value. Each time it needs a
    new Access Address, the Link Layer shall generate a new random value
    that meets the following requirements:
      (...)
      * It shall have a minimum of two transitions in the most
        significant six bits.

Current implementation of the above only checks if there are no
transitions in 6 msb so it can create invalid access address.