### PR TITLE
l2cap: Fix channel creation

### DIFF
--- a/apps/btshell/src/cmd_l2cap.c
+++ b/apps/btshell/src/cmd_l2cap.c
@@ -130,9 +130,11 @@ cmd_l2cap_create_server(int argc, char **argv)
 
     rc = btshell_l2cap_create_srv(psm, accept_response);
     if (rc) {
-        console_printf("Server create error: 0x%02x", rc);
+        console_printf("Server create error: 0x%02x\n", rc);
+        return rc;
     }
 
+    console_printf("Server created successfully\n");
     return 0;
 }
 


### PR DESCRIPTION
Previously the channel was added to the channels list after sending
COC Accept event to the application. The application called
ble_l2cap_coc_recv_ready which was trying to find channel on a list,
but failed. With this patch the channel is added on a list before sending
Accept event, and if the application returns an error, the channel is removed
from the list. Moreover if we fail to send Connection Success, the application
should now not receive a confirmation that we are connected.