### PR TITLE
nimble/ll: Fix handling directed advertising with privacy

### DIFF
--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -2878,7 +2878,7 @@ ble_ll_adv_rx_req(uint8_t pdu_type, struct os_mbuf *rxpdu)
          * are doing directed advertising
          */
         if (advsm->props & BLE_HCI_LE_SET_EXT_ADV_PROP_DIRECTED) {
-            if (memcmp(advsm->peer_addr, peer, BLE_DEV_ADDR_LEN)) {
+            if (memcmp(advsm->initiator_addr, peer, BLE_DEV_ADDR_LEN)) {
                 return -1;
             }
         }


### PR DESCRIPTION
Fix incorrect address comparision. advsm->peer_addr is the address
provided via HCI, in the advertising packets we use advsm->initiator_addr
which is either advsm->peer_addr or RPA.

Without this patch it is not possible to connect to Nimble when it
is using RPA in the directed advertising