### PR TITLE
nimble/ll: Fix update advertising data while advertising

### DIFF
--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -856,6 +856,11 @@ ble_ll_adv_tx_start_cb(struct ble_ll_sched_item *sch)
 
     ble_ll_adv_active_chanset_set_pri(advsm);
 
+    if ((advsm->flags & BLE_LL_ADV_SM_FLAG_NEW_ADV_DATA) ||
+        (advsm->flags & BLE_LL_ADV_SM_FLAG_NEW_SCAN_RSP_DATA)) {
+        goto adv_tx_done;
+    }
+
     /* Set the power */
     ble_phy_txpwr_set(advsm->adv_txpwr);
 


### PR DESCRIPTION
With this patch we make sure that if advertising or scan data has been
changed just after advertising event had been completed, new data will
be used in next advertising event.

Note: For this moment we will skip one advertising event in order to
recalculate timings for aux packet, but this could be improved in the
future.