### PR TITLE
apps/bttester: Add Bluetooth tester application

### DIFF
--- a/apps/bttester/README
+++ b/apps/bttester/README
@@ -1,0 +1,57 @@
+Title: Bluetooth tester application
+
+Description:
+
+Tester application uses binary protocol to control Zephyr stack and is aimed at
+automated testing. It requires two serial ports to operate.
+The first serial is used by Bluetooth Testing Protocol (BTP) to drive Bluetooth
+stack. BTP commands and events are received and buffered for further processing
+over the same serial.
+
+--------------------------------------------------------------------------------
+
+Supported Profiles:
+
+GAP, GATT, SM
+--------------------------------------------------------------------------------
+
+Building and running on QEMU:
+
+QEMU should have connection with the external host Bluetooth hardware.
+The btproxy tool from BlueZ can be used to give access to a Bluetooth controller
+attached to the Linux host OS:
+
+$ sudo tools/btproxy -u
+Listening on /tmp/bt-server-bredr
+
+/tmp/bt-server-bredr option is already set in Makefile through QEMU_EXTRA_FLAGS.
+
+To build tester application for QEMU use BOARD=qemu_cortex_m3 and
+CONF_FILE=qemu.conf. After this qemu can be started through the "run"
+build target.
+
+Note: Target board have to support enough UARTs for BTP and controller.
+      We recommend using qemu_cortex_m3.
+
+'bt-stack-tester' UNIX socket (previously set in Makefile) can be used for now
+to control tester application.
+--------------------------------------------------------------------------------
+
+Building and running on Arduino 101:
+
+Arduino 101 is equipped with Nordic nRF51 Bluetooth LE controller.
+Please refer to the Zephyr Project docs [1] to see how to build and flash the
+controller with the HCI Bluetooth LE firmware.
+
+Next, build and flash tester application by employing the "flash" build
+target.
+
+While running tester application on Arduino 101, serial converter, typically
+UART <-> USB is required by BTP to operate. Connect Arduino 101 Tx and Rx lines
+(0 and 1 ports on Arduino 101 board) through the UART converter to the host
+USB port.
+
+Use serial client, e.g. PUTTY to communicate over the serial port
+(typically /dev/ttyUSBx) with the tester using BTP.
+
+[1] https://www.zephyrproject.org/doc/boards/x86/arduino_101/doc/board.html#flashing-the-bluetooth-core

--- a/apps/bttester/README
+++ b/apps/bttester/README
@@ -2,56 +2,13 @@ Title: Bluetooth tester application
 
 Description:
 
-Tester application uses binary protocol to control Zephyr stack and is aimed at
-automated testing. It requires two serial ports to operate.
-The first serial is used by Bluetooth Testing Protocol (BTP) to drive Bluetooth
-stack. BTP commands and events are received and buffered for further processing
-over the same serial.
-
+Tester application uses binary protocol to control Mynewt Nimble stack
+and is aimed at automated testing. It uses Bluetooth Testing Protocol (BTP)
+to drive Bluetooth stack. BTP commands and events are received and buffered for
+further processing.
 --------------------------------------------------------------------------------
-
 Supported Profiles:
 
-GAP, GATT, SM
+GAP, GATT, SM, L2CAP, MESH
 --------------------------------------------------------------------------------
 
-Building and running on QEMU:
-
-QEMU should have connection with the external host Bluetooth hardware.
-The btproxy tool from BlueZ can be used to give access to a Bluetooth controller
-attached to the Linux host OS:
-
-$ sudo tools/btproxy -u
-Listening on /tmp/bt-server-bredr
-
-/tmp/bt-server-bredr option is already set in Makefile through QEMU_EXTRA_FLAGS.
-
-To build tester application for QEMU use BOARD=qemu_cortex_m3 and
-CONF_FILE=qemu.conf. After this qemu can be started through the "run"
-build target.
-
-Note: Target board have to support enough UARTs for BTP and controller.
-      We recommend using qemu_cortex_m3.
-
-'bt-stack-tester' UNIX socket (previously set in Makefile) can be used for now
-to control tester application.
---------------------------------------------------------------------------------
-
-Building and running on Arduino 101:
-
-Arduino 101 is equipped with Nordic nRF51 Bluetooth LE controller.
-Please refer to the Zephyr Project docs [1] to see how to build and flash the
-controller with the HCI Bluetooth LE firmware.
-
-Next, build and flash tester application by employing the "flash" build
-target.
-
-While running tester application on Arduino 101, serial converter, typically
-UART <-> USB is required by BTP to operate. Connect Arduino 101 Tx and Rx lines
-(0 and 1 ports on Arduino 101 board) through the UART converter to the host
-USB port.
-
-Use serial client, e.g. PUTTY to communicate over the serial port
-(typically /dev/ttyUSBx) with the tester using BTP.
-
-[1] https://www.zephyrproject.org/doc/boards/x86/arduino_101/doc/board.html#flashing-the-bluetooth-core

--- a/apps/bttester/btp_spec.txt
+++ b/apps/bttester/btp_spec.txt
@@ -1,0 +1,1640 @@
+Tester protocol for Bluetooth stack
+***********************************
+
+Copyright (C) 2015  Intel Corporation
+
+
+Overview
+========
+
+This document describes the format of data used for communicating between tester
+and implementation under test (IUT).
+
+The protocol is SOCK_STREAM based and follows a strict PDU specification
+with a generic header and initial registration exchange. The communication is
+driven from tester with commands/response exchange. The protocol is single PDU
+exchanged based, meaning every command requires a response. IUT will use events
+to signal notifications.
+
+Commands and events use single socket. All services are multi-plexed over same
+socket.
+
+	.--  IUT  --.                             .--Tester--.
+	|           |                             |          |
+	|           |          Command            |          |
+	|           | <-------------------------- |          |
+	|           |                             |          |
+	|           |          Response           |          |
+	|           | --------------------------> |          |
+	|           |                             |          |
+	|           |           Event             |          |
+	|           | --------------------------> |          |
+	|           |                             |          |
+	'-----------'                             '----------'
+
+
+Packet Structures
+=================
+
+Every packet will follow the basic header to support simple multi-plexing
+over the same socket. It will also support a basic control channel with service
+id 0. Due to use of single socket for command/response and events it is
+possible that event(s) will be received before response to command.
+
+	0            8       16                  24            40
+	+------------+--------+------------------+-------------+
+	| Service ID | Opcode | Controller Index | Data Length |
+	+------------+--------+------------------+-------------+
+	|                                                      |
+
+The unique service ID is assigned by this specification for each service
+supported by tester.
+
+As general rule of thumb, the opcode for command matches the opcode for a
+response. Or the opcode 0x00 for an error is returned.
+
+Events opcodes start from 0x80.
+
+All fields are in little-endian byte order (least significant byte first).
+
+Controller Index can have a special value <non-controller> to indicate that
+command or event is not related to any controller. Possible values:
+
+	<controller id>		0x00 to 0xFE
+	<non-controller>	0xFF
+
+Error response is common for all services and has fixed structure:
+
+	Opcode 0x00 - Error response
+
+		Response parameters: Status (1 octet)
+
+		Valid status values:	0x01 = Fail
+					0x02 = Unknown Command
+					0x03 = Not ready
+					0x04 = Invalid Index
+
+Core Service (ID 0)
+===================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Read Supported Services command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	<supported services> (variable)
+
+		Each bit in response is a flag indicating if service with ID
+		matching bit number is supported. Bit set to 1 means that
+		service is supported. If specific bit is not present in response
+		(less than required bytes received) it shall be assumed that
+		service is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Register Service command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	Service ID (1 octet)
+		Response parameters:	<none>
+
+		In case a command is sent for an undeclared service ID, it will
+		be rejected. Also there will be no events for undeclared
+		service ID.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Unregister Service command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	Service ID (1 octet)
+		Response parameters:	<none>
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - IUT ready event
+
+		Controller Index:	<non-controller>
+		Event parameters:	<none>
+
+		This event indicates that IUT has been initialized and is ready to
+		receive BTP commands.
+		Tester shall wait for this event before sending any command to the IUT.
+
+GAP Service (ID 1)
+==================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Read Controller Index List command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	Number of Controllers (1 octet)
+					Controller Index[i] (1 octet)
+
+		This command returns the list of controllers.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Read Controller Information command/response
+
+	Controller Index:	<controller id>
+	Command parameters:	<none>
+	Response parameters:	Address (6 Octets)
+				Supported_Settings (4 Octets)
+				Current_Settings (4 Octets)
+				Class_Of_Device (3 Octets)
+				Name (249 Octets)
+				Short_Name (11 Octets)
+
+		This command is used to retrieve the current state and basic
+		information of a controller. It is typically used right after
+		getting the response to the Read Controller Index List command
+
+		Current_Settings and Supported_Settings is a bitmask with
+		currently the following available bits:
+
+			0	Powered
+			1	Connectable
+			2	Fast Connectable
+			3	Discoverable
+			4	Bondable
+			5	Link Level Security (Sec. mode 3)
+			6	Secure Simple Pairing
+			7	Basic Rate/Enhanced Data Rate
+			8	High Speed
+			9	Low Energy
+			10	Advertising
+			11	Secure Connections
+			12	Debug Keys
+			13	Privacy
+			14	Controller Configuration
+			15	Static Address
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Reset command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	Current_Settings (4 Octets)
+
+		This allows to clean up any state data (eg. keys) and restore
+		controller to its default system state.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x05 - Set Powered command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Powered (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Powered values:	0x00 = Off
+					0x01 = On
+
+		This command is used to power on or off a controller.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x06 - Set Connectable command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Connectable (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Connectable values:	0x00 = Off
+						0x01 = On
+
+		This command is used to set controller connectable.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x07 - Set Fast Connectable command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Fast Connectable (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Fast Connectable values:	0x00 = Off
+						0x01 = On
+
+		This command is used to set controller fast connectable.
+		This command is only available for BR/EDR capable controllers.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x08 - Set Discoverable command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Discoverable (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Discoverable values:	0x00 = Off
+						0x01 = General Discoverable
+						0x02 = Limited Discoverable
+
+		This command is used to set controller discoverable.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x09 - Set Bondable command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Bondable (1 octet)
+		Response parameters:	Current_Settings (4 Octets)
+
+		Valid Bondable values:	0x00 = Off
+					0x01 = On
+
+		This command is used to set controller bondable.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0a - Start Advertising command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Adv_Data_Len (1 octet)
+					Scan_Rsp_len (1 octet)
+					Adv_Data (0-255 octets)
+					Scan_Rsp (0-255 octets)
+		Return Parameters:	Current_Settings (4 Octets)
+
+		This command is used to start advertising.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0b - Stop Advertising command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Return Parameters:	Current_Settings (4 Octets)
+
+		This command is used to stop advertising.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0c - Start Discovery command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Flags (1 octet)
+		Return Parameters:	<none>
+
+		Possible values for the Flags parameter are a bit-wise or
+		of the following bits:
+					0 = LE scan
+					1 = BR/EDR scan
+					2 = Use limited discovery procedure
+					3 = Use active scan type
+					4 = Use observation procedure
+
+		This command is used to start discovery.
+
+		Observation Procedure allows to receive advertisements
+		(and scan responses) from broadcasters (that are not visible
+		during General or Limited discovery, because those are not
+		discoverable). This procedure can use either passive or active
+		scan type. If "Use observation procedure" (bit 4) is set,
+		"Use limited discovery procedure" (bit 2) is excluded.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0d - Stop Discovery command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Return Parameters:	<none>
+
+		This command is used to stop discovery.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0e - Connect command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Return Parameters:	<none>
+
+		Valid Address_Type parameter values:
+					0x00 = Public
+					0x01 = Random
+
+		This command is used to create a Link Layer connection with
+		remote device.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0f - Disconnect command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Return Parameters:	<none>
+
+		Valid Address_Type parameter values:
+					0x00 = Public
+					0x01 = Random
+
+		This command is used to terminate an existing connection or
+		to cancel pending connection attempt.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x10 - Set IO Capability command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	IO_Capability (1 octet)
+		Return Parameters:	<none>
+
+		Valid IO_Capabilities parameter values:
+					0x00 = Display Only
+					0x01 = Display Yes/No
+					0x02 = Keyboard Only
+					0x03 = No Input, No Output
+					0x04 = Keyboard Display
+
+		This command is used to set IO capability.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x11 - Pair command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Return Parameters:	<none>
+
+		This command is used to initiate pairing with remote.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x12 - Unpair command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Return Parameters:	<none>
+
+		This command is used to unpair with remote.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x13 - Passkey Entry Response command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Passkey (4 octets)
+		Return Parameters:	<none>
+
+		This command is used to response with passkey for pairing
+		request.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x14 - Passkey Confirmation Response command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Match (1 octet)
+		Return Parameters:	<none>
+
+		This command is used to response for pairing request with
+		confirmation in accordance with initiator and responder
+		passkey.
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - New Settings event
+
+		Controller Index:	<controller id>
+		Event parameters:	Current_Settings (4 octets)
+
+		This event indicates that one or more of the settings for a
+		controller has changed.
+
+	Opcode 0x81 - Device Found event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					RSSI (1 octet)
+					Flags (1 octet)
+					EIR_Data_Length (2 Octets)
+					EIR_Data (0-65535 Octets)
+
+		Possible values for the Flags parameter are a bit-wise or
+		of the following bits:
+					0 = RSSI valid
+					1 = Adv_Data included
+					2 = Scan_Rsp included
+
+		This event indicates that a device was found during device
+		discovery.
+
+	Opcode 0x82 - Device Connected event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates that a device was connected.
+
+	Opcode 0x83 - Device Disconnected event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates that a device was disconnected.
+
+	Opcode 0x84 - Passkey Display event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Passkey (4 octets)
+
+		This event indicates that passkey was received and it needs to
+		be confirmed on remote side.
+
+	Opcode 0x85 - Passkey Enter Request event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates that remote requests for passkey enter.
+
+	Opcode 0x86 - Passkey Confirm Request event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Passkey (4 octets)
+
+		This event indicates that passkey needs to be confirmed.
+
+	Opcode 0x87 - Identity Resolved event
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Identity_Address_Type (1 octet)
+					Identity_Address (6 octets)
+
+		This event indicates that the remote Identity Address has been
+		resolved.
+
+GATT Service (ID 2)
+===================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<non-controller>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Add Service
+
+		Controller Index:	<controller id>
+		Command parameters:	Type (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Service_ID (2 octets)
+
+		Valid Type parameter values:
+					0x00 = Primary
+					0x01 = Secondary
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This command is used to add new service to GATT Server.
+		Service ID of service declaration is returned in the response.
+		Attribute database shall be initiated sequentially.
+		After this issuing this command tester shall add characteristics
+		or included services this service contains.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Add Characteristic
+
+		Controller Index:	<controller id>
+		Command parameters:	Service_ID (2 octets)
+					Properties (1 octet)
+					Permissions (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Characteristic_ID (2 octets)
+
+		Possible values for Service_ID:
+					0x0000 = Add in sequence
+					0x0001-0xffff = Add to service
+
+		Possible response parameters:
+					0x0000 = Relative ID, will be set after
+					start_server
+					0x0001-0xffff = ID in db
+
+		Possible values for the Properties parameter are a bit-wise
+		of the following bits:
+
+			0	Broadcast
+			1	Read
+			2	Write Without Response
+			3	Write
+			4	Notify
+			5	Indicate
+			6	Authenticated Signed Writes
+			7	Extended Properties
+
+		Possible values for the Permissions parameter are a bit-wise
+		of the following bits:
+
+			0	Read
+			1	Write
+			2	Read with Encryption
+			3	Write with Encryption
+			4	Read with Authentication
+			5	Write with Authentication
+			6	Read with Authorization
+			7	Write with Authorization
+
+		This command is used to add new characteristic to GATT Server.
+		Characteristic ID of characteristic declaration is returned in
+		the response.
+		Attribute's database shall be initiated sequentially.
+		After issuing this command tester can add descriptors to this
+		characteristic.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Add Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Characteristic_ID (2 octets)
+					Permissions (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Descriptor_ID (2 octets)
+
+		Possible values for Characteristic_ID:
+					0x0000 = Add in sequence
+					0x0001-0xffff = Add to characteristic
+
+		Possible response parameters:
+					0x0000 = Relative ID, will be set after
+					start_server
+					0x0001-0xffff = ID in db
+
+		This command is used to add new characteristic descriptor
+		to GATT Server. The command shall be used right after
+		Add Characteristic or previous Add Descriptor command.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x05 - Add Included Service
+
+		Controller Index:	<controller id>
+		Command parameters:	Service_ID (2 octets)
+		Response parameters:	Included_Service_ID (2 octets)
+
+		This command is used to add new included service declaration
+		to GATT Server. Service that is going to be included has to be
+		already added to the server. Attribute_ID of include
+		declaration is returned in the response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x06 - Set Characteristic/Descriptor Value
+
+		Controller Index:	<controller id>
+		Command parameters:	Attribute_ID (2 octets)
+					Value_Length (2 octet)
+					Value (1-512 octets)
+		Response parameters:	<none>
+
+		Possible values for Characteristic_ID:
+					0x0000 = Set last attribute in db value
+					0x0001-0xffff = Set value of attribute
+					under ID
+
+		This command is used to set the value of characteristic
+		or descriptor.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x07 - Start Server
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	Database_Attribute_Offset (2 octets)
+					Database_Attribute_Count (1 octet)
+
+		This command is used to start server with previously prepared
+		attributes database. Device database may contain predefined
+		attributes. Predefined attributes should be registered before
+		attempt to register sequential database.
+		Subsequent calls of this command shall return an error.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x08 - Reset Server
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	<none>
+
+		This command is used to clear the server from attributes.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x09 - Set Required Encryption Key Size
+
+		Controller Index:	<controller id>
+		Command parameters:	Attribute_ID (2 octets)
+					Encryption_Key_Size (1 octet)
+		Response parameters:	<none>
+
+		Possible values for Attribute_ID:
+					0x0000 = Set encryption key of last
+					added attribute
+					0x0001-0xffff = Set enctryption of
+					attribute under ID
+
+		This command is used to set required Encryption Key Size of an
+		attribute. It shall be used only if encryption or authentication
+		is needed to have access to this attribute. Otherwise an error
+		shall be returned.
+
+		Possible values for Encryption_Key_Size parameter are:
+								<0x07, 0x0f>
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0a - Exchange MTU
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Response parameters:	<none>
+
+		This command is used by GATT Client to configure ATT protocol.
+		IUT is expected to send Exchange MTU Request to negotiate
+		MTU size.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0b - Discover All Primary Services
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+		Response parameters:	Services_Count (1 octet)
+					[array] Service (variable)
+
+		Object Service is defined as:
+					Start_Handle (2 octets)
+					End_Group_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover all primary
+		services on a server.
+		Services found during discovery are returned in the response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0c - Discover Primary Service by UUID
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Services_Count (1 octet)
+					[array] Service (variable)
+
+		Object Service is defined as:
+					Start_Handle (2 octets)
+					End_Group_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover primary services
+		with specific UUID on a server.
+		Services found during discovery are returned in the response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0d - Find Included Services
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Service_Start_Handle (2 octets)
+					Service_End_Handle (2 octets)
+		Response parameters:	Services_Count (1 octet)
+					[array] Included_Service (variable)
+
+		Object Included_Service is defined as:
+					Included_Handle (2 octets)
+					Type (1 octet)
+					Service (7 or 21 octets)
+
+		Valid Type parameter values:
+					0x00 = Primary
+					0x01 = Secondary
+
+		Object Service is defined as:
+					Start_Handle (2 octets)
+					End_Group_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover service
+		relationships to other services.
+		Services found during discovery are returned in the response.
+
+	Opcode 0x0e - Discover All Characteristics of a Service
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Service_Start_Handle (2 octets)
+					Service_End_Handle (2 octets)
+		Response parameters:	Characteristics_Count (1 octet)
+					[array] Characteristic (variable)
+
+		Object Characteristic is defined as:
+					Characteristic_Handle (2 octets)
+					Value_Handle (2 octets)
+					Properties (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover all
+		characteristics within specified service range.
+		Characteristics found during discovery are returned in the
+		response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0f - Discover Characteristics by UUID
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Start_Handle (2 octets)
+					End_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	Characteristics_Count (1 octet)
+					[array] Characteristic (variable)
+
+		Object Characteristic is defined as:
+					Characteristic_Handle (2 octets)
+					Value_Handle (2 octets)
+					Properties (1 octet)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover characteristic
+		declarations with given UUID on a server.
+		Characteristics found during discovery are returned in the
+		response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x10 - Discover All Characteristic Descriptors
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Start_Handle (2 octets)
+					End_Handle (2 octets)
+		Response parameters:	Descriptors_Count (1 octet)
+					[array] Descriptor (variable)
+
+		Object Descriptor is defined as:
+					Descriptor_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used by a client to discover all the
+		characteristic descriptors contained within characteristic.
+		Descriptors found during discovery are returned in the
+		response.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x11 - Read Characteristic Value/Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+		Response parameters:	ATT_Response (1 octet)
+					Data_Length (2 octets)
+					Data (variable)
+
+		This procedure is used to read a Characteristic Value or
+		Characteristic Descriptor from a server.
+		Read results are returned in the response to this command.
+		ATT_Response shall be set to 0x00, if Read has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x12 - Read Using Characteristic UUID
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Start_Handle (2 octets)
+					End_Handle (2 octets)
+					UUID_Length (1 octet)
+					UUID (2 or 16 octets)
+		Response parameters:	ATT_Response (1 octet)s
+					Data_Length (2 octets)
+					Data (variable)
+
+		Valid UUID_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used to read a Characteristic Value from a
+		server when characteristic UUID is known.
+		Read results are returned in the response to this command.
+		ATT_Response shall be set to 0x00, if Read has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x13 - Read Long Characteristic Value/Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Offset (2 octets)
+		Response parameters:	ATT_Response (1 octet)
+					Data_Length (2 octets)
+					Data (variable)
+
+		This procedure is used to read Long Characteristic Value or
+		Long Characteristic Descriptor from a server.
+		Read results are returned in the response to this command.
+		ATT_Response shall be set to 0x00, if Read has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x14 - Read Multiple Characteristic Values
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handles_Count (1 octet)
+					Handles (variable)
+		Response parameters:	ATT_Response (1 octet)
+					Data_Length (2 octets)
+					Data (variable)
+
+		This procedure is used to read multiple Characteristic Values
+		from a server.
+		Read results are returned in the response to this command.
+		ATT_Response shall be set to 0x00, if Read has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x15 - Write Without Response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	<none>
+
+		This procedure is used to write a Characteristic Value to a
+		server. There is no acknowledgment that the write was
+		successfully performed.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x16 - Signed Write Without Response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	<none>
+
+		This procedure is used to write a Characteristic Value to a
+		server. There is no acknowledgment that the write was
+		successfully performed. This procedure is intended to be used
+		if client and server are bonded, and connected using
+		non-encrypted link.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x17 - Write Characteristic Value/Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	ATT_Response (1 octet)
+
+		This procedure is used to write a Characteristic Value or
+		Characteristic Descriptor to a server.
+		ATT_Response shall be set to 0x00, if Write has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x18 - Write Long Characteristic Value/Descriptor
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Offset (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	ATT_Response (1 octet)
+
+		This procedure is used to write a Long Characteristic Value or
+		Long Characteristic Descriptor to a server.
+		ATT_Response shall be set to 0x00, if Write has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x19 - Reliable Write
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Handle (2 octets)
+					Offset (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+		Response parameters:	ATT_Response (1 octet)
+
+		This procedure is used to write a Characteristic Value to
+		a server and assurance is required that the correct
+		Characteristic Value is going to be written.
+		ATT_Response shall be set to 0x00, if Write has been completed
+		successfully. Otherwise it shall be set to ATT error code
+		received.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x1a - Configure Notifications
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Enable (1 octet)
+					CCC_Handle (2 octets)
+		Response parameters:	<none>
+
+		This procedure is used to configure server to notify
+		characteristic value to a client.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x1b - Configure Indications
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Enable (1 octet)
+					CCC_Handle (2 octets)
+		Response parameters:	<none>
+
+		This procedure is used to configure server to indicate
+		characteristic value to a client.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x1c - Get Attributes
+
+		Controller Index:	<controller id>
+		Command parameters:	Start Handle (2 octets)
+					End Handle (2 octets)
+					Type_Length (1 octet)
+					Type (2 or 16 octets)
+		Response parameters:	Attributes_Count (1 octet)
+					[array] Attribute (variable)
+
+		Object Attribute is defined as:
+					Handle (2 octets)
+					Permission (1 octet)
+					Type_Length (1 octet)
+					Type (2 or 16 octets)
+
+		Valid Type_Length parameter values:
+					0x02 = UUID16
+					0x10 = UUID128
+
+		This procedure is used to query GATT Server for attributes based
+		on given search pattern. Attributes can be searched using
+		Attribute Handle range and Attribute Type.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x1d - Get Attribute Value
+
+		Controller Index:	<controller id>
+		Command parameters:	Handle (2 octets)
+		Response parameters:	ATT_Response (1 octet)
+					Value_Length (2 octet)
+					Value (variable)
+
+		This procedure is used to query GATT Server for attribute value.
+		In case of long attribute value, multiple responses will be
+		sent. BTP_STATUS_SUCCESS response indicates the procedure is
+		finished.
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - Notification/Indication Received
+
+		Controller Index:	<controller id>
+		Event parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					Type (1 octet)
+					Handle (2 octets)
+					Data_Length (2 octets)
+					Data (variable)
+
+		Valid Type parameter values:
+					0x01 = Notification
+					0x02 = Indication
+
+		This event indicates that IUT has received notification
+		or notification.
+
+	Opcode 0x81 - Attribute Value Changed
+
+		Controller Index:	<controller id>
+		Event parameters:	Attribute_ID (2 octets)
+					Data_Length (2 octet)
+					Data (1-512 octets)
+
+		This event command is used to indicate attribute
+		(characteristic or descriptor) value changed.
+		Event is triggered when ATT Write operation to Tester GATT
+		Server has been performed successfully.
+
+L2CAP Service (ID 3)
+==================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Connect command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	Address_Type (1 octet)
+					Address (6 octets)
+					PSM (2 octets)
+		Response parameters:	Chan_ID (1 octet)
+
+		This command is used to create an L2CAP channel.
+		Chan_ID is returned in the response to this command to allow
+		cancellation of this connection request using Disconnect
+		command.
+		Connected Event (or Disconnected Event in case of an error)
+		shall be expected after issuing this command.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Disconnect command
+
+		Controller Index:	<controller id>
+		Command parameters:	Chan_ID (1 octet)
+		Response parameters:	<none>
+
+		This command is used to close an L2CAP channel.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+		Disconnected Event shall be expected after issuing this command.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Send Data command
+
+		Controller Index:	<controller id>
+		Command parameters:	Chan_ID (1 octet)
+					Data_Length (2 octets)
+					Data (Data_Length octets)
+		Response parameters:	<none>
+
+		This command is used to send data over L2CAP channel.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x05 - Listen command
+
+		Controller Index:	<controller id>
+		Command parameters:	PSM (2 octets)
+					Transport (1 octet)
+		Response parameters:	<none>
+
+		Valid Transport parameter values:
+					0x00 = BR/EDR
+					0x01 = LE
+
+		This command is used to register L2CAP PSM and listen for
+		incoming data.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x06 - Accept Connection Request
+
+		Controller Index:	<controller id>
+		Command parameters:	Chan_ID (1 octet)
+					Result (2 octets)
+		Return Parameters:	<none>
+
+		This command is used to accept/reject incoming connection
+		request. Connection can be rejected with non-zero Result value
+		(refer to the L2CAP <LE Credit Based> Connection Result values).
+		Connected Event shall be expected after issuing this command.
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - Connection Request Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Chan_ID (1 octet)
+					PSM (2 octets)
+					Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates incoming request for L2CAP connection.
+		Connection Request needs to be accepted/rejected with result
+		code using Accept Connection Request command.
+
+	Opcode 0x81 - Connected Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Chan_ID (1 octet)
+					PSM (2 octets)
+					Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates new L2CAP connection.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+
+	Opcode 0x82 - Disconnected Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Result (2 octets)
+					Chan_ID (1 octet)
+					PSM (2 octets)
+					Address_Type (1 octet)
+					Address (6 octets)
+
+		This event indicates L2CAP disconnection.
+		Result value is returned in the response, if remote rejected
+		connection request only. Otherwise it shall be set to zero.
+		Please refer to the Core Specification for possible
+		L2CAP <LE Credit Based> Connection Result values.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+
+	Opcode 0x83 - Data Received Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Chan_ID (1 octet)
+					Data_Length (2 octets)
+					Data (Data_Length octets)
+
+		This event forwards data received over L2CAP channel.
+		Chan_ID is the internal application number that identifies
+		L2CAP channel.
+
+Mesh Node Service (ID 4)
+==================
+
+Commands and responses:
+
+	Opcode 0x00 - Error response
+
+	Opcode 0x01 - Read Supported Commands command/response
+
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	<supported commands> (variable)
+
+		Each bit in response is a flag indicating if command with
+		opcode matching bit number is supported. Bit set to 1 means
+		that command is supported. Bit 0 is reserved and shall always
+		be set to 0. If specific bit is not present in response (less
+		than required bytes received) it shall be assumed that command
+		is not supported.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x02 - Configure Provisioning command/response
+		Controller Index:	<controller id>
+		Command parameters:	UUID (16 octets)
+					Static Auth (16 octets)
+					Output Size (1 octet)
+					Output Actions (2 octets)
+					Input Size (1 octet)
+					Input Actions (2 octets)
+
+		This command is used to configure provisioning options.
+
+		Output actions is a bitmask with following available bits:
+			0	Blink
+			1	Beep
+			2	Vibrate
+			3	Display number
+			4	Display string
+
+		Input actions is a bitmask with following available bits:
+			0	Push
+			1	Twist
+			2	Enter number
+			3	Enter string
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x03 - Provision Node command/response
+		Controller Index:	<controller id>
+		Command parameters:	Network Key (16 octets)
+					Network Key Index (2 octets)
+					Provisioning Flags (1 octet)
+					IV Index (4 octets)
+					Sequence Number (4 octets)
+					Primary Element Address (2 octets)
+					Device Key (16 octets)
+
+		This command is used to provide provisioning information. It can
+		be used whenever unprovisioned beacon is advertising or not.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x04 - Init command/response
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to start advertising either as
+		unprovisioned beacon or network node. Action depends on previous
+		configuration.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x05 - Reset command/response
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to reset state of a provisioned node making
+		it to start sending unprovisioned beacons.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x06 - Input number command/response
+		Controller Index:	<controller id>
+		Command parameters:	Number (4 octets)
+
+		This command is used to reply with input number as a response to
+		Input action event.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x07 - Input string command/response
+		Controller Index:	<controller id>
+		Command parameters:	String Length (1 octet)
+					String (variable)
+
+		This command is used to reply with input string as a response to
+		Input action event.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x08 - IV Update Test Mode
+		Controller Index:	<controller id>
+		Command parameters:	Toggle (1 octet)
+
+		Valid Toggle values:
+					0x00 = Disable
+					0x01 = Enable
+
+		This command is used to toggle the IV Update test mode.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x09 - IV Update toggle state
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to make a IV Update state transition
+		while in IV Update test mode, ignoring the 96 hour limit.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0a - Network Send
+		Controller Index:	<controller id>
+		Command parameters:	TTL (1 octet)
+					SRC (2 octets)
+					DST (2 octets)
+					Payload_Len (1 octet)
+					Payload (variable)
+
+		This command is used to send network layer packet.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0b - Health Generate Faults
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+		Response parameters:	Test_ID (1 octet)
+					Current_Faults_Count (1 octet)
+					Registered_Faults_Count (1 octet)
+					Current_Faults (variable)
+					Registered_Faults (variable)
+
+		This command is used to generate health faults on IUT.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0c - Health Clear Faults
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to clear fault arrays on IUT.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0d - Low Power Node
+		Controller Index:	<controller id>
+		Command parameters:	Toggle (1 octet)
+
+		Valid Toggle values:
+					0x00 = Disable
+					0x01 = Enable
+
+		This command is used to toggle the Low Power feature of the
+		local device.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0e - Low Power Node Poll
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to send out a Friend Poll message.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x0f - Model Send
+		Controller Index:	<controller id>
+		Command parameters:	SRC (2 octets)
+					DST (2 octets)
+					Payload_Len (1 octet)
+					Payload (variable)
+
+		This command is used to send Mesh model message.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x10 - Low Power Node Subscribe
+		Controller Index:	<controller id>
+		Command parameters:	Address (2 octets)
+
+		This command is used to send out a Friend Subscription List
+		Add message message.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x11 - Low Power Node Unsubscribe
+		Controller Index:	<controller id>
+		Command parameters:	Address (2 octets)
+
+		This command is used to send out a Friend Subscription List
+		Remove message.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x12 - Clear Replay Protection List Cache
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to clear Replay Protection List Cache.
+
+		In case of an error, the error response will be returned.
+
+	Opcode 0x13 - Enable advertising with Node Identity
+		Controller Index:	<controller id>
+		Command parameters:	<none>
+
+		This command is used to start advertising on each subnet using
+		Node Identity for the next 60 seconds.
+
+		In case of an error, the error response will be returned.
+
+Events:
+	Opcode 0x80 - Output number action Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Action (2 octets)
+					Number (4 octets)
+
+	Opcode 0x81 - Output string action Event
+
+		Controller Index:	<controller id>
+		Event parameters:	String Length (1 octet)
+					String (variable)
+
+	Opcode 0x82 - Input action Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Action (2 octets)
+					Size (1 octet)
+
+		This event indicates that input action is required. Depending
+		on action it may require reply with 'Input number' or
+		'Input string' commands.
+
+		Depending on action either number or string fields are valid.
+
+	Opcode 0x83 - Provisioned Event
+
+		Controller Index:	<controller id>
+		Event parameters:	<none>
+
+		This event indicate that node was provisioned.
+
+	Opcode 0x84 - Link open Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Bearer (1 octet)
+
+		Valid Bearer parameter values:
+
+					0x00 = PB-ADV
+					0x01 = PB-GATT
+
+		This event indicates that provisioning link has been opened on
+		given bearer.
+
+	Opcode 0x85 - Link closed Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Bearer (1 octet)
+
+		Valid Bearer parameter values:
+
+					0x00 = PB-ADV
+					0x01 = PB-GATT
+
+		This event indicates that provisioning link has been closed on
+		given bearer.
+
+	Opcode 0x86 - Network receive Event
+
+		Controller Index:	<controller id>
+		Event parameters:	TTL (1 octet)
+					CTL (1 octet)
+					SRC (2 octets)
+					DST (2 octets)
+					Payload_Len (1 octet)
+					Payload (variable)
+
+		This event indicates reception of network packet.
+
+	Opcode 0x87 - Invalid BearerOpcode Event
+
+		Controller Index:	<controller id>
+		Event parameters:	Opcode (1 octet)
+
+		This event indicates reception of provisioning message with
+		invalid RFU BearerOpcode.
+
+	Opcode 0x88 - Transport Incomplete Timer Expired Event
+
+		Controller Index:	<controller id>
+		Event parameters:	<none>
+
+		This event indicates that segmented message incomplete timer
+		expired.

--- a/apps/bttester/pkg.yml
+++ b/apps/bttester/pkg.yml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: apps/bttester
+pkg.type: app
+pkg.description: Bluetooth tester application
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/shell"
+    - "@apache-mynewt-nimble/nimble/controller"
+    - "@apache-mynewt-nimble/nimble/host"
+    - "@apache-mynewt-nimble/nimble/host/services/gap"
+    - "@apache-mynewt-nimble/nimble/host/services/gatt"
+    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/transport/ram"
+    - "@apache-mynewt-core/hw/drivers/uart"
+    - "@apache-mynewt-core/hw/drivers/rtt"
+

--- a/apps/bttester/src/atomic.h
+++ b/apps/bttester/src/atomic.h
@@ -1,0 +1,386 @@
+/* atomic operations */
+
+/*
+ * Copyright (c) 1997-2015, Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __ATOMIC_H__
+#define __ATOMIC_H__
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef int atomic_t;
+typedef atomic_t atomic_val_t;
+
+/**
+ * @defgroup atomic_apis Atomic Services APIs
+ * @ingroup kernel_apis
+ * @{
+ */
+
+/**
+ * @brief Atomic compare-and-set.
+ *
+ * This routine performs an atomic compare-and-set on @a target. If the current
+ * value of @a target equals @a old_value, @a target is set to @a new_value.
+ * If the current value of @a target does not equal @a old_value, @a target
+ * is left unchanged.
+ *
+ * @param target Address of atomic variable.
+ * @param old_value Original value to compare against.
+ * @param new_value New value to store.
+ * @return 1 if @a new_value is written, 0 otherwise.
+ */
+static inline int atomic_cas(atomic_t *target, atomic_val_t old_value,
+        atomic_val_t new_value)
+{
+    return __atomic_compare_exchange_n(target, &old_value, new_value,
+            0, __ATOMIC_SEQ_CST,
+            __ATOMIC_SEQ_CST);
+}
+
+/**
+ *
+ * @brief Atomic addition.
+ *
+ * This routine performs an atomic addition on @a target.
+ *
+ * @param target Address of atomic variable.
+ * @param value Value to add.
+ *
+ * @return Previous value of @a target.
+ */
+static inline atomic_val_t atomic_add(atomic_t *target, atomic_val_t value)
+{
+    return __atomic_fetch_add(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ *
+ * @brief Atomic subtraction.
+ *
+ * This routine performs an atomic subtraction on @a target.
+ *
+ * @param target Address of atomic variable.
+ * @param value Value to subtract.
+ *
+ * @return Previous value of @a target.
+ */
+
+static inline atomic_val_t atomic_sub(atomic_t *target, atomic_val_t value)
+{
+    return __atomic_fetch_sub(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ *
+ * @brief Atomic increment.
+ *
+ * This routine performs an atomic increment by 1 on @a target.
+ *
+ * @param target Address of atomic variable.
+ *
+ * @return Previous value of @a target.
+ */
+
+static inline atomic_val_t atomic_inc(atomic_t *target)
+{
+    return atomic_add(target, 1);
+}
+
+/**
+ *
+ * @brief Atomic decrement.
+ *
+ * This routine performs an atomic decrement by 1 on @a target.
+ *
+ * @param target Address of atomic variable.
+ *
+ * @return Previous value of @a target.
+ */
+
+static inline atomic_val_t atomic_dec(atomic_t *target)
+{
+    return atomic_sub(target, 1);
+}
+
+/**
+ *
+ * @brief Atomic get.
+ *
+ * This routine performs an atomic read on @a target.
+ *
+ * @param target Address of atomic variable.
+ *
+ * @return Value of @a target.
+ */
+
+static inline atomic_val_t atomic_get(const atomic_t *target)
+{
+    return __atomic_load_n(target, __ATOMIC_SEQ_CST);
+}
+
+/**
+ *
+ * @brief Atomic get-and-set.
+ *
+ * This routine atomically sets @a target to @a value and returns
+ * the previous value of @a target.
+ *
+ * @param target Address of atomic variable.
+ * @param value Value to write to @a target.
+ *
+ * @return Previous value of @a target.
+ */
+
+static inline atomic_val_t atomic_set(atomic_t *target, atomic_val_t value)
+{
+    /* This builtin, as described by Intel, is not a traditional
+     * test-and-set operation, but rather an atomic exchange operation. It
+     * writes value into *ptr, and returns the previous contents of *ptr.
+     */
+    return __atomic_exchange_n(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ *
+ * @brief Atomic clear.
+ *
+ * This routine atomically sets @a target to zero and returns its previous
+ * value. (Hence, it is equivalent to atomic_set(target, 0).)
+ *
+ * @param target Address of atomic variable.
+ *
+ * @return Previous value of @a target.
+ */
+
+static inline atomic_val_t atomic_clear(atomic_t *target)
+{
+    return atomic_set(target, 0);
+}
+
+/**
+ *
+ * @brief Atomic bitwise inclusive OR.
+ *
+ * This routine atomically sets @a target to the bitwise inclusive OR of
+ * @a target and @a value.
+ *
+ * @param target Address of atomic variable.
+ * @param value Value to OR.
+ *
+ * @return Previous value of @a target.
+ */
+
+static inline atomic_val_t atomic_or(atomic_t *target, atomic_val_t value)
+{
+    return __atomic_fetch_or(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ *
+ * @brief Atomic bitwise exclusive OR (XOR).
+ *
+ * This routine atomically sets @a target to the bitwise exclusive OR (XOR) of
+ * @a target and @a value.
+ *
+ * @param target Address of atomic variable.
+ * @param value Value to XOR
+ *
+ * @return Previous value of @a target.
+ */
+
+static inline atomic_val_t atomic_xor(atomic_t *target, atomic_val_t value)
+{
+    return __atomic_fetch_xor(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ *
+ * @brief Atomic bitwise AND.
+ *
+ * This routine atomically sets @a target to the bitwise AND of @a target
+ * and @a value.
+ *
+ * @param target Address of atomic variable.
+ * @param value Value to AND.
+ *
+ * @return Previous value of @a target.
+ */
+
+static inline atomic_val_t atomic_and(atomic_t *target, atomic_val_t value)
+{
+    return __atomic_fetch_and(target, value, __ATOMIC_SEQ_CST);
+}
+
+/**
+ *
+ * @brief Atomic bitwise NAND.
+ *
+ * This routine atomically sets @a target to the bitwise NAND of @a target
+ * and @a value. (This operation is equivalent to target = ~(target & value).)
+ *
+ * @param target Address of atomic variable.
+ * @param value Value to NAND.
+ *
+ * @return Previous value of @a target.
+ */
+
+static inline atomic_val_t atomic_nand(atomic_t *target, atomic_val_t value)
+{
+    return __atomic_fetch_nand(target, value, __ATOMIC_SEQ_CST);
+}
+
+    /**
+     * @brief Initialize an atomic variable.
+     *
+     * This macro can be used to initialize an atomic variable. For example,
+     * @code atomic_t my_var = ATOMIC_INIT(75); @endcode
+     *
+     * @param i Value to assign to atomic variable.
+     */
+#define ATOMIC_INIT(i) (i)
+
+    /**
+     * @cond INTERNAL_HIDDEN
+     */
+
+#define ATOMIC_BITS (sizeof(atomic_val_t) * 8)
+#define ATOMIC_MASK(bit) (1 << ((bit) & (ATOMIC_BITS - 1)))
+#define ATOMIC_ELEM(addr, bit) ((addr) + ((bit) / ATOMIC_BITS))
+
+    /**
+     * INTERNAL_HIDDEN @endcond
+     */
+
+    /**
+     * @brief Define an array of atomic variables.
+     *
+     * This macro defines an array of atomic variables containing at least
+     * @a num_bits bits.
+     *
+     * @note
+     * If used from file scope, the bits of the array are initialized to zero;
+     * if used from within a function, the bits are left uninitialized.
+     *
+     * @param name Name of array of atomic variables.
+     * @param num_bits Number of bits needed.
+     */
+#define ATOMIC_DEFINE(name, num_bits) \
+	atomic_t name[1 + ((num_bits) - 1) / ATOMIC_BITS]
+
+    /**
+     * @brief Atomically test a bit.
+     *
+     * This routine tests whether bit number @a bit of @a target is set or not.
+     * The target may be a single atomic variable or an array of them.
+     *
+     * @param target Address of atomic variable or array.
+     * @param bit Bit number (starting from 0).
+     *
+     * @return 1 if the bit was set, 0 if it wasn't.
+     */
+    static inline int
+    atomic_test_bit(const atomic_t *target, int bit)
+    {
+        atomic_val_t val = atomic_get(ATOMIC_ELEM(target, bit));
+
+        return (1 & (val >> (bit & (ATOMIC_BITS - 1))));
+    }
+
+    /**
+     * @brief Atomically test and clear a bit.
+     *
+     * Atomically clear bit number @a bit of @a target and return its old value.
+     * The target may be a single atomic variable or an array of them.
+     *
+     * @param target Address of atomic variable or array.
+     * @param bit Bit number (starting from 0).
+     *
+     * @return 1 if the bit was set, 0 if it wasn't.
+     */
+    static inline int
+    atomic_test_and_clear_bit(atomic_t *target, int bit)
+    {
+        atomic_val_t mask = ATOMIC_MASK(bit);
+        atomic_val_t old;
+
+        old = atomic_and(ATOMIC_ELEM(target, bit), ~mask);
+
+        return (old & mask) != 0;
+    }
+
+    /**
+     * @brief Atomically set a bit.
+     *
+     * Atomically set bit number @a bit of @a target and return its old value.
+     * The target may be a single atomic variable or an array of them.
+     *
+     * @param target Address of atomic variable or array.
+     * @param bit Bit number (starting from 0).
+     *
+     * @return 1 if the bit was set, 0 if it wasn't.
+     */
+    static inline int
+    atomic_test_and_set_bit(atomic_t *target, int bit)
+    {
+        atomic_val_t mask = ATOMIC_MASK(bit);
+        atomic_val_t old;
+
+        old = atomic_or(ATOMIC_ELEM(target, bit), mask);
+
+        return (old & mask) != 0;
+    }
+
+    /**
+     * @brief Atomically clear a bit.
+     *
+     * Atomically clear bit number @a bit of @a target.
+     * The target may be a single atomic variable or an array of them.
+     *
+     * @param target Address of atomic variable or array.
+     * @param bit Bit number (starting from 0).
+     *
+     * @return N/A
+     */
+    static inline void
+    atomic_clear_bit(atomic_t *target, int bit)
+    {
+        atomic_val_t mask = ATOMIC_MASK(bit);
+
+        atomic_and(ATOMIC_ELEM(target, bit), ~mask);
+    }
+
+    /**
+     * @brief Atomically set a bit.
+     *
+     * Atomically set bit number @a bit of @a target.
+     * The target may be a single atomic variable or an array of them.
+     *
+     * @param target Address of atomic variable or array.
+     * @param bit Bit number (starting from 0).
+     *
+     * @return N/A
+     */
+    static inline void
+    atomic_set_bit(atomic_t *target, int bit)
+    {
+        atomic_val_t mask = ATOMIC_MASK(bit);
+
+        atomic_or(ATOMIC_ELEM(target, bit), mask);
+    }
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ATOMIC_H__ */

--- a/apps/bttester/src/bttester.c
+++ b/apps/bttester/src/bttester.c
@@ -1,0 +1,300 @@
+/* bttester.c - Bluetooth Tester */
+
+/*
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <stdio.h>
+#include <string.h>
+#include <zephyr/types.h>
+
+#include <toolchain.h>
+#include <bluetooth/bluetooth.h>
+#include <misc/byteorder.h>
+#include <console/uart_pipe.h>
+
+#include "bttester.h"
+
+#define STACKSIZE 2048
+static K_THREAD_STACK_DEFINE(stack, STACKSIZE);
+static struct k_thread cmd_thread;
+
+#define CMD_QUEUED 2
+struct btp_buf {
+	u32_t _reserved;
+	union {
+		u8_t data[BTP_MTU];
+		struct btp_hdr hdr;
+	};
+};
+
+static struct btp_buf cmd_buf[CMD_QUEUED];
+
+static K_FIFO_DEFINE(cmds_queue);
+static K_FIFO_DEFINE(avail_queue);
+
+static void supported_commands(u8_t *data, u16_t len)
+{
+	u8_t buf[1];
+	struct core_read_supported_commands_rp *rp = (void *) buf;
+
+	memset(buf, 0, sizeof(buf));
+
+	tester_set_bit(buf, CORE_READ_SUPPORTED_COMMANDS);
+	tester_set_bit(buf, CORE_READ_SUPPORTED_SERVICES);
+	tester_set_bit(buf, CORE_REGISTER_SERVICE);
+	tester_set_bit(buf, CORE_UNREGISTER_SERVICE);
+
+	tester_send(BTP_SERVICE_ID_CORE, CORE_READ_SUPPORTED_COMMANDS,
+		    BTP_INDEX_NONE, (u8_t *) rp, sizeof(buf));
+}
+
+static void supported_services(u8_t *data, u16_t len)
+{
+	u8_t buf[1];
+	struct core_read_supported_services_rp *rp = (void *) buf;
+
+	memset(buf, 0, sizeof(buf));
+
+	tester_set_bit(buf, BTP_SERVICE_ID_CORE);
+	tester_set_bit(buf, BTP_SERVICE_ID_GAP);
+	tester_set_bit(buf, BTP_SERVICE_ID_GATT);
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+	tester_set_bit(buf, BTP_SERVICE_ID_L2CAP);
+#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
+#if defined(CONFIG_BT_MESH)
+	tester_set_bit(buf, BTP_SERVICE_ID_MESH);
+#endif /* CONFIG_BT_MESH */
+
+	tester_send(BTP_SERVICE_ID_CORE, CORE_READ_SUPPORTED_SERVICES,
+		    BTP_INDEX_NONE, (u8_t *) rp, sizeof(buf));
+}
+
+static void register_service(u8_t *data, u16_t len)
+{
+	struct core_register_service_cmd *cmd = (void *) data;
+	u8_t status;
+
+	switch (cmd->id) {
+	case BTP_SERVICE_ID_GAP:
+		status = tester_init_gap();
+		/* Rsp with success status will be handled by bt enable cb */
+		if (status == BTP_STATUS_FAILED) {
+			goto rsp;
+		}
+		return;
+	case BTP_SERVICE_ID_GATT:
+		status = tester_init_gatt();
+		break;
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+	case BTP_SERVICE_ID_L2CAP:
+		status = tester_init_l2cap();
+#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
+		break;
+#if defined(CONFIG_BT_MESH)
+	case BTP_SERVICE_ID_MESH:
+		status = tester_init_mesh();
+		break;
+#endif /* CONFIG_BT_MESH */
+	default:
+		status = BTP_STATUS_FAILED;
+		break;
+	}
+
+rsp:
+	tester_rsp(BTP_SERVICE_ID_CORE, CORE_REGISTER_SERVICE, BTP_INDEX_NONE,
+		   status);
+}
+
+static void unregister_service(u8_t *data, u16_t len)
+{
+	struct core_unregister_service_cmd *cmd = (void *) data;
+	u8_t status;
+
+	switch (cmd->id) {
+	case BTP_SERVICE_ID_GAP:
+		status = tester_unregister_gap();
+		break;
+	case BTP_SERVICE_ID_GATT:
+		status = tester_unregister_gatt();
+		break;
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+	case BTP_SERVICE_ID_L2CAP:
+		status = tester_unregister_l2cap();
+		break;
+#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
+#if defined(CONFIG_BT_MESH)
+	case BTP_SERVICE_ID_MESH:
+		status = tester_unregister_mesh();
+		break;
+#endif /* CONFIG_BT_MESH */
+	default:
+		status = BTP_STATUS_FAILED;
+		break;
+	}
+
+	tester_rsp(BTP_SERVICE_ID_CORE, CORE_UNREGISTER_SERVICE, BTP_INDEX_NONE,
+		   status);
+}
+
+static void handle_core(u8_t opcode, u8_t index, u8_t *data,
+			u16_t len)
+{
+	if (index != BTP_INDEX_NONE) {
+		tester_rsp(BTP_SERVICE_ID_CORE, opcode, index, BTP_STATUS_FAILED);
+		return;
+	}
+
+	switch (opcode) {
+	case CORE_READ_SUPPORTED_COMMANDS:
+		supported_commands(data, len);
+		return;
+	case CORE_READ_SUPPORTED_SERVICES:
+		supported_services(data, len);
+		return;
+	case CORE_REGISTER_SERVICE:
+		register_service(data, len);
+		return;
+	case CORE_UNREGISTER_SERVICE:
+		unregister_service(data, len);
+		return;
+	default:
+		tester_rsp(BTP_SERVICE_ID_CORE, opcode, BTP_INDEX_NONE,
+			   BTP_STATUS_UNKNOWN_CMD);
+		return;
+	}
+}
+
+static void cmd_handler(void *p1, void *p2, void *p3)
+{
+	while (1) {
+		struct btp_buf *cmd;
+		u16_t len;
+
+		cmd = k_fifo_get(&cmds_queue, K_FOREVER);
+
+		len = sys_le16_to_cpu(cmd->hdr.len);
+
+		/* TODO
+		 * verify if service is registered before calling handler
+		 */
+
+		switch (cmd->hdr.service) {
+		case BTP_SERVICE_ID_CORE:
+			handle_core(cmd->hdr.opcode, cmd->hdr.index,
+				    cmd->hdr.data, len);
+			break;
+		case BTP_SERVICE_ID_GAP:
+			tester_handle_gap(cmd->hdr.opcode, cmd->hdr.index,
+					  cmd->hdr.data, len);
+			break;
+		case BTP_SERVICE_ID_GATT:
+			tester_handle_gatt(cmd->hdr.opcode, cmd->hdr.index,
+					   cmd->hdr.data, len);
+			break;
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+		case BTP_SERVICE_ID_L2CAP:
+			tester_handle_l2cap(cmd->hdr.opcode, cmd->hdr.index,
+					    cmd->hdr.data, len);
+#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
+			break;
+#if defined(CONFIG_BT_MESH)
+		case BTP_SERVICE_ID_MESH:
+			tester_handle_mesh(cmd->hdr.opcode, cmd->hdr.index,
+					   cmd->hdr.data, len);
+			break;
+#endif /* CONFIG_BT_MESH */
+		default:
+			tester_rsp(cmd->hdr.service, cmd->hdr.opcode,
+				   cmd->hdr.index, BTP_STATUS_FAILED);
+			break;
+		}
+
+		k_fifo_put(&avail_queue, cmd);
+	}
+}
+
+static u8_t *recv_cb(u8_t *buf, size_t *off)
+{
+	struct btp_hdr *cmd = (void *) buf;
+	struct btp_buf *new_buf;
+	u16_t len;
+
+	if (*off < sizeof(*cmd)) {
+		return buf;
+	}
+
+	len = sys_le16_to_cpu(cmd->len);
+	if (len > BTP_MTU - sizeof(*cmd)) {
+		SYS_LOG_ERR("BT tester: invalid packet length");
+		*off = 0;
+		return buf;
+	}
+
+	if (*off < sizeof(*cmd) + len) {
+		return buf;
+	}
+
+	new_buf =  k_fifo_get(&avail_queue, K_NO_WAIT);
+	if (!new_buf) {
+		SYS_LOG_ERR("BT tester: RX overflow");
+		*off = 0;
+		return buf;
+	}
+
+	k_fifo_put(&cmds_queue, CONTAINER_OF(buf, struct btp_buf, data));
+
+	*off = 0;
+	return new_buf->data;
+}
+
+void tester_init(void)
+{
+	int i;
+	struct btp_buf *buf;
+
+	for (i = 0; i < CMD_QUEUED; i++) {
+		k_fifo_put(&avail_queue, &cmd_buf[i]);
+	}
+
+	k_thread_create(&cmd_thread, stack, STACKSIZE, cmd_handler,
+			NULL, NULL, NULL, K_PRIO_COOP(7), 0, K_NO_WAIT);
+
+	buf = k_fifo_get(&avail_queue, K_NO_WAIT);
+	uart_pipe_register(buf->data, BTP_MTU, recv_cb);
+
+	tester_send(BTP_SERVICE_ID_CORE, CORE_EV_IUT_READY, BTP_INDEX_NONE,
+		    NULL, 0);
+}
+
+void tester_send(u8_t service, u8_t opcode, u8_t index, u8_t *data,
+		 size_t len)
+{
+	struct btp_hdr msg;
+
+	msg.service = service;
+	msg.opcode = opcode;
+	msg.index = index;
+	msg.len = len;
+
+	uart_pipe_send((u8_t *)&msg, sizeof(msg));
+	if (data && len) {
+		uart_pipe_send(data, len);
+	}
+}
+
+void tester_rsp(u8_t service, u8_t opcode, u8_t index, u8_t status)
+{
+	struct btp_status s;
+
+	if (status == BTP_STATUS_SUCCESS) {
+		tester_send(service, opcode, index, NULL, 0);
+		return;
+	}
+
+	s.code = status;
+	tester_send(service, BTP_STATUS, index, (u8_t *) &s, sizeof(s));
+}

--- a/apps/bttester/src/bttester.h
+++ b/apps/bttester/src/bttester.h
@@ -1,0 +1,846 @@
+/* bttester.h - Bluetooth tester headers */
+
+/*
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <misc/util.h>
+
+#define BTP_MTU 1024
+#define BTP_DATA_MAX_SIZE (BTP_MTU - sizeof(struct btp_hdr))
+
+#define BTP_INDEX_NONE		0xff
+
+#define BTP_SERVICE_ID_CORE	0
+#define BTP_SERVICE_ID_GAP	1
+#define BTP_SERVICE_ID_GATT	2
+#define BTP_SERVICE_ID_L2CAP	3
+#define BTP_SERVICE_ID_MESH	4
+
+#define BTP_STATUS_SUCCESS	0x00
+#define BTP_STATUS_FAILED	0x01
+#define BTP_STATUS_UNKNOWN_CMD	0x02
+#define BTP_STATUS_NOT_READY	0x03
+
+#define SYS_LOG_LEVEL SYS_LOG_LEVEL_DEBUG
+#define SYS_LOG_DOMAIN "bttester"
+#include <logging/sys_log.h>
+
+struct btp_hdr {
+	u8_t  service;
+	u8_t  opcode;
+	u8_t  index;
+	u16_t len;
+	u8_t  data[0];
+} __packed;
+
+#define BTP_STATUS			0x00
+struct btp_status {
+	u8_t code;
+} __packed;
+
+/* Core Service */
+#define CORE_READ_SUPPORTED_COMMANDS	0x01
+struct core_read_supported_commands_rp {
+	u8_t data[0];
+} __packed;
+
+#define CORE_READ_SUPPORTED_SERVICES	0x02
+struct core_read_supported_services_rp {
+	u8_t data[0];
+} __packed;
+
+#define CORE_REGISTER_SERVICE		0x03
+struct core_register_service_cmd {
+	u8_t id;
+} __packed;
+
+#define CORE_UNREGISTER_SERVICE		0x04
+struct core_unregister_service_cmd {
+	u8_t id;
+} __packed;
+
+/* events */
+#define CORE_EV_IUT_READY		0x80
+
+/* GAP Service */
+/* commands */
+#define GAP_READ_SUPPORTED_COMMANDS	0x01
+struct gap_read_supported_commands_rp {
+	u8_t data[0];
+} __packed;
+
+#define GAP_READ_CONTROLLER_INDEX_LIST	0x02
+struct gap_read_controller_index_list_rp {
+	u8_t num;
+	u8_t index[0];
+} __packed;
+
+#define GAP_SETTINGS_POWERED		0
+#define GAP_SETTINGS_CONNECTABLE	1
+#define GAP_SETTINGS_FAST_CONNECTABLE	2
+#define GAP_SETTINGS_DISCOVERABLE	3
+#define GAP_SETTINGS_BONDABLE		4
+#define GAP_SETTINGS_LINK_SEC_3		5
+#define GAP_SETTINGS_SSP		6
+#define GAP_SETTINGS_BREDR		7
+#define GAP_SETTINGS_HS			8
+#define GAP_SETTINGS_LE			9
+#define GAP_SETTINGS_ADVERTISING	10
+#define GAP_SETTINGS_SC			11
+#define GAP_SETTINGS_DEBUG_KEYS		12
+#define GAP_SETTINGS_PRIVACY		13
+#define GAP_SETTINGS_CONTROLLER_CONFIG	14
+#define GAP_SETTINGS_STATIC_ADDRESS	15
+
+#define GAP_READ_CONTROLLER_INFO	0x03
+struct gap_read_controller_info_rp {
+	u8_t  address[6];
+	u32_t supported_settings;
+	u32_t current_settings;
+	u8_t  cod[3];
+	u8_t  name[249];
+	u8_t  short_name[11];
+} __packed;
+
+#define GAP_RESET			0x04
+struct gap_reset_rp {
+	u32_t current_settings;
+} __packed;
+
+#define GAP_SET_POWERED			0x05
+struct gap_set_powered_cmd {
+	u8_t powered;
+} __packed;
+struct gap_set_powered_rp {
+	u32_t current_settings;
+} __packed;
+
+#define GAP_SET_CONNECTABLE		0x06
+struct gap_set_connectable_cmd {
+	u8_t connectable;
+} __packed;
+struct gap_set_connectable_rp {
+	u32_t current_settings;
+} __packed;
+
+#define GAP_SET_FAST_CONNECTABLE	0x07
+struct gap_set_fast_connectable_cmd {
+	u8_t fast_connectable;
+} __packed;
+struct gap_set_fast_connectable_rp {
+	u32_t current_settings;
+} __packed;
+
+#define GAP_NON_DISCOVERABLE		0x00
+#define GAP_GENERAL_DISCOVERABLE	0x01
+#define GAP_LIMITED_DISCOVERABLE	0x02
+
+#define GAP_SET_DISCOVERABLE		0x08
+struct gap_set_discoverable_cmd {
+	u8_t discoverable;
+} __packed;
+struct gap_set_discoverable_rp {
+	u32_t current_settings;
+} __packed;
+
+#define GAP_SET_BONDABLE		0x09
+struct gap_set_bondable_cmd {
+	u8_t gap_set_bondable_cmd;
+} __packed;
+struct gap_set_bondable_rp {
+	u32_t current_settings;
+} __packed;
+
+#define GAP_START_ADVERTISING	0x0a
+struct gap_start_advertising_cmd {
+	u8_t adv_data_len;
+	u8_t scan_rsp_len;
+	u8_t adv_data[0];
+	u8_t scan_rsp[0];
+} __packed;
+struct gap_start_advertising_rp {
+	u32_t current_settings;
+} __packed;
+
+#define GAP_STOP_ADVERTISING		0x0b
+struct gap_stop_advertising_rp {
+	u32_t current_settings;
+} __packed;
+
+#define GAP_DISCOVERY_FLAG_LE			0x01
+#define GAP_DISCOVERY_FLAG_BREDR		0x02
+#define GAP_DISCOVERY_FLAG_LIMITED		0x04
+#define GAP_DISCOVERY_FLAG_LE_ACTIVE_SCAN	0x08
+#define GAP_DISCOVERY_FLAG_LE_OBSERVE		0x10
+
+#define GAP_START_DISCOVERY		0x0c
+struct gap_start_discovery_cmd {
+	u8_t flags;
+} __packed;
+
+#define GAP_STOP_DISCOVERY		0x0d
+
+#define GAP_CONNECT			0x0e
+struct gap_connect_cmd {
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
+#define GAP_DISCONNECT			0x0f
+struct gap_disconnect_cmd {
+	u8_t  address_type;
+	u8_t  address[6];
+} __packed;
+
+#define GAP_IO_CAP_DISPLAY_ONLY		0
+#define GAP_IO_CAP_DISPLAY_YESNO	1
+#define GAP_IO_CAP_KEYBOARD_ONLY	2
+#define GAP_IO_CAP_NO_INPUT_OUTPUT	3
+#define GAP_IO_CAP_KEYBOARD_DISPLAY	4
+
+#define GAP_SET_IO_CAP			0x10
+struct gap_set_io_cap_cmd {
+	u8_t io_cap;
+} __packed;
+
+#define GAP_PAIR			0x11
+struct gap_pair_cmd {
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
+#define GAP_UNPAIR			0x12
+struct gap_unpair_cmd {
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
+#define GAP_PASSKEY_ENTRY		0x13
+struct gap_passkey_entry_cmd {
+	u8_t  address_type;
+	u8_t  address[6];
+	u32_t passkey;
+} __packed;
+
+#define GAP_PASSKEY_CONFIRM		0x14
+struct gap_passkey_confirm_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u8_t match;
+} __packed;
+
+/* events */
+#define GAP_EV_NEW_SETTINGS		0x80
+struct gap_new_settings_ev {
+	u32_t current_settings;
+} __packed;
+
+#define GAP_DEVICE_FOUND_FLAG_RSSI	0x01
+#define GAP_DEVICE_FOUND_FLAG_AD	0x02
+#define GAP_DEVICE_FOUND_FLAG_SD	0x04
+
+#define GAP_EV_DEVICE_FOUND		0x81
+struct gap_device_found_ev {
+	u8_t  address_type;
+	u8_t  address[6];
+	s8_t   rssi;
+	u8_t  flags;
+	u16_t eir_data_len;
+	u8_t  eir_data[0];
+} __packed;
+
+#define GAP_EV_DEVICE_CONNECTED		0x82
+struct gap_device_connected_ev {
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
+#define GAP_EV_DEVICE_DISCONNECTED	0x83
+struct gap_device_disconnected_ev {
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
+#define GAP_EV_PASSKEY_DISPLAY		0x84
+struct gap_passkey_display_ev {
+	u8_t  address_type;
+	u8_t  address[6];
+	u32_t passkey;
+} __packed;
+
+#define GAP_EV_PASSKEY_ENTRY_REQ	0x85
+struct gap_passkey_entry_req_ev {
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
+#define GAP_EV_PASSKEY_CONFIRM_REQ	0x86
+struct gap_passkey_confirm_req_ev {
+	u8_t  address_type;
+	u8_t  address[6];
+	u32_t passkey;
+} __packed;
+
+#define GAP_EV_IDENTITY_RESOLVED	0x87
+struct gap_identity_resolved_ev {
+	u8_t address_type;
+	u8_t address[6];
+	u8_t identity_address_type;
+	u8_t identity_address[6];
+} __packed;
+
+/* GATT Service */
+/* commands */
+#define GATT_READ_SUPPORTED_COMMANDS	0x01
+struct gatt_read_supported_commands_rp {
+	u8_t data[0];
+} __packed;
+
+#define GATT_SERVICE_PRIMARY		0x00
+#define GATT_SERVICE_SECONDARY		0x01
+
+#define GATT_ADD_SERVICE		0x02
+struct gatt_add_service_cmd {
+	u8_t type;
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+struct gatt_add_service_rp {
+	u16_t svc_id;
+} __packed;
+
+#define GATT_ADD_CHARACTERISTIC		0x03
+struct gatt_add_characteristic_cmd {
+	u16_t svc_id;
+	u8_t properties;
+	u8_t permissions;
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+struct gatt_add_characteristic_rp {
+	u16_t char_id;
+} __packed;
+
+#define GATT_ADD_DESCRIPTOR		0x04
+struct gatt_add_descriptor_cmd {
+	u16_t char_id;
+	u8_t permissions;
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+struct gatt_add_descriptor_rp {
+	u16_t desc_id;
+} __packed;
+
+#define GATT_ADD_INCLUDED_SERVICE	0x05
+struct gatt_add_included_service_cmd {
+	u16_t svc_id;
+} __packed;
+struct gatt_add_included_service_rp {
+	u16_t included_service_id;
+} __packed;
+
+#define GATT_SET_VALUE			0x06
+	struct gatt_set_value_cmd {
+	u16_t attr_id;
+	u16_t len;
+	u8_t value[0];
+} __packed;
+
+#define GATT_START_SERVER		0x07
+struct gatt_start_server_rp {
+	u16_t db_attr_off;
+	u8_t db_attr_cnt;
+} __packed;
+
+#define GATT_SET_ENC_KEY_SIZE		0x09
+struct gatt_set_enc_key_size_cmd {
+	u16_t attr_id;
+	u8_t key_size;
+} __packed;
+
+/* Gatt Client */
+struct gatt_service {
+	u16_t start_handle;
+	u16_t end_handle;
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+
+struct gatt_included {
+	u16_t included_handle;
+	struct gatt_service service;
+} __packed;
+
+struct gatt_characteristic {
+	u16_t characteristic_handle;
+	u16_t value_handle;
+	u8_t properties;
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+
+struct gatt_descriptor {
+	u16_t descriptor_handle;
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+
+#define GATT_EXCHANGE_MTU		0x0a
+
+#define GATT_DISC_PRIM_UUID		0x0c
+struct gatt_disc_prim_uuid_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+struct gatt_disc_prim_uuid_rp {
+	u8_t services_count;
+	struct gatt_service services[0];
+} __packed;
+
+#define GATT_FIND_INCLUDED		0x0d
+struct gatt_find_included_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t start_handle;
+	u16_t end_handle;
+} __packed;
+struct gatt_find_included_rp {
+	u8_t services_count;
+	struct gatt_included included[0];
+} __packed;
+
+#define GATT_DISC_ALL_CHRC		0x0e
+struct gatt_disc_all_chrc_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t start_handle;
+	u16_t end_handle;
+} __packed;
+struct gatt_disc_chrc_rp {
+	u8_t characteristics_count;
+	struct gatt_characteristic characteristics[0];
+} __packed;
+
+#define GATT_DISC_CHRC_UUID		0x0f
+struct gatt_disc_chrc_uuid_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t start_handle;
+	u16_t end_handle;
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+
+#define GATT_DISC_ALL_DESC		0x10
+struct gatt_disc_all_desc_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t start_handle;
+	u16_t end_handle;
+} __packed;
+struct gatt_disc_all_desc_rp {
+	u8_t descriptors_count;
+	struct gatt_descriptor descriptors[0];
+} __packed;
+
+#define GATT_READ			0x11
+struct gatt_read_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t handle;
+} __packed;
+struct gatt_read_rp {
+	u8_t att_response;
+	u16_t data_length;
+	u8_t data[0];
+} __packed;
+
+#define GATT_READ_LONG			0x13
+struct gatt_read_long_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t handle;
+	u16_t offset;
+} __packed;
+
+#define GATT_READ_MULTIPLE		0x14
+struct gatt_read_multiple_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u8_t handles_count;
+	u16_t handles[0];
+} __packed;
+
+#define GATT_WRITE_WITHOUT_RSP		0x15
+struct gatt_write_without_rsp_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t handle;
+	u16_t data_length;
+	u8_t data[0];
+} __packed;
+
+#define GATT_SIGNED_WRITE_WITHOUT_RSP	0x16
+struct gatt_signed_write_without_rsp_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t handle;
+	u16_t data_length;
+	u8_t data[0];
+} __packed;
+
+#define GATT_WRITE			0x17
+struct gatt_write_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t handle;
+	u16_t data_length;
+	u8_t data[0];
+} __packed;
+
+#define GATT_WRITE_LONG			0x18
+struct gatt_write_long_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t handle;
+	u16_t offset;
+	u16_t data_length;
+	u8_t data[0];
+} __packed;
+
+#define GATT_CFG_NOTIFY			0x1a
+#define GATT_CFG_INDICATE		0x1b
+struct gatt_cfg_notify_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u8_t enable;
+	u16_t ccc_handle;
+} __packed;
+
+#define GATT_GET_ATTRIBUTES		0x1c
+struct gatt_get_attributes_cmd {
+	u16_t start_handle;
+	u16_t end_handle;
+	u8_t type_length;
+	u8_t type[0];
+} __packed;
+struct gatt_get_attributes_rp {
+	u8_t attrs_count;
+	u8_t attrs[0];
+} __packed;
+struct gatt_attr {
+	u16_t handle;
+	u8_t permission;
+	u8_t type_length;
+	u8_t type[0];
+} __packed;
+
+#define GATT_GET_ATTRIBUTE_VALUE	0x1d
+struct gatt_get_attribute_value_cmd {
+	u16_t handle;
+} __packed;
+struct gatt_get_attribute_value_rp {
+	u8_t att_response;
+	u16_t value_length;
+	u8_t value[0];
+} __packed;
+
+/* GATT events */
+#define GATT_EV_NOTIFICATION		0x80
+struct gatt_notification_ev {
+	u8_t address_type;
+	u8_t address[6];
+	u8_t type;
+	u16_t handle;
+	u16_t data_length;
+	u8_t data[0];
+} __packed;
+
+#define GATT_EV_ATTR_VALUE_CHANGED	0x81
+struct gatt_attr_value_changed_ev {
+	u16_t handle;
+	u16_t data_length;
+	u8_t data[0];
+} __packed;
+
+static inline void tester_set_bit(u8_t *addr, unsigned int bit)
+{
+	u8_t *p = addr + (bit / 8);
+
+	*p |= BIT(bit % 8);
+}
+
+static inline u8_t tester_test_bit(const u8_t *addr, unsigned int bit)
+{
+	const u8_t *p = addr + (bit / 8);
+
+	return *p & BIT(bit % 8);
+}
+
+/* L2CAP Service */
+/* commands */
+#define L2CAP_READ_SUPPORTED_COMMANDS	0x01
+struct l2cap_read_supported_commands_rp {
+	u8_t data[0];
+} __packed;
+
+#define L2CAP_CONNECT			0x02
+struct l2cap_connect_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t psm;
+} __packed;
+
+struct l2cap_connect_rp {
+	u8_t chan_id;
+} __packed;
+
+#define L2CAP_DISCONNECT		0x03
+struct l2cap_disconnect_cmd {
+	u8_t chan_id;
+} __packed;
+
+#define L2CAP_SEND_DATA			0x04
+struct l2cap_send_data_cmd {
+	u8_t chan_id;
+	u16_t data_len;
+	u8_t data[];
+} __packed;
+
+#define L2CAP_TRANSPORT_BREDR		0x00
+#define L2CAP_TRANSPORT_LE		0x01
+
+#define L2CAP_LISTEN			0x05
+struct l2cap_listen_cmd {
+	u16_t psm;
+	u8_t transport;
+} __packed;
+
+#define L2CAP_ACCEPT_CONNECTION		0x06
+struct l2cap_accept_connection_cmd {
+	u8_t chan_id;
+	u16_t result;
+} __packed;
+
+/* events */
+#define L2CAP_EV_CONNECTION_REQ		0x80
+struct l2cap_connection_req_ev {
+	u8_t chan_id;
+	u16_t psm;
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
+#define L2CAP_EV_CONNECTED		0x81
+struct l2cap_connected_ev {
+	u8_t chan_id;
+	u16_t psm;
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
+#define L2CAP_EV_DISCONNECTED		0x82
+struct l2cap_disconnected_ev {
+	u16_t result;
+	u8_t chan_id;
+	u16_t psm;
+	u8_t address_type;
+	u8_t address[6];
+} __packed;
+
+#define L2CAP_EV_DATA_RECEIVED		0x83
+struct l2cap_data_received_ev {
+	u8_t chan_id;
+	u16_t data_length;
+	u8_t data[0];
+} __packed;
+
+/* MESH Service */
+/* commands */
+#define MESH_READ_SUPPORTED_COMMANDS	0x01
+struct mesh_read_supported_commands_rp {
+	u8_t data[0];
+} __packed;
+
+#define MESH_OUT_BLINK			BIT(0)
+#define MESH_OUT_BEEP			BIT(1)
+#define MESH_OUT_VIBRATE		BIT(2)
+#define MESH_OUT_DISPLAY_NUMBER		BIT(3)
+#define MESH_OUT_DISPLAY_STRING		BIT(4)
+
+#define MESH_IN_PUSH			BIT(0)
+#define MESH_IN_TWIST			BIT(1)
+#define MESH_IN_ENTER_NUMBER		BIT(2)
+#define MESH_IN_ENTER_STRING		BIT(3)
+
+#define MESH_CONFIG_PROVISIONING	0x02
+struct mesh_config_provisioning_cmd {
+	u8_t uuid[16];
+	u8_t static_auth[16];
+	u8_t out_size;
+	u16_t out_actions;
+	u8_t in_size;
+	u16_t in_actions;
+} __packed;
+
+#define MESH_PROVISION_NODE		0x03
+struct mesh_provision_node_cmd {
+	u8_t net_key[16];
+	u16_t net_key_idx;
+	u8_t flags;
+	u32_t iv_index;
+	u32_t seq_num;
+	u16_t addr;
+	u8_t dev_key[16];
+} __packed;
+
+#define MESH_INIT			0x04
+#define MESH_RESET			0x05
+#define MESH_INPUT_NUMBER		0x06
+struct mesh_input_number_cmd {
+	u32_t number;
+} __packed;
+
+#define MESH_INPUT_STRING		0x07
+struct mesh_input_string_cmd {
+	u8_t string_len;
+	u8_t string[0];
+} __packed;
+
+#define MESH_IVU_TEST_MODE		0x08
+struct mesh_ivu_test_mode_cmd {
+	u8_t enable;
+} __packed;
+
+#define MESH_IVU_TOGGLE_STATE			0x09
+
+#define MESH_NET_SEND			0x0a
+struct mesh_net_send_cmd {
+	u8_t ttl;
+	u16_t src;
+	u16_t dst;
+	u8_t payload_len;
+	u8_t payload[0];
+} __packed;
+
+#define MESH_HEALTH_GENERATE_FAULTS	0x0b
+struct mesh_health_generate_faults_rp {
+	u8_t test_id;
+	u8_t cur_faults_count;
+	u8_t reg_faults_count;
+	u8_t current_faults[0];
+	u8_t registered_faults[0];
+} __packed;
+
+#define MESH_HEALTH_CLEAR_FAULTS	0x0c
+
+#define MESH_LPN			0x0d
+struct mesh_lpn_set_cmd {
+	u8_t enable;
+} __packed;
+
+#define MESH_LPN_POLL			0x0e
+
+#define MESH_MODEL_SEND			0x0f
+struct mesh_model_send_cmd {
+	u16_t src;
+	u16_t dst;
+	u8_t payload_len;
+	u8_t payload[0];
+} __packed;
+
+#define MESH_LPN_SUBSCRIBE		0x10
+struct mesh_lpn_subscribe_cmd {
+	u16_t address;
+} __packed;
+
+#define MESH_LPN_UNSUBSCRIBE		0x11
+struct mesh_lpn_unsubscribe_cmd {
+	u16_t address;
+} __packed;
+
+#define MESH_RPL_CLEAR			0x12
+#define MESH_PROXY_IDENTITY		0x13
+
+/* events */
+#define MESH_EV_OUT_NUMBER_ACTION	0x80
+struct mesh_out_number_action_ev {
+	u16_t action;
+	u32_t number;
+} __packed;
+
+#define MESH_EV_OUT_STRING_ACTION	0x81
+struct mesh_out_string_action_ev {
+	u8_t string_len;
+	u8_t string[0];
+} __packed;
+
+#define MESH_EV_IN_ACTION		0x82
+struct mesh_in_action_ev {
+	u16_t action;
+	u8_t size;
+} __packed;
+
+#define MESH_EV_PROVISIONED		0x83
+
+#define MESH_PROV_BEARER_PB_ADV		0x00
+#define MESH_PROV_BEARER_PB_GATT	0x01
+#define MESH_EV_PROV_LINK_OPEN		0x84
+struct mesh_prov_link_open_ev {
+	u8_t bearer;
+} __packed;
+
+#define MESH_EV_PROV_LINK_CLOSED	0x85
+struct mesh_prov_link_closed_ev {
+	u8_t bearer;
+} __packed;
+
+#define MESH_EV_NET_RECV		0x86
+struct mesh_net_recv_ev {
+	u8_t ttl;
+	u8_t ctl;
+	u16_t src;
+	u16_t dst;
+	u8_t payload_len;
+	u8_t payload[0];
+} __packed;
+
+#define MESH_EV_INVALID_BEARER		0x87
+struct mesh_invalid_bearer_ev {
+	u8_t opcode;
+} __packed;
+
+#define MESH_EV_INCOMP_TIMER_EXP	0x88
+
+void tester_init(void);
+void tester_rsp(u8_t service, u8_t opcode, u8_t index, u8_t status);
+void tester_send(u8_t service, u8_t opcode, u8_t index, u8_t *data,
+		 size_t len);
+
+u8_t tester_init_gap(void);
+u8_t tester_unregister_gap(void);
+void tester_handle_gap(u8_t opcode, u8_t index, u8_t *data,
+		       u16_t len);
+u8_t tester_init_gatt(void);
+u8_t tester_unregister_gatt(void);
+void tester_handle_gatt(u8_t opcode, u8_t index, u8_t *data,
+			u16_t len);
+
+#if defined(CONFIG_BT_L2CAP_DYNAMIC_CHANNEL)
+u8_t tester_init_l2cap(void);
+u8_t tester_unregister_l2cap(void);
+void tester_handle_l2cap(u8_t opcode, u8_t index, u8_t *data,
+			 u16_t len);
+#endif /* CONFIG_BT_L2CAP_DYNAMIC_CHANNEL */
+
+#if defined(CONFIG_BT_MESH)
+u8_t tester_init_mesh(void);
+u8_t tester_unregister_mesh(void);
+void tester_handle_mesh(u8_t opcode, u8_t index, u8_t *data, u16_t len);
+#endif /* CONFIG_BT_MESH */

--- a/apps/bttester/src/bttester_pipe.h
+++ b/apps/bttester/src/bttester_pipe.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __BTTESTER_PIPE_H__
+#define __BTTESTER_PIPE_H__
+
+#include <stdlib.h>
+#include "bttester.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef u8_t *(*bttester_pipe_recv_cb)(u8_t *buf, size_t *off);
+void bttester_pipe_register(u8_t *buf, size_t len, bttester_pipe_recv_cb cb);
+int bttester_pipe_send(const u8_t *data, int len);
+int bttester_pipe_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BTTESTER_PIPE_H__ */

--- a/apps/bttester/src/gap.c
+++ b/apps/bttester/src/gap.c
@@ -6,82 +6,73 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <atomic.h>
-#include <zephyr/types.h>
-#include <string.h>
+#include "host/ble_gap.h"
+#include "console/console.h"
 
-#include <toolchain.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
+#include "../../../../apache-mynewt-nimble/nimble/host/src/ble_hs_pvcy_priv.h"
+#include "../../../nimble/host/src/ble_hs_hci_priv.h"
+#include "../../../nimble/host/src/ble_sm_priv.h"
 
-#include <misc/byteorder.h>
-#include <net/buf.h>
-
+#include "atomic.h"
 #include "bttester.h"
 
 #define CONTROLLER_INDEX 0
 #define CONTROLLER_NAME "btp_tester"
 
-#define BT_LE_AD_DISCOV_MASK (BT_LE_AD_LIMITED | BT_LE_AD_GENERAL)
+#define BLE_AD_DISCOV_MASK (BLE_HS_ADV_F_DISC_LTD | BLE_HS_ADV_F_DISC_GEN)
 #define ADV_BUF_LEN (sizeof(struct gap_device_found_ev) + 2 * 31)
 
+const uint8_t irk[16] = {
+	0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+	0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+};
+
+#if MYNEWT_VAL(BTTESTER_CONN_PARAM_UPDATE)
+struct hal_timer conn_param_update_timer;
+#endif
 static atomic_t current_settings;
-struct bt_conn_auth_cb cb;
+static u8_t own_addr_type = BLE_OWN_ADDR_PUBLIC;
+static ble_addr_t peer_id_addr;
+static ble_addr_t peer_ota_addr;
+static bool encrypted = false;
 
-static void le_connected(struct bt_conn *conn, u8_t err)
+static int gap_conn_find_by_addr(const ble_addr_t *dev_addr,
+				 struct ble_gap_conn_desc *out_desc)
 {
-	struct gap_device_connected_ev ev;
-	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
+	ble_addr_t addr = *dev_addr;
 
-	if (err) {
-		return;
+	if (memcmp(BLE_ADDR_ANY, &peer_id_addr, 6) == 0) {
+		return ble_gap_conn_find_by_addr(&addr, out_desc);
 	}
 
-	memcpy(ev.address, addr->a.val, sizeof(ev.address));
-	ev.address_type = addr->type;
+	if (BLE_ADDR_IS_RPA(&addr)) {
+		if(ble_addr_cmp(&peer_ota_addr, &addr) != 0) {
+			return -1;
+		}
 
-	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_CONNECTED,
-		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+		return ble_gap_conn_find_by_addr(&addr, out_desc);
+	} else {
+		if(ble_addr_cmp(&peer_id_addr, &addr) != 0) {
+			return -1;
+		}
+
+		if (BLE_ADDR_IS_RPA(&peer_ota_addr)) {
+			/* Change addr type to ID addr */
+			addr.type |= 2;
+		}
+
+		return ble_gap_conn_find_by_addr(&addr, out_desc);
+	}
 }
 
-static void le_disconnected(struct bt_conn *conn, u8_t reason)
-{
-	struct gap_device_disconnected_ev ev;
-	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
-
-	memcpy(ev.address, addr->a.val, sizeof(ev.address));
-	ev.address_type = addr->type;
-
-	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_DISCONNECTED,
-		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
-}
-
-static void le_identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
-				 const bt_addr_le_t *identity)
-{
-	struct gap_identity_resolved_ev ev;
-
-	ev.address_type = rpa->type;
-	memcpy(ev.address, rpa->a.val, sizeof(ev.address));
-
-	ev.identity_address_type = identity->type;
-	memcpy(ev.identity_address, identity->a.val,
-	       sizeof(ev.identity_address));
-
-	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_IDENTITY_RESOLVED,
-		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
-}
-
-static struct bt_conn_cb conn_callbacks = {
-	.connected = le_connected,
-	.disconnected = le_disconnected,
-	.identity_resolved = le_identity_resolved,
-};
+static int gap_event_cb(struct ble_gap_event *event, void *arg);
 
 static void supported_commands(u8_t *data, u16_t len)
 {
 	u8_t cmds[3];
 	struct gap_read_supported_commands_rp *rp = (void *) &cmds;
+
+	SYS_LOG_DBG("");
 
 	memset(cmds, 0, sizeof(cmds));
 
@@ -98,6 +89,7 @@ static void supported_commands(u8_t *data, u16_t len)
 	tester_set_bit(cmds, GAP_DISCONNECT);
 	tester_set_bit(cmds, GAP_SET_IO_CAP);
 	tester_set_bit(cmds, GAP_PAIR);
+	tester_set_bit(cmds, GAP_UNPAIR);
 	tester_set_bit(cmds, GAP_PASSKEY_ENTRY);
 
 	tester_send(BTP_SERVICE_ID_GAP, GAP_READ_SUPPORTED_COMMANDS,
@@ -108,6 +100,8 @@ static void controller_index_list(u8_t *data,  u16_t len)
 {
 	struct gap_read_controller_index_list_rp *rp;
 	u8_t buf[sizeof(*rp) + 1];
+
+	SYS_LOG_DBG("");
 
 	rp = (void *) buf;
 
@@ -121,24 +115,35 @@ static void controller_index_list(u8_t *data,  u16_t len)
 static void controller_info(u8_t *data, u16_t len)
 {
 	struct gap_read_controller_info_rp rp;
-	struct bt_le_oob oob;
-	u32_t supported_settings;
+	u32_t supported_settings = 0;
+	ble_addr_t addr;
+	int rc;
+
+	SYS_LOG_DBG("");
+
+	rc = ble_hs_pvcy_set_our_irk(irk);
+	assert(rc == 0);
 
 	memset(&rp, 0, sizeof(rp));
 
-	bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
-	memcpy(rp.address, &oob.addr.a, sizeof(bt_addr_t));
-	/*
-	 * If privacy is used, the device uses random type address, otherwise
-	 * static random or public type address is used.
-	 */
-#if !defined(CONFIG_BT_PRIVACY)
-	if (oob.addr.type == BT_ADDR_LE_RANDOM) {
-		atomic_set_bit(&current_settings, GAP_SETTINGS_STATIC_ADDRESS);
-	}
-#endif /* CONFIG_BT_PRIVACY */
+	rc = ble_hs_id_gen_rnd(0, &addr);
+	assert(rc == 0);
+	rc = ble_hs_id_set_rnd(addr.val);
+	assert(rc == 0);
 
-	supported_settings = BIT(GAP_SETTINGS_POWERED);
+	if (MYNEWT_VAL(BTTESTER_PRIVACY_MODE)) {
+		own_addr_type = BLE_OWN_ADDR_RPA_RANDOM_DEFAULT;
+		atomic_set_bit(&current_settings, GAP_SETTINGS_PRIVACY);
+		supported_settings |= BIT(GAP_SETTINGS_PRIVACY);
+		memcpy(rp.address, addr.val, sizeof(rp.address));
+	} else {
+		memcpy(rp.address, MYNEWT_VAL(BLE_PUBLIC_DEV_ADDR),
+		       sizeof(rp.address));
+	}
+
+	ble_hs_cfg.sm_mitm = 0;
+
+	supported_settings |= BIT(GAP_SETTINGS_POWERED);
 	supported_settings |= BIT(GAP_SETTINGS_CONNECTABLE);
 	supported_settings |= BIT(GAP_SETTINGS_BONDABLE);
 	supported_settings |= BIT(GAP_SETTINGS_LE);
@@ -153,15 +158,24 @@ static void controller_info(u8_t *data, u16_t len)
 		    CONTROLLER_INDEX, (u8_t *) &rp, sizeof(rp));
 }
 
+static struct ble_gap_adv_params adv_params = {
+	.conn_mode = BLE_GAP_CONN_MODE_NON,
+	.disc_mode = BLE_GAP_DISC_MODE_NON,
+};
+
 static void set_connectable(u8_t *data, u16_t len)
 {
 	const struct gap_set_connectable_cmd *cmd = (void *) data;
 	struct gap_set_connectable_rp rp;
 
+	SYS_LOG_DBG("");
+
 	if (cmd->connectable) {
 		atomic_set_bit(&current_settings, GAP_SETTINGS_CONNECTABLE);
+		adv_params.conn_mode = BLE_GAP_CONN_MODE_UND;
 	} else {
 		atomic_clear_bit(&current_settings, GAP_SETTINGS_CONNECTABLE);
+		adv_params.conn_mode = BLE_GAP_CONN_MODE_NON;
 	}
 
 	rp.current_settings = sys_cpu_to_le32(current_settings);
@@ -170,30 +184,31 @@ static void set_connectable(u8_t *data, u16_t len)
 		    (u8_t *) &rp, sizeof(rp));
 }
 
-static u8_t ad_flags = BT_LE_AD_NO_BREDR;
-static struct bt_data ad[10] = {
-	BT_DATA(BT_DATA_FLAGS, &ad_flags, sizeof(ad_flags)),
-};
-static struct bt_data sd[10];
+static u8_t ad_flags = BLE_HS_ADV_F_BREDR_UNSUP;
 
 static void set_discoverable(u8_t *data, u16_t len)
 {
 	const struct gap_set_discoverable_cmd *cmd = (void *) data;
 	struct gap_set_discoverable_rp rp;
 
+	SYS_LOG_DBG("");
+
 	switch (cmd->discoverable) {
 	case GAP_NON_DISCOVERABLE:
-		ad_flags &= ~(BT_LE_AD_GENERAL | BT_LE_AD_LIMITED);
+		ad_flags &= ~(BLE_HS_ADV_F_DISC_GEN | BLE_HS_ADV_F_DISC_LTD);
+		adv_params.disc_mode = BLE_GAP_DISC_MODE_NON;
 		atomic_clear_bit(&current_settings, GAP_SETTINGS_DISCOVERABLE);
 		break;
 	case GAP_GENERAL_DISCOVERABLE:
-		ad_flags &= ~BT_LE_AD_LIMITED;
-		ad_flags |= BT_LE_AD_GENERAL;
+		ad_flags &= ~BLE_HS_ADV_F_DISC_LTD;
+		ad_flags |= BLE_HS_ADV_F_DISC_GEN;
+		adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;
 		atomic_set_bit(&current_settings, GAP_SETTINGS_DISCOVERABLE);
 		break;
 	case GAP_LIMITED_DISCOVERABLE:
-		ad_flags &= ~BT_LE_AD_GENERAL;
-		ad_flags |= BT_LE_AD_LIMITED;
+		ad_flags &= ~BLE_HS_ADV_F_DISC_GEN;
+		ad_flags |= BLE_HS_ADV_F_DISC_LTD;
+		adv_params.disc_mode = BLE_GAP_DISC_MODE_LTD;
 		atomic_set_bit(&current_settings, GAP_SETTINGS_DISCOVERABLE);
 		break;
 	default:
@@ -208,13 +223,40 @@ static void set_discoverable(u8_t *data, u16_t len)
 		    (u8_t *) &rp, sizeof(rp));
 }
 
+static struct bt_data ad[10] = {
+	BT_DATA(BLE_HS_ADV_TYPE_FLAGS, &ad_flags, sizeof(ad_flags)),
+};
+static struct bt_data sd[10];
+
+static int set_ad(const struct bt_data *ad, size_t ad_len,
+		  u8_t *buf, u8_t *buf_len)
+{
+	int i;
+
+	for (i = 0; i < ad_len; i++) {
+		buf[(*buf_len)++] = ad[i].data_len + 1;
+		buf[(*buf_len)++] = ad[i].type;
+
+		memcpy(&buf[*buf_len], ad[i].data,
+		       ad[i].data_len);
+		*buf_len += ad[i].data_len;
+	}
+
+	return 0;
+}
+
 static void start_advertising(const u8_t *data, u16_t len)
 {
 	const struct gap_start_advertising_cmd *cmd = (void *) data;
 	struct gap_start_advertising_rp rp;
+	uint8_t buf[BLE_HS_ADV_MAX_SZ];
+	uint8_t buf_len = 0;
 	u8_t adv_len, sd_len;
-	bool adv_conn;
+	int err;
+
 	int i;
+
+	SYS_LOG_DBG("");
 
 	for (i = 0, adv_len = 1; i < cmd->adv_data_len; adv_len++) {
 		if (adv_len >= ARRAY_SIZE(ad)) {
@@ -240,12 +282,36 @@ static void start_advertising(const u8_t *data, u16_t len)
 		i += sd[sd_len].data_len;
 	}
 
-	adv_conn = atomic_test_bit(&current_settings, GAP_SETTINGS_CONNECTABLE);
+	err = set_ad(ad, adv_len, buf, &buf_len);
+	if (err) {
+		goto fail;
+	}
 
-	/* BTP API don't allow to set empty scan response data. */
-	if (bt_le_adv_start(adv_conn ? BT_LE_ADV_CONN : BT_LE_ADV_NCONN,
-			    ad, adv_len, sd_len ? sd : NULL, sd_len) < 0) {
-		SYS_LOG_ERR("Failed to start advertising");
+	err = ble_gap_adv_set_data(buf, buf_len);
+	if (err != 0) {
+		goto fail;
+	}
+
+	if (sd_len) {
+		buf_len = 0;
+
+		err = set_ad(sd, sd_len, buf, &buf_len);
+		if (err) {
+			SYS_LOG_ERR("Advertising failed: err %d", err);
+			goto fail;
+		}
+
+		err = ble_gap_adv_rsp_set_data(buf, buf_len);
+		if (err != 0) {
+			SYS_LOG_ERR("Advertising failed: err %d", err);
+			goto fail;
+		}
+	}
+
+	err = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER,
+				&adv_params, gap_event_cb, NULL);
+	if (err) {
+		SYS_LOG_ERR("Advertising failed: err %d", err);
 		goto fail;
 	}
 
@@ -264,7 +330,9 @@ static void stop_advertising(const u8_t *data, u16_t len)
 {
 	struct gap_stop_advertising_rp rp;
 
-	if (bt_le_adv_stop() < 0) {
+	SYS_LOG_DBG("");
+
+	if (ble_gap_adv_stop() != 0) {
 		tester_rsp(BTP_SERVICE_ID_GAP, GAP_STOP_ADVERTISING,
 			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
 		return;
@@ -277,25 +345,25 @@ static void stop_advertising(const u8_t *data, u16_t len)
 		    (u8_t *) &rp, sizeof(rp));
 }
 
-static u8_t get_ad_flags(struct net_buf_simple *ad)
+static u8_t get_ad_flags(u8_t *data, u8_t data_len)
 {
 	u8_t len, i;
 
 	/* Parse advertisement to get flags */
-	for (i = 0; i < ad->len; i += len - 1) {
-		len = ad->data[i++];
+	for (i = 0; i < data_len; i += len - 1) {
+		len = data[i++];
 		if (!len) {
 			break;
 		}
 
 		/* Check if field length is correct */
-		if (len > (ad->len - i) || (ad->len - i) < 1) {
+		if (len > (data_len - i) || (data_len - i) < 1) {
 			break;
 		}
 
-		switch (ad->data[i++]) {
-		case BT_DATA_FLAGS:
-			return ad->data[i];
+		switch (data[i++]) {
+		case BLE_HS_ADV_TYPE_FLAGS:
+			return data[i];
 		default:
 			break;
 		}
@@ -305,10 +373,10 @@ static u8_t get_ad_flags(struct net_buf_simple *ad)
 }
 
 static u8_t discovery_flags;
-static struct net_buf_simple *adv_buf = NET_BUF_SIMPLE(ADV_BUF_LEN);
+static struct os_mbuf *adv_buf;
 
-static void store_adv(const bt_addr_le_t *addr, s8_t rssi,
-		      struct net_buf_simple *ad)
+static void store_adv(const ble_addr_t *addr, s8_t rssi,
+		      u8_t *data, u8_t len)
 {
 	struct gap_device_found_ev *ev;
 
@@ -317,65 +385,65 @@ static void store_adv(const bt_addr_le_t *addr, s8_t rssi,
 
 	ev = net_buf_simple_add(adv_buf, sizeof(*ev));
 
-	memcpy(ev->address, addr->a.val, sizeof(ev->address));
+	memcpy(ev->address, addr->val, sizeof(ev->address));
 	ev->address_type = addr->type;
 	ev->rssi = rssi;
 	ev->flags = GAP_DEVICE_FOUND_FLAG_AD | GAP_DEVICE_FOUND_FLAG_RSSI;
-	ev->eir_data_len = ad->len;
-	memcpy(net_buf_simple_add(adv_buf, ad->len), ad->data, ad->len);
+	ev->eir_data_len = len;
+	memcpy(net_buf_simple_add(adv_buf, len), data, len);
 }
 
-static void device_found(const bt_addr_le_t *addr, s8_t rssi, u8_t evtype,
-			 struct net_buf_simple *ad)
+static void device_found(ble_addr_t *addr, s8_t rssi, u8_t evtype,
+			 u8_t *data, u8_t len)
 {
+	struct gap_device_found_ev *ev;
+	ble_addr_t a;
+
 	/* if General/Limited Discovery - parse Advertising data to get flags */
 	if (!(discovery_flags & GAP_DISCOVERY_FLAG_LE_OBSERVE) &&
-	    (evtype != BT_LE_ADV_SCAN_RSP)) {
-		u8_t flags = get_ad_flags(ad);
+	    (evtype != BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP)) {
+		u8_t flags = get_ad_flags(data, len);
 
 		/* ignore non-discoverable devices */
-		if (!(flags & BT_LE_AD_DISCOV_MASK)) {
+		if (!(flags & BLE_AD_DISCOV_MASK)) {
 			SYS_LOG_DBG("Non discoverable, skipping");
 			return;
 		}
 
 		/* if Limited Discovery - ignore general discoverable devices */
 		if ((discovery_flags & GAP_DISCOVERY_FLAG_LIMITED) &&
-		    !(flags & BT_LE_AD_LIMITED)) {
+		    !(flags & BLE_HS_ADV_F_DISC_LTD)) {
 			SYS_LOG_DBG("General discoverable, skipping");
 			return;
 		}
 	}
 
 	/* attach Scan Response data */
-	if (evtype == BT_LE_ADV_SCAN_RSP) {
-		struct gap_device_found_ev *ev;
-		bt_addr_le_t a;
-
+	if (evtype == BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP) {
 		/* skip if there is no pending advertisement */
-		if (!adv_buf->len) {
+		if (!adv_buf->om_len) {
 			SYS_LOG_INF("No pending advertisement, skipping");
 			return;
 		}
 
-		ev = (void *) adv_buf->data;
+		ev = (void *) adv_buf->om_data;
 		a.type = ev->address_type;
-		memcpy(a.a.val, ev->address, sizeof(a.a.val));
+		memcpy(a.val, ev->address, sizeof(a.val));
 
 		/*
 		 * in general, the Scan Response comes right after the
 		 * Advertisement, but if not if send stored event and ignore
 		 * this one
 		 */
-		if (bt_addr_le_cmp(addr, &a)) {
+		if (ble_addr_cmp(addr, &a)) {
 			SYS_LOG_INF("Address does not match, skipping");
 			goto done;
 		}
 
-		ev->eir_data_len += ad->len;
+		ev->eir_data_len += len;
 		ev->flags |= GAP_DEVICE_FOUND_FLAG_SD;
 
-		memcpy(net_buf_simple_add(adv_buf, ad->len), ad->data, ad->len);
+		memcpy(net_buf_simple_add(adv_buf, len), data, len);
 
 		goto done;
 	}
@@ -384,28 +452,44 @@ static void device_found(const bt_addr_le_t *addr, s8_t rssi, u8_t evtype,
 	 * if there is another pending advertisement, send it and store the
 	 * current one
 	 */
-	if (adv_buf->len) {
+	if (adv_buf->om_len) {
 		tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_FOUND,
-			    CONTROLLER_INDEX, adv_buf->data, adv_buf->len);
+			    CONTROLLER_INDEX, adv_buf->om_data,
+			    adv_buf->om_len);
 	}
 
-	store_adv(addr, rssi, ad);
+	store_adv(addr, rssi, data, len);
 
 	/* if Active Scan and scannable event - wait for Scan Response */
 	if ((discovery_flags & GAP_DISCOVERY_FLAG_LE_ACTIVE_SCAN) &&
-	    (evtype == BT_LE_ADV_IND || evtype == BT_LE_ADV_SCAN_IND)) {
+	    (evtype == BLE_HCI_ADV_RPT_EVTYPE_ADV_IND ||
+	     evtype == BLE_HCI_ADV_RPT_EVTYPE_SCAN_IND)) {
 		SYS_LOG_DBG("Waiting for scan response");
 		return;
 	}
 done:
 	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_FOUND,
-		    CONTROLLER_INDEX, adv_buf->data, adv_buf->len);
+		    CONTROLLER_INDEX, adv_buf->om_data, adv_buf->om_len);
+}
+
+static int discovery_cb(struct ble_gap_event *event, void *arg)
+{
+	if (event->type == BLE_GAP_EVENT_DISC) {
+		device_found(&event->disc.addr, event->disc.rssi,
+			     event->disc.event_type, event->disc.data,
+			     event->disc.length_data);
+	}
+
+	return 0;
 }
 
 static void start_discovery(const u8_t *data, u16_t len)
 {
 	const struct gap_start_discovery_cmd *cmd = (void *) data;
+	struct ble_gap_disc_params params = {0};
 	u8_t status;
+
+	SYS_LOG_DBG("");
 
 	/* only LE scan is supported */
 	if (cmd->flags & GAP_DISCOVERY_FLAG_BREDR) {
@@ -413,9 +497,12 @@ static void start_discovery(const u8_t *data, u16_t len)
 		goto reply;
 	}
 
-	if (bt_le_scan_start(cmd->flags & GAP_DISCOVERY_FLAG_LE_ACTIVE_SCAN ?
-			     BT_LE_SCAN_ACTIVE : BT_LE_SCAN_PASSIVE,
-			     device_found) < 0) {
+	params.passive = (cmd->flags & GAP_DISCOVERY_FLAG_LE_ACTIVE_SCAN) == 0;
+	params.limited = (cmd->flags & GAP_DISCOVERY_FLAG_LIMITED) > 0;
+	params.filter_duplicates = 1;
+
+	if (ble_gap_disc(own_addr_type, BLE_HS_FOREVER,
+			 &params, discovery_cb, NULL) != 0) {
 		status = BTP_STATUS_FAILED;
 		goto reply;
 	}
@@ -433,7 +520,9 @@ static void stop_discovery(const u8_t *data, u16_t len)
 {
 	u8_t status = BTP_STATUS_SUCCESS;
 
-	if (bt_le_scan_stop() < 0) {
+	SYS_LOG_DBG("");
+
+	if (ble_gap_disc_cancel() != 0) {
 		status = BTP_STATUS_FAILED;
 	}
 
@@ -441,19 +530,418 @@ static void stop_discovery(const u8_t *data, u16_t len)
 		   status);
 }
 
+#if MYNEWT_VAL(BTTESTER_CONN_PARAM_UPDATE)
+static void conn_param_update_cb(uint16_t conn_handle, int status, void *arg)
+{
+	console_printf("conn param update complete; conn_handle=%d status=%d\n",
+		       conn_handle, status);
+}
+
+static void conn_param_update(void *arg)
+{
+	int rc;
+	struct ble_l2cap_sig_update_params params;
+
+	params.itvl_min = 0x200;
+	params.itvl_max = 0x300;
+	params.slave_latency = 0;
+	params.timeout_multiplier = 0x500;
+
+	rc = ble_l2cap_sig_update(1, &params, conn_param_update_cb,
+				  NULL);
+	assert(rc == 0);
+}
+#endif
+
+static void le_connected(u16_t conn_handle, int status)
+{
+	struct ble_gap_conn_desc desc;
+	struct gap_device_connected_ev ev;
+	ble_addr_t *addr;
+	int rc;
+
+	SYS_LOG_DBG("");
+
+	if (status != 0) {
+		return;
+	}
+
+	rc = ble_gap_conn_find(conn_handle, &desc);
+	if (rc) {
+		return;
+	}
+
+	peer_id_addr = desc.peer_id_addr;
+	peer_ota_addr = desc.peer_ota_addr;
+
+	addr = &desc.peer_ota_addr;
+
+	memcpy(ev.address, addr->val, sizeof(ev.address));
+	ev.address_type = addr->type;
+
+#if MYNEWT_VAL(BTTESTER_CONN_PARAM_UPDATE)
+	os_cputime_timer_relative(&conn_param_update_timer, 5000000);
+#endif
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_CONNECTED,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void le_disconnected(struct ble_gap_conn_desc *conn, int reason)
+{
+	struct gap_device_disconnected_ev ev;
+	ble_addr_t *addr = &conn->peer_ota_addr;
+
+	SYS_LOG_DBG("");
+
+	memcpy(ev.address, addr->val, sizeof(ev.address));
+	ev.address_type = addr->type;
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_DISCONNECTED,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void auth_passkey_display(u16_t conn_handle, unsigned int passkey)
+{
+	struct ble_gap_conn_desc desc;
+	struct gap_passkey_display_ev ev;
+	ble_addr_t *addr;
+	struct ble_sm_io pk;
+	int rc;
+
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find(conn_handle, &desc);
+	if (rc) {
+		return;
+	}
+
+	rc = ble_hs_hci_util_rand(&pk.passkey, sizeof(pk.passkey));
+	assert(rc == 0);
+	/* Max value is 999999 */
+	pk.passkey %= 1000000;
+	pk.action = BLE_SM_IOACT_DISP;
+
+	rc = ble_sm_inject_io(conn_handle, &pk);
+	assert(rc == 0);
+
+	addr = &desc.peer_ota_addr;
+
+	memcpy(ev.address, addr->val, sizeof(ev.address));
+	ev.address_type = addr->type;
+	ev.passkey = sys_cpu_to_le32(pk.passkey);
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_PASSKEY_DISPLAY,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void auth_passkey_entry(u16_t conn_handle)
+{
+	struct ble_gap_conn_desc desc;
+	struct gap_passkey_entry_req_ev ev;
+	ble_addr_t *addr;
+	int rc;
+
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find(conn_handle, &desc);
+	if (rc) {
+		return;
+	}
+
+	addr = &desc.peer_ota_addr;
+
+	memcpy(ev.address, addr->val, sizeof(ev.address));
+	ev.address_type = addr->type;
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_PASSKEY_ENTRY_REQ,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void auth_passkey_numcmp(u16_t conn_handle, unsigned int passkey)
+{
+	struct ble_gap_conn_desc desc;
+	struct gap_passkey_confirm_req_ev ev;
+	ble_addr_t *addr;
+	int rc;
+
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find(conn_handle, &desc);
+	if (rc) {
+		return;
+	}
+
+	addr = &desc.peer_ota_addr;
+
+	memcpy(ev.address, addr->val, sizeof(ev.address));
+	ev.address_type = addr->type;
+	ev.passkey = sys_cpu_to_le32(passkey);
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_PASSKEY_CONFIRM_REQ,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void le_passkey_action(u16_t conn_handle,
+			      struct ble_gap_passkey_params *params)
+{
+	SYS_LOG_DBG("");
+
+	switch (params->action) {
+	case BLE_SM_IOACT_INPUT:
+		auth_passkey_entry(conn_handle);
+		break;
+	case BLE_SM_IOACT_DISP:
+		auth_passkey_display(conn_handle, params->numcmp);
+		break;
+	case BLE_SM_IOACT_NUMCMP:
+		auth_passkey_numcmp(conn_handle, params->numcmp);
+		break;
+	default:
+		break;
+	}
+}
+
+static void le_identity_resolved(u16_t conn_handle)
+{
+	struct ble_gap_conn_desc desc;
+	struct gap_identity_resolved_ev ev;
+	int rc;
+
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find(conn_handle, &desc);
+	if (rc) {
+		return;
+	}
+
+	peer_id_addr = desc.peer_id_addr;
+	peer_ota_addr = desc.peer_ota_addr;
+
+	ev.address_type = desc.peer_ota_addr.type;
+	memcpy(ev.address, desc.peer_ota_addr.val, sizeof(ev.address));
+
+	ev.identity_address_type = desc.peer_id_addr.type;
+	memcpy(ev.identity_address, desc.peer_id_addr.val,
+	       sizeof(ev.identity_address));
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_IDENTITY_RESOLVED,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void le_encryption_changed(struct ble_gap_conn_desc *desc)
+{
+	encrypted = (bool) desc->sec_state.encrypted;
+}
+
+static void print_bytes(const uint8_t *bytes, int len)
+{
+	int i;
+
+	for (i = 0; i < len; i++) {
+		console_printf("%s0x%02x", i != 0 ? ":" : "", bytes[i]);
+	}
+}
+
+static void print_mbuf(const struct os_mbuf *om)
+{
+	int colon;
+
+	colon = 0;
+	while (om != NULL) {
+		if (colon) {
+			console_printf(":");
+		} else {
+			colon = 1;
+		}
+		print_bytes(om->om_data, om->om_len);
+		om = SLIST_NEXT(om, om_next);
+	}
+}
+
+static void print_addr(const void *addr)
+{
+	const uint8_t *u8p;
+
+	u8p = addr;
+	console_printf("%02x:%02x:%02x:%02x:%02x:%02x",
+		       u8p[5], u8p[4], u8p[3], u8p[2], u8p[1], u8p[0]);
+}
+
+static void print_conn_desc(const struct ble_gap_conn_desc *desc)
+{
+	console_printf("handle=%d our_ota_addr_type=%d our_ota_addr=",
+		       desc->conn_handle, desc->our_ota_addr.type);
+	print_addr(desc->our_ota_addr.val);
+	console_printf(" our_id_addr_type=%d our_id_addr=",
+		       desc->our_id_addr.type);
+	print_addr(desc->our_id_addr.val);
+	console_printf(" peer_ota_addr_type=%d peer_ota_addr=",
+		       desc->peer_ota_addr.type);
+	print_addr(desc->peer_ota_addr.val);
+	console_printf(" peer_id_addr_type=%d peer_id_addr=",
+		       desc->peer_id_addr.type);
+	print_addr(desc->peer_id_addr.val);
+	console_printf(" conn_itvl=%d conn_latency=%d supervision_timeout=%d "
+		       "encrypted=%d authenticated=%d bonded=%d\n",
+		       desc->conn_itvl, desc->conn_latency,
+		       desc->supervision_timeout,
+		       desc->sec_state.encrypted,
+		       desc->sec_state.authenticated,
+		       desc->sec_state.bonded);
+}
+
+static void adv_complete(void)
+{
+	struct gap_new_settings_ev ev;
+
+	atomic_clear_bit(&current_settings, GAP_SETTINGS_ADVERTISING);
+	ev.current_settings = sys_cpu_to_le32(current_settings);
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_NEW_SETTINGS, CONTROLLER_INDEX,
+		    (u8_t *) &ev, sizeof(ev));
+}
+
+static int gap_event_cb(struct ble_gap_event *event, void *arg)
+{
+	struct ble_gap_conn_desc desc;
+	int rc;
+
+	switch (event->type) {
+	case BLE_GAP_EVENT_ADV_COMPLETE:
+		console_printf("advertising complete; reason=%d\n",
+			       event->adv_complete.reason);
+		break;
+	case BLE_GAP_EVENT_CONNECT:
+		console_printf("connection %s; status=%d ",
+			       event->connect.status == 0 ? "established" : "failed",
+			       event->connect.status);
+		if (event->connect.status == 0) {
+			rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+			assert(rc == 0);
+			print_conn_desc(&desc);
+		}
+
+		if (desc.role == BLE_GAP_ROLE_SLAVE) {
+			adv_complete();
+		}
+
+		le_connected(event->connect.conn_handle,
+			     event->connect.status);
+		break;
+	case BLE_GAP_EVENT_DISCONNECT:
+		console_printf("disconnect; reason=%d ", event->disconnect.reason);
+		print_conn_desc(&event->disconnect.conn);
+		le_disconnected(&event->disconnect.conn,
+				event->disconnect.reason);
+		break;
+	case BLE_GAP_EVENT_ENC_CHANGE:
+		console_printf("encryption change event; status=%d ", event->enc_change.status);
+		rc = ble_gap_conn_find(event->enc_change.conn_handle, &desc);
+		assert(rc == 0);
+		print_conn_desc(&desc);
+		le_encryption_changed(&desc);
+		break;
+	case BLE_GAP_EVENT_PASSKEY_ACTION:
+		console_printf("passkey action event; action=%d",
+			       event->passkey.params.action);
+		if (event->passkey.params.action == BLE_SM_IOACT_NUMCMP) {
+			console_printf(" numcmp=%lu",
+				       (unsigned long)event->passkey.params.numcmp);
+		}
+		console_printf("\n");
+		le_passkey_action(event->passkey.conn_handle,
+				  &event->passkey.params);
+		break;
+	case BLE_GAP_EVENT_IDENTITY_RESOLVED:
+		console_printf("identity resolved ");
+		rc = ble_gap_conn_find(event->identity_resolved.conn_handle, &desc);
+		assert(rc == 0);
+		print_conn_desc(&desc);
+		le_identity_resolved(event->identity_resolved.conn_handle);
+		break;
+	case BLE_GAP_EVENT_NOTIFY_RX:
+		console_printf("notification rx event; attr_handle=%d indication=%d "
+			       "len=%d data=",
+			       event->notify_rx.attr_handle,
+			       event->notify_rx.indication,
+			       OS_MBUF_PKTLEN(event->notify_rx.om));
+
+		print_mbuf(event->notify_rx.om);
+		console_printf("\n");
+		tester_gatt_notify_rx_ev(event->notify_rx.conn_handle,
+					 event->notify_rx.attr_handle,
+					 event->notify_rx.indication,
+					 event->notify_rx.om);
+		break;
+	case BLE_GAP_EVENT_SUBSCRIBE:
+		console_printf("subscribe event; conn_handle=%d attr_handle=%d "
+			       "reason=%d prevn=%d curn=%d previ=%d curi=%d\n",
+			       event->subscribe.conn_handle,
+			       event->subscribe.attr_handle,
+			       event->subscribe.reason,
+			       event->subscribe.prev_notify,
+			       event->subscribe.cur_notify,
+			       event->subscribe.prev_indicate,
+			       event->subscribe.cur_indicate);
+		tester_gatt_subscribe_ev(event->subscribe.conn_handle,
+					 event->subscribe.attr_handle,
+					 event->subscribe.reason,
+					 event->subscribe.prev_notify,
+					 event->subscribe.cur_notify,
+					 event->subscribe.prev_indicate,
+					 event->subscribe.cur_indicate);
+		break;
+	case BLE_GAP_EVENT_REPEAT_PAIRING:
+		console_printf("repeat pairing event; conn_handle=%d "
+			       "cur_key_sz=%d cur_auth=%d cur_sc=%d "
+			       "new_key_sz=%d new_auth=%d new_sc=%d "
+			       "new_bonding=%d\n",
+			event->repeat_pairing.conn_handle,
+			event->repeat_pairing.cur_key_size,
+			event->repeat_pairing.cur_authenticated,
+			event->repeat_pairing.cur_sc,
+			event->repeat_pairing.new_key_size,
+			event->repeat_pairing.new_authenticated,
+			event->repeat_pairing.new_sc,
+			event->repeat_pairing.new_bonding);
+		rc = ble_gap_conn_find(event->repeat_pairing.conn_handle, &desc);
+		assert(rc == 0);
+		rc = ble_store_util_delete_peer(&desc.peer_id_addr);
+		assert(rc == 0);
+		return BLE_GAP_REPEAT_PAIRING_RETRY;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
 static void connect(const u8_t *data, u16_t len)
 {
-	struct bt_conn *conn;
+	struct ble_gap_conn_params conn_params = { 0 };
 	u8_t status;
+	int rc;
 
-	conn = bt_conn_create_le((bt_addr_le_t *) data,
-				 BT_LE_CONN_PARAM_DEFAULT);
-	if (!conn) {
+	SYS_LOG_DBG("");
+
+	conn_params.scan_itvl = 0x0010;
+	conn_params.scan_window = 0x0010;
+	conn_params.itvl_min = BLE_GAP_INITIAL_CONN_ITVL_MIN;
+	conn_params.itvl_max = BLE_GAP_INITIAL_CONN_ITVL_MAX;
+	conn_params.latency = 0;
+	conn_params.supervision_timeout = 0x0100;
+	conn_params.min_ce_len = 0x0010;
+	conn_params.max_ce_len = 0x0300;
+
+	rc = ble_gap_connect(own_addr_type, (ble_addr_t *) data,
+			     0, &conn_params,
+			     gap_event_cb, NULL);
+	if (rc) {
 		status = BTP_STATUS_FAILED;
 		goto rsp;
 	}
 
-	bt_conn_unref(conn);
 	status = BTP_STATUS_SUCCESS;
 
 rsp:
@@ -462,56 +950,27 @@ rsp:
 
 static void disconnect(const u8_t *data, u16_t len)
 {
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc desc;
 	u8_t status;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
+	SYS_LOG_DBG("");
+
+	rc = gap_conn_find_by_addr((ble_addr_t *)data, &desc);
+	if (rc) {
 		status = BTP_STATUS_FAILED;
 		goto rsp;
 	}
 
-	if (bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN)) {
+	if (ble_gap_terminate(desc.conn_handle, BLE_ERR_REM_USER_CONN_TERM)) {
 		status = BTP_STATUS_FAILED;
 	} else {
 		status = BTP_STATUS_SUCCESS;
 	}
 
-	bt_conn_unref(conn);
-
 rsp:
 	tester_rsp(BTP_SERVICE_ID_GAP, GAP_DISCONNECT, CONTROLLER_INDEX,
 		   status);
-}
-
-static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
-{
-	struct gap_passkey_display_ev ev;
-	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
-
-	memcpy(ev.address, addr->a.val, sizeof(ev.address));
-	ev.address_type = addr->type;
-	ev.passkey = sys_cpu_to_le32(passkey);
-
-	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_PASSKEY_DISPLAY,
-		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
-}
-
-static void auth_passkey_entry(struct bt_conn *conn)
-{
-	struct gap_passkey_entry_req_ev ev;
-	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
-
-	memcpy(ev.address, addr->a.val, sizeof(ev.address));
-	ev.address_type = addr->type;
-
-	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_PASSKEY_ENTRY_REQ,
-		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
-}
-
-static void auth_cancel(struct bt_conn *conn)
-{
-	/* TODO */
 }
 
 static void set_io_cap(const u8_t *data, u16_t len)
@@ -519,34 +978,31 @@ static void set_io_cap(const u8_t *data, u16_t len)
 	const struct gap_set_io_cap_cmd *cmd = (void *) data;
 	u8_t status;
 
-	/* Reset io cap requirements */
-	memset(&cb, 0, sizeof(cb));
-	bt_conn_auth_cb_register(NULL);
+	SYS_LOG_DBG("");
 
 	switch (cmd->io_cap) {
 	case GAP_IO_CAP_DISPLAY_ONLY:
-		cb.cancel = auth_cancel;
-		cb.passkey_display = auth_passkey_display;
+		ble_hs_cfg.sm_io_cap = BLE_SM_IO_CAP_DISP_ONLY;
+		ble_hs_cfg.sm_mitm = 1;
 		break;
 	case GAP_IO_CAP_KEYBOARD_DISPLAY:
-		cb.cancel = auth_cancel;
-		cb.passkey_display = auth_passkey_display;
-		cb.passkey_entry = auth_passkey_entry;
+		ble_hs_cfg.sm_io_cap = BLE_SM_IO_CAP_KEYBOARD_DISP;
+		ble_hs_cfg.sm_mitm = 1;
 		break;
 	case GAP_IO_CAP_NO_INPUT_OUTPUT:
-		cb.cancel = auth_cancel;
+		ble_hs_cfg.sm_io_cap = BLE_SM_IO_CAP_NO_IO;
+		ble_hs_cfg.sm_mitm = 0;
+		break;
 		break;
 	case GAP_IO_CAP_KEYBOARD_ONLY:
-		cb.cancel = auth_cancel;
-		cb.passkey_entry = auth_passkey_entry;
+		ble_hs_cfg.sm_io_cap = BLE_SM_IO_CAP_KEYBOARD_ONLY;
+		ble_hs_cfg.sm_mitm = 1;
 		break;
 	case GAP_IO_CAP_DISPLAY_YESNO:
+		ble_hs_cfg.sm_io_cap = BLE_SM_IO_CAP_DISP_YES_NO;
+		ble_hs_cfg.sm_mitm = 1;
+		break;
 	default:
-		status = BTP_STATUS_FAILED;
-		goto rsp;
-	}
-
-	if (bt_conn_auth_cb_register(&cb)) {
 		status = BTP_STATUS_FAILED;
 		goto rsp;
 	}
@@ -560,22 +1016,30 @@ rsp:
 
 static void pair(const u8_t *data, u16_t len)
 {
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc desc;
 	u8_t status;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
+	SYS_LOG_DBG("");
+
+	rc = gap_conn_find_by_addr((ble_addr_t *)data, &desc);
+	if (rc) {
 		status = BTP_STATUS_FAILED;
 		goto rsp;
 	}
 
-	if (bt_conn_security(conn, BT_SECURITY_MEDIUM)) {
-		status = BTP_STATUS_FAILED;
-		bt_conn_unref(conn);
-		goto rsp;
+	if (desc.role == BLE_GAP_ROLE_SLAVE) {
+		if (ble_sm_slave_initiate(desc.conn_handle)) {
+			status = BTP_STATUS_FAILED;
+			goto rsp;
+		}
+	} else {
+		if (ble_sm_pair_initiate(desc.conn_handle)) {
+			status = BTP_STATUS_FAILED;
+			goto rsp;
+		}
 	}
 
-	bt_conn_unref(conn);
 	status = BTP_STATUS_SUCCESS;
 
 rsp:
@@ -584,51 +1048,40 @@ rsp:
 
 static void unpair(const u8_t *data, u16_t len)
 {
-	struct gap_unpair_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
-	bt_addr_le_t addr;
 	u8_t status;
 	int err;
 
-	addr.type = cmd->address_type;
-	memcpy(addr.a.val, cmd->address, sizeof(addr.a.val));
+	SYS_LOG_DBG("");
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &addr);
-	if (!conn) {
-		goto keys;
-	}
-
-	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
-
-	bt_conn_unref(conn);
-
-	if (err < 0) {
-		status = BTP_STATUS_FAILED;
-		goto rsp;
-	}
-keys:
-	err = bt_unpair(BT_ID_DEFAULT, &addr);
-
-	status = err < 0 ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS;
-rsp:
+	err = ble_gap_unpair((ble_addr_t *) data);
+	status = (uint8_t) (err != 0 ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
 	tester_rsp(BTP_SERVICE_ID_GAP, GAP_UNPAIR, CONTROLLER_INDEX, status);
 }
 
 static void passkey_entry(const u8_t *data, u16_t len)
 {
 	const struct gap_passkey_entry_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc desc;
+	struct ble_sm_io pk;
 	u8_t status;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
+	SYS_LOG_DBG("");
+
+	rc = gap_conn_find_by_addr((ble_addr_t *)data, &desc);
+	if (rc) {
 		status = BTP_STATUS_FAILED;
 		goto rsp;
 	}
 
-	bt_conn_auth_passkey_entry(conn, sys_le32_to_cpu(cmd->passkey));
+	pk.passkey = sys_le32_to_cpu(cmd->passkey);
 
-	bt_conn_unref(conn);
+	rc = ble_sm_inject_io(desc.conn_handle, &pk);
+	if (rc) {
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
 	status = BTP_STATUS_SUCCESS;
 
 rsp:
@@ -720,14 +1173,8 @@ static void tester_init_gap_cb(int err)
 
 	atomic_clear(&current_settings);
 	atomic_set_bit(&current_settings, GAP_SETTINGS_POWERED);
-	atomic_set_bit(&current_settings, GAP_SETTINGS_CONNECTABLE);
 	atomic_set_bit(&current_settings, GAP_SETTINGS_BONDABLE);
 	atomic_set_bit(&current_settings, GAP_SETTINGS_LE);
-#if defined(CONFIG_BT_PRIVACY)
-	atomic_set_bit(&current_settings, GAP_SETTINGS_PRIVACY);
-#endif /* CONFIG_BT_PRIVACY */
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	tester_rsp(BTP_SERVICE_ID_CORE, CORE_REGISTER_SERVICE, BTP_INDEX_NONE,
 		   BTP_STATUS_SUCCESS);
@@ -735,10 +1182,14 @@ static void tester_init_gap_cb(int err)
 
 u8_t tester_init_gap(void)
 {
-	if (bt_enable(tester_init_gap_cb) < 0) {
-		return BTP_STATUS_FAILED;
-	}
+	adv_buf = NET_BUF_SIMPLE(ADV_BUF_LEN);
 
+#if MYNEWT_VAL(BTTESTER_CONN_PARAM_UPDATE)
+	os_cputime_timer_init(&conn_param_update_timer,
+			      conn_param_update, NULL);
+#endif
+
+	tester_init_gap_cb(BTP_STATUS_SUCCESS);
 	return BTP_STATUS_SUCCESS;
 }
 

--- a/apps/bttester/src/gap.c
+++ b/apps/bttester/src/gap.c
@@ -1,0 +1,748 @@
+/* gap.c - Bluetooth GAP Tester */
+
+/*
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <atomic.h>
+#include <zephyr/types.h>
+#include <string.h>
+
+#include <toolchain.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/conn.h>
+
+#include <misc/byteorder.h>
+#include <net/buf.h>
+
+#include "bttester.h"
+
+#define CONTROLLER_INDEX 0
+#define CONTROLLER_NAME "btp_tester"
+
+#define BT_LE_AD_DISCOV_MASK (BT_LE_AD_LIMITED | BT_LE_AD_GENERAL)
+#define ADV_BUF_LEN (sizeof(struct gap_device_found_ev) + 2 * 31)
+
+static atomic_t current_settings;
+struct bt_conn_auth_cb cb;
+
+static void le_connected(struct bt_conn *conn, u8_t err)
+{
+	struct gap_device_connected_ev ev;
+	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
+
+	if (err) {
+		return;
+	}
+
+	memcpy(ev.address, addr->a.val, sizeof(ev.address));
+	ev.address_type = addr->type;
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_CONNECTED,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void le_disconnected(struct bt_conn *conn, u8_t reason)
+{
+	struct gap_device_disconnected_ev ev;
+	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
+
+	memcpy(ev.address, addr->a.val, sizeof(ev.address));
+	ev.address_type = addr->type;
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_DISCONNECTED,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void le_identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
+				 const bt_addr_le_t *identity)
+{
+	struct gap_identity_resolved_ev ev;
+
+	ev.address_type = rpa->type;
+	memcpy(ev.address, rpa->a.val, sizeof(ev.address));
+
+	ev.identity_address_type = identity->type;
+	memcpy(ev.identity_address, identity->a.val,
+	       sizeof(ev.identity_address));
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_IDENTITY_RESOLVED,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static struct bt_conn_cb conn_callbacks = {
+	.connected = le_connected,
+	.disconnected = le_disconnected,
+	.identity_resolved = le_identity_resolved,
+};
+
+static void supported_commands(u8_t *data, u16_t len)
+{
+	u8_t cmds[3];
+	struct gap_read_supported_commands_rp *rp = (void *) &cmds;
+
+	memset(cmds, 0, sizeof(cmds));
+
+	tester_set_bit(cmds, GAP_READ_SUPPORTED_COMMANDS);
+	tester_set_bit(cmds, GAP_READ_CONTROLLER_INDEX_LIST);
+	tester_set_bit(cmds, GAP_READ_CONTROLLER_INFO);
+	tester_set_bit(cmds, GAP_SET_CONNECTABLE);
+	tester_set_bit(cmds, GAP_SET_DISCOVERABLE);
+	tester_set_bit(cmds, GAP_START_ADVERTISING);
+	tester_set_bit(cmds, GAP_STOP_ADVERTISING);
+	tester_set_bit(cmds, GAP_START_DISCOVERY);
+	tester_set_bit(cmds, GAP_STOP_DISCOVERY);
+	tester_set_bit(cmds, GAP_CONNECT);
+	tester_set_bit(cmds, GAP_DISCONNECT);
+	tester_set_bit(cmds, GAP_SET_IO_CAP);
+	tester_set_bit(cmds, GAP_PAIR);
+	tester_set_bit(cmds, GAP_PASSKEY_ENTRY);
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_READ_SUPPORTED_COMMANDS,
+		    CONTROLLER_INDEX, (u8_t *) rp, sizeof(cmds));
+}
+
+static void controller_index_list(u8_t *data,  u16_t len)
+{
+	struct gap_read_controller_index_list_rp *rp;
+	u8_t buf[sizeof(*rp) + 1];
+
+	rp = (void *) buf;
+
+	rp->num = 1;
+	rp->index[0] = CONTROLLER_INDEX;
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_READ_CONTROLLER_INDEX_LIST,
+		    BTP_INDEX_NONE, (u8_t *) rp, sizeof(buf));
+}
+
+static void controller_info(u8_t *data, u16_t len)
+{
+	struct gap_read_controller_info_rp rp;
+	struct bt_le_oob oob;
+	u32_t supported_settings;
+
+	memset(&rp, 0, sizeof(rp));
+
+	bt_le_oob_get_local(BT_ID_DEFAULT, &oob);
+	memcpy(rp.address, &oob.addr.a, sizeof(bt_addr_t));
+	/*
+	 * If privacy is used, the device uses random type address, otherwise
+	 * static random or public type address is used.
+	 */
+#if !defined(CONFIG_BT_PRIVACY)
+	if (oob.addr.type == BT_ADDR_LE_RANDOM) {
+		atomic_set_bit(&current_settings, GAP_SETTINGS_STATIC_ADDRESS);
+	}
+#endif /* CONFIG_BT_PRIVACY */
+
+	supported_settings = BIT(GAP_SETTINGS_POWERED);
+	supported_settings |= BIT(GAP_SETTINGS_CONNECTABLE);
+	supported_settings |= BIT(GAP_SETTINGS_BONDABLE);
+	supported_settings |= BIT(GAP_SETTINGS_LE);
+	supported_settings |= BIT(GAP_SETTINGS_ADVERTISING);
+
+	rp.supported_settings = sys_cpu_to_le32(supported_settings);
+	rp.current_settings = sys_cpu_to_le32(current_settings);
+
+	memcpy(rp.name, CONTROLLER_NAME, sizeof(CONTROLLER_NAME));
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_READ_CONTROLLER_INFO,
+		    CONTROLLER_INDEX, (u8_t *) &rp, sizeof(rp));
+}
+
+static void set_connectable(u8_t *data, u16_t len)
+{
+	const struct gap_set_connectable_cmd *cmd = (void *) data;
+	struct gap_set_connectable_rp rp;
+
+	if (cmd->connectable) {
+		atomic_set_bit(&current_settings, GAP_SETTINGS_CONNECTABLE);
+	} else {
+		atomic_clear_bit(&current_settings, GAP_SETTINGS_CONNECTABLE);
+	}
+
+	rp.current_settings = sys_cpu_to_le32(current_settings);
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_SET_CONNECTABLE, CONTROLLER_INDEX,
+		    (u8_t *) &rp, sizeof(rp));
+}
+
+static u8_t ad_flags = BT_LE_AD_NO_BREDR;
+static struct bt_data ad[10] = {
+	BT_DATA(BT_DATA_FLAGS, &ad_flags, sizeof(ad_flags)),
+};
+static struct bt_data sd[10];
+
+static void set_discoverable(u8_t *data, u16_t len)
+{
+	const struct gap_set_discoverable_cmd *cmd = (void *) data;
+	struct gap_set_discoverable_rp rp;
+
+	switch (cmd->discoverable) {
+	case GAP_NON_DISCOVERABLE:
+		ad_flags &= ~(BT_LE_AD_GENERAL | BT_LE_AD_LIMITED);
+		atomic_clear_bit(&current_settings, GAP_SETTINGS_DISCOVERABLE);
+		break;
+	case GAP_GENERAL_DISCOVERABLE:
+		ad_flags &= ~BT_LE_AD_LIMITED;
+		ad_flags |= BT_LE_AD_GENERAL;
+		atomic_set_bit(&current_settings, GAP_SETTINGS_DISCOVERABLE);
+		break;
+	case GAP_LIMITED_DISCOVERABLE:
+		ad_flags &= ~BT_LE_AD_GENERAL;
+		ad_flags |= BT_LE_AD_LIMITED;
+		atomic_set_bit(&current_settings, GAP_SETTINGS_DISCOVERABLE);
+		break;
+	default:
+		tester_rsp(BTP_SERVICE_ID_GAP, GAP_SET_DISCOVERABLE,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+		return;
+	}
+
+	rp.current_settings = sys_cpu_to_le32(current_settings);
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_SET_DISCOVERABLE, CONTROLLER_INDEX,
+		    (u8_t *) &rp, sizeof(rp));
+}
+
+static void start_advertising(const u8_t *data, u16_t len)
+{
+	const struct gap_start_advertising_cmd *cmd = (void *) data;
+	struct gap_start_advertising_rp rp;
+	u8_t adv_len, sd_len;
+	bool adv_conn;
+	int i;
+
+	for (i = 0, adv_len = 1; i < cmd->adv_data_len; adv_len++) {
+		if (adv_len >= ARRAY_SIZE(ad)) {
+			SYS_LOG_ERR("ad[] Out of memory");
+			goto fail;
+		}
+
+		ad[adv_len].type = cmd->adv_data[i++];
+		ad[adv_len].data_len = cmd->adv_data[i++];
+		ad[adv_len].data = &cmd->adv_data[i];
+		i += ad[adv_len].data_len;
+	}
+
+	for (i = 0, sd_len = 0; i < cmd->scan_rsp_len; sd_len++) {
+		if (sd_len >= ARRAY_SIZE(sd)) {
+			SYS_LOG_ERR("sd[] Out of memory");
+			goto fail;
+		}
+
+		sd[sd_len].type = cmd->scan_rsp[i++];
+		sd[sd_len].data_len = cmd->scan_rsp[i++];
+		sd[sd_len].data = &cmd->scan_rsp[i];
+		i += sd[sd_len].data_len;
+	}
+
+	adv_conn = atomic_test_bit(&current_settings, GAP_SETTINGS_CONNECTABLE);
+
+	/* BTP API don't allow to set empty scan response data. */
+	if (bt_le_adv_start(adv_conn ? BT_LE_ADV_CONN : BT_LE_ADV_NCONN,
+			    ad, adv_len, sd_len ? sd : NULL, sd_len) < 0) {
+		SYS_LOG_ERR("Failed to start advertising");
+		goto fail;
+	}
+
+	atomic_set_bit(&current_settings, GAP_SETTINGS_ADVERTISING);
+	rp.current_settings = sys_cpu_to_le32(current_settings);
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_START_ADVERTISING, CONTROLLER_INDEX,
+		    (u8_t *) &rp, sizeof(rp));
+	return;
+fail:
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_START_ADVERTISING, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static void stop_advertising(const u8_t *data, u16_t len)
+{
+	struct gap_stop_advertising_rp rp;
+
+	if (bt_le_adv_stop() < 0) {
+		tester_rsp(BTP_SERVICE_ID_GAP, GAP_STOP_ADVERTISING,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+		return;
+	}
+
+	atomic_clear_bit(&current_settings, GAP_SETTINGS_ADVERTISING);
+	rp.current_settings = sys_cpu_to_le32(current_settings);
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_STOP_ADVERTISING, CONTROLLER_INDEX,
+		    (u8_t *) &rp, sizeof(rp));
+}
+
+static u8_t get_ad_flags(struct net_buf_simple *ad)
+{
+	u8_t len, i;
+
+	/* Parse advertisement to get flags */
+	for (i = 0; i < ad->len; i += len - 1) {
+		len = ad->data[i++];
+		if (!len) {
+			break;
+		}
+
+		/* Check if field length is correct */
+		if (len > (ad->len - i) || (ad->len - i) < 1) {
+			break;
+		}
+
+		switch (ad->data[i++]) {
+		case BT_DATA_FLAGS:
+			return ad->data[i];
+		default:
+			break;
+		}
+	}
+
+	return 0;
+}
+
+static u8_t discovery_flags;
+static struct net_buf_simple *adv_buf = NET_BUF_SIMPLE(ADV_BUF_LEN);
+
+static void store_adv(const bt_addr_le_t *addr, s8_t rssi,
+		      struct net_buf_simple *ad)
+{
+	struct gap_device_found_ev *ev;
+
+	/* cleanup */
+	net_buf_simple_init(adv_buf, 0);
+
+	ev = net_buf_simple_add(adv_buf, sizeof(*ev));
+
+	memcpy(ev->address, addr->a.val, sizeof(ev->address));
+	ev->address_type = addr->type;
+	ev->rssi = rssi;
+	ev->flags = GAP_DEVICE_FOUND_FLAG_AD | GAP_DEVICE_FOUND_FLAG_RSSI;
+	ev->eir_data_len = ad->len;
+	memcpy(net_buf_simple_add(adv_buf, ad->len), ad->data, ad->len);
+}
+
+static void device_found(const bt_addr_le_t *addr, s8_t rssi, u8_t evtype,
+			 struct net_buf_simple *ad)
+{
+	/* if General/Limited Discovery - parse Advertising data to get flags */
+	if (!(discovery_flags & GAP_DISCOVERY_FLAG_LE_OBSERVE) &&
+	    (evtype != BT_LE_ADV_SCAN_RSP)) {
+		u8_t flags = get_ad_flags(ad);
+
+		/* ignore non-discoverable devices */
+		if (!(flags & BT_LE_AD_DISCOV_MASK)) {
+			SYS_LOG_DBG("Non discoverable, skipping");
+			return;
+		}
+
+		/* if Limited Discovery - ignore general discoverable devices */
+		if ((discovery_flags & GAP_DISCOVERY_FLAG_LIMITED) &&
+		    !(flags & BT_LE_AD_LIMITED)) {
+			SYS_LOG_DBG("General discoverable, skipping");
+			return;
+		}
+	}
+
+	/* attach Scan Response data */
+	if (evtype == BT_LE_ADV_SCAN_RSP) {
+		struct gap_device_found_ev *ev;
+		bt_addr_le_t a;
+
+		/* skip if there is no pending advertisement */
+		if (!adv_buf->len) {
+			SYS_LOG_INF("No pending advertisement, skipping");
+			return;
+		}
+
+		ev = (void *) adv_buf->data;
+		a.type = ev->address_type;
+		memcpy(a.a.val, ev->address, sizeof(a.a.val));
+
+		/*
+		 * in general, the Scan Response comes right after the
+		 * Advertisement, but if not if send stored event and ignore
+		 * this one
+		 */
+		if (bt_addr_le_cmp(addr, &a)) {
+			SYS_LOG_INF("Address does not match, skipping");
+			goto done;
+		}
+
+		ev->eir_data_len += ad->len;
+		ev->flags |= GAP_DEVICE_FOUND_FLAG_SD;
+
+		memcpy(net_buf_simple_add(adv_buf, ad->len), ad->data, ad->len);
+
+		goto done;
+	}
+
+	/*
+	 * if there is another pending advertisement, send it and store the
+	 * current one
+	 */
+	if (adv_buf->len) {
+		tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_FOUND,
+			    CONTROLLER_INDEX, adv_buf->data, adv_buf->len);
+	}
+
+	store_adv(addr, rssi, ad);
+
+	/* if Active Scan and scannable event - wait for Scan Response */
+	if ((discovery_flags & GAP_DISCOVERY_FLAG_LE_ACTIVE_SCAN) &&
+	    (evtype == BT_LE_ADV_IND || evtype == BT_LE_ADV_SCAN_IND)) {
+		SYS_LOG_DBG("Waiting for scan response");
+		return;
+	}
+done:
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_DEVICE_FOUND,
+		    CONTROLLER_INDEX, adv_buf->data, adv_buf->len);
+}
+
+static void start_discovery(const u8_t *data, u16_t len)
+{
+	const struct gap_start_discovery_cmd *cmd = (void *) data;
+	u8_t status;
+
+	/* only LE scan is supported */
+	if (cmd->flags & GAP_DISCOVERY_FLAG_BREDR) {
+		status = BTP_STATUS_FAILED;
+		goto reply;
+	}
+
+	if (bt_le_scan_start(cmd->flags & GAP_DISCOVERY_FLAG_LE_ACTIVE_SCAN ?
+			     BT_LE_SCAN_ACTIVE : BT_LE_SCAN_PASSIVE,
+			     device_found) < 0) {
+		status = BTP_STATUS_FAILED;
+		goto reply;
+	}
+
+	net_buf_simple_init(adv_buf, 0);
+	discovery_flags = cmd->flags;
+
+	status = BTP_STATUS_SUCCESS;
+reply:
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_START_DISCOVERY, CONTROLLER_INDEX,
+		   status);
+}
+
+static void stop_discovery(const u8_t *data, u16_t len)
+{
+	u8_t status = BTP_STATUS_SUCCESS;
+
+	if (bt_le_scan_stop() < 0) {
+		status = BTP_STATUS_FAILED;
+	}
+
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_STOP_DISCOVERY, CONTROLLER_INDEX,
+		   status);
+}
+
+static void connect(const u8_t *data, u16_t len)
+{
+	struct bt_conn *conn;
+	u8_t status;
+
+	conn = bt_conn_create_le((bt_addr_le_t *) data,
+				 BT_LE_CONN_PARAM_DEFAULT);
+	if (!conn) {
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
+	bt_conn_unref(conn);
+	status = BTP_STATUS_SUCCESS;
+
+rsp:
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_CONNECT, CONTROLLER_INDEX, status);
+}
+
+static void disconnect(const u8_t *data, u16_t len)
+{
+	struct bt_conn *conn;
+	u8_t status;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
+	if (bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN)) {
+		status = BTP_STATUS_FAILED;
+	} else {
+		status = BTP_STATUS_SUCCESS;
+	}
+
+	bt_conn_unref(conn);
+
+rsp:
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_DISCONNECT, CONTROLLER_INDEX,
+		   status);
+}
+
+static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
+{
+	struct gap_passkey_display_ev ev;
+	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
+
+	memcpy(ev.address, addr->a.val, sizeof(ev.address));
+	ev.address_type = addr->type;
+	ev.passkey = sys_cpu_to_le32(passkey);
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_PASSKEY_DISPLAY,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void auth_passkey_entry(struct bt_conn *conn)
+{
+	struct gap_passkey_entry_req_ev ev;
+	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
+
+	memcpy(ev.address, addr->a.val, sizeof(ev.address));
+	ev.address_type = addr->type;
+
+	tester_send(BTP_SERVICE_ID_GAP, GAP_EV_PASSKEY_ENTRY_REQ,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void auth_cancel(struct bt_conn *conn)
+{
+	/* TODO */
+}
+
+static void set_io_cap(const u8_t *data, u16_t len)
+{
+	const struct gap_set_io_cap_cmd *cmd = (void *) data;
+	u8_t status;
+
+	/* Reset io cap requirements */
+	memset(&cb, 0, sizeof(cb));
+	bt_conn_auth_cb_register(NULL);
+
+	switch (cmd->io_cap) {
+	case GAP_IO_CAP_DISPLAY_ONLY:
+		cb.cancel = auth_cancel;
+		cb.passkey_display = auth_passkey_display;
+		break;
+	case GAP_IO_CAP_KEYBOARD_DISPLAY:
+		cb.cancel = auth_cancel;
+		cb.passkey_display = auth_passkey_display;
+		cb.passkey_entry = auth_passkey_entry;
+		break;
+	case GAP_IO_CAP_NO_INPUT_OUTPUT:
+		cb.cancel = auth_cancel;
+		break;
+	case GAP_IO_CAP_KEYBOARD_ONLY:
+		cb.cancel = auth_cancel;
+		cb.passkey_entry = auth_passkey_entry;
+		break;
+	case GAP_IO_CAP_DISPLAY_YESNO:
+	default:
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
+	if (bt_conn_auth_cb_register(&cb)) {
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
+	status = BTP_STATUS_SUCCESS;
+
+rsp:
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_SET_IO_CAP, CONTROLLER_INDEX,
+		   status);
+}
+
+static void pair(const u8_t *data, u16_t len)
+{
+	struct bt_conn *conn;
+	u8_t status;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
+	if (bt_conn_security(conn, BT_SECURITY_MEDIUM)) {
+		status = BTP_STATUS_FAILED;
+		bt_conn_unref(conn);
+		goto rsp;
+	}
+
+	bt_conn_unref(conn);
+	status = BTP_STATUS_SUCCESS;
+
+rsp:
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_PAIR, CONTROLLER_INDEX, status);
+}
+
+static void unpair(const u8_t *data, u16_t len)
+{
+	struct gap_unpair_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+	bt_addr_le_t addr;
+	u8_t status;
+	int err;
+
+	addr.type = cmd->address_type;
+	memcpy(addr.a.val, cmd->address, sizeof(addr.a.val));
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, &addr);
+	if (!conn) {
+		goto keys;
+	}
+
+	err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+
+	bt_conn_unref(conn);
+
+	if (err < 0) {
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+keys:
+	err = bt_unpair(BT_ID_DEFAULT, &addr);
+
+	status = err < 0 ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS;
+rsp:
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_UNPAIR, CONTROLLER_INDEX, status);
+}
+
+static void passkey_entry(const u8_t *data, u16_t len)
+{
+	const struct gap_passkey_entry_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+	u8_t status;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
+	bt_conn_auth_passkey_entry(conn, sys_le32_to_cpu(cmd->passkey));
+
+	bt_conn_unref(conn);
+	status = BTP_STATUS_SUCCESS;
+
+rsp:
+	tester_rsp(BTP_SERVICE_ID_GAP, GAP_PASSKEY_ENTRY, CONTROLLER_INDEX,
+		   status);
+}
+
+void tester_handle_gap(u8_t opcode, u8_t index, u8_t *data,
+		       u16_t len)
+{
+	switch (opcode) {
+	case GAP_READ_SUPPORTED_COMMANDS:
+	case GAP_READ_CONTROLLER_INDEX_LIST:
+		if (index != BTP_INDEX_NONE){
+			tester_rsp(BTP_SERVICE_ID_GAP, opcode, index,
+				   BTP_STATUS_FAILED);
+			return;
+		}
+		break;
+	default:
+		if (index != CONTROLLER_INDEX){
+			tester_rsp(BTP_SERVICE_ID_GAP, opcode, index,
+				   BTP_STATUS_FAILED);
+			return;
+		}
+		break;
+	}
+
+	switch (opcode) {
+	case GAP_READ_SUPPORTED_COMMANDS:
+		supported_commands(data, len);
+		return;
+	case GAP_READ_CONTROLLER_INDEX_LIST:
+		controller_index_list(data, len);
+		return;
+	case GAP_READ_CONTROLLER_INFO:
+		controller_info(data, len);
+		return;
+	case GAP_SET_CONNECTABLE:
+		set_connectable(data, len);
+		return;
+	case GAP_SET_DISCOVERABLE:
+		set_discoverable(data, len);
+		return;
+	case GAP_START_ADVERTISING:
+		start_advertising(data, len);
+		return;
+	case GAP_STOP_ADVERTISING:
+		stop_advertising(data, len);
+		return;
+	case GAP_START_DISCOVERY:
+		start_discovery(data, len);
+		return;
+	case GAP_STOP_DISCOVERY:
+		stop_discovery(data, len);
+		return;
+	case GAP_CONNECT:
+		connect(data, len);
+		return;
+	case GAP_DISCONNECT:
+		disconnect(data, len);
+		return;
+	case GAP_SET_IO_CAP:
+		set_io_cap(data, len);
+		return;
+	case GAP_PAIR:
+		pair(data, len);
+		return;
+	case GAP_UNPAIR:
+		unpair(data, len);
+		return;
+	case GAP_PASSKEY_ENTRY:
+		passkey_entry(data, len);
+		return;
+	default:
+		tester_rsp(BTP_SERVICE_ID_GAP, opcode, index,
+			   BTP_STATUS_UNKNOWN_CMD);
+		return;
+	}
+}
+
+static void tester_init_gap_cb(int err)
+{
+	if (err) {
+		tester_rsp(BTP_SERVICE_ID_CORE, CORE_REGISTER_SERVICE,
+			   BTP_INDEX_NONE, BTP_STATUS_FAILED);
+		return;
+	}
+
+	atomic_clear(&current_settings);
+	atomic_set_bit(&current_settings, GAP_SETTINGS_POWERED);
+	atomic_set_bit(&current_settings, GAP_SETTINGS_CONNECTABLE);
+	atomic_set_bit(&current_settings, GAP_SETTINGS_BONDABLE);
+	atomic_set_bit(&current_settings, GAP_SETTINGS_LE);
+#if defined(CONFIG_BT_PRIVACY)
+	atomic_set_bit(&current_settings, GAP_SETTINGS_PRIVACY);
+#endif /* CONFIG_BT_PRIVACY */
+
+	bt_conn_cb_register(&conn_callbacks);
+
+	tester_rsp(BTP_SERVICE_ID_CORE, CORE_REGISTER_SERVICE, BTP_INDEX_NONE,
+		   BTP_STATUS_SUCCESS);
+}
+
+u8_t tester_init_gap(void)
+{
+	if (bt_enable(tester_init_gap_cb) < 0) {
+		return BTP_STATUS_FAILED;
+	}
+
+	return BTP_STATUS_SUCCESS;
+}
+
+u8_t tester_unregister_gap(void)
+{
+	return BTP_STATUS_SUCCESS;
+}

--- a/apps/bttester/src/gatt.c
+++ b/apps/bttester/src/gatt.c
@@ -1,0 +1,1952 @@
+/* gatt.c - Bluetooth GATT Server Tester */
+
+/*
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/types.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+
+#include <toolchain.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/conn.h>
+#include <bluetooth/gatt.h>
+#include <bluetooth/uuid.h>
+#include <misc/byteorder.h>
+#include <misc/printk.h>
+#include <net/buf.h>
+
+#include "bttester.h"
+
+#define CONTROLLER_INDEX 0
+#define MAX_BUFFER_SIZE 2048
+#define MAX_UUID_LEN 16
+
+/* This masks Permission bits from GATT API */
+#define GATT_PERM_MASK			(BT_GATT_PERM_READ | \
+					 BT_GATT_PERM_READ_AUTHEN | \
+					 BT_GATT_PERM_READ_ENCRYPT | \
+					 BT_GATT_PERM_WRITE | \
+					 BT_GATT_PERM_WRITE_AUTHEN | \
+					 BT_GATT_PERM_WRITE_ENCRYPT | \
+					 BT_GATT_PERM_PREPARE_WRITE)
+#define GATT_PERM_ENC_READ_MASK		(BT_GATT_PERM_READ_ENCRYPT | \
+					 BT_GATT_PERM_READ_AUTHEN)
+#define GATT_PERM_ENC_WRITE_MASK	(BT_GATT_PERM_WRITE_ENCRYPT | \
+					 BT_GATT_PERM_WRITE_AUTHEN)
+#define GATT_PERM_READ_AUTHORIZATION	0x40
+#define GATT_PERM_WRITE_AUTHORIZATION	0x80
+
+/* GATT server context */
+#define SERVER_MAX_SERVICES		10
+#define SERVER_MAX_ATTRIBUTES		50
+#define SERVER_BUF_SIZE			2048
+
+/* bt_gatt_attr_next cannot be used on non-registered services */
+#define NEXT_DB_ATTR(attr) (attr + 1)
+#define LAST_DB_ATTR (server_db + (attr_count - 1))
+
+#define server_buf_push(_len)	net_buf_push(server_buf, ROUND_UP(_len, 4))
+#define server_buf_pull(_len)	net_buf_pull(server_buf, ROUND_UP(_len, 4))
+
+static struct bt_gatt_service server_svcs[SERVER_MAX_SERVICES];
+static struct bt_gatt_attr server_db[SERVER_MAX_ATTRIBUTES];
+static struct net_buf *server_buf;
+NET_BUF_POOL_DEFINE(server_pool, 1, SERVER_BUF_SIZE, 0, NULL);
+
+static u8_t attr_count;
+static u8_t svc_attr_count;
+static u8_t svc_count;
+
+/*
+ * gatt_buf - cache used by a gatt client (to cache data read/discovered)
+ * and gatt server (to store attribute user_data).
+ * It is not intended to be used by client and server at the same time.
+ */
+static struct {
+	u16_t len;
+	u8_t buf[MAX_BUFFER_SIZE];
+} gatt_buf;
+
+static void *gatt_buf_add(const void *data, size_t len)
+{
+	void *ptr = gatt_buf.buf + gatt_buf.len;
+
+	if ((len + gatt_buf.len) > MAX_BUFFER_SIZE) {
+		return NULL;
+	}
+
+	if (data) {
+		memcpy(ptr, data, len);
+	} else {
+		memset(ptr, 0, len);
+	}
+
+	gatt_buf.len += len;
+
+	SYS_LOG_DBG("%d/%d used", gatt_buf.len, MAX_BUFFER_SIZE);
+
+	return ptr;
+}
+
+static void *gatt_buf_reserve(size_t len)
+{
+	return gatt_buf_add(NULL, len);
+}
+
+static void gatt_buf_clear(void)
+{
+	memset(&gatt_buf, 0, sizeof(gatt_buf));
+}
+
+union uuid {
+	struct bt_uuid uuid;
+	struct bt_uuid_16 u16;
+	struct bt_uuid_128 u128;
+};
+
+static struct bt_gatt_attr *gatt_db_add(const struct bt_gatt_attr *pattern,
+					size_t user_data_len)
+{
+	static struct bt_gatt_attr *attr = server_db;
+	const union uuid *u = CONTAINER_OF(pattern->uuid, union uuid, uuid);
+	size_t uuid_size = u->uuid.type == BT_UUID_TYPE_16 ? sizeof(u->u16) :
+							     sizeof(u->u128);
+
+	/* Return NULL if database is full */
+	if (attr == &server_db[SERVER_MAX_ATTRIBUTES - 1]) {
+		return NULL;
+	}
+
+	/* First attribute in db must be service */
+	if (!svc_count) {
+		return NULL;
+	}
+
+	memcpy(attr, pattern, sizeof(*attr));
+
+	/* Store the UUID. */
+	attr->uuid = server_buf_push(uuid_size);
+	memcpy((void *) attr->uuid, &u->uuid, uuid_size);
+
+	/* Copy user_data to the buffer. */
+	if (user_data_len) {
+		attr->user_data = server_buf_push(user_data_len);
+		memcpy(attr->user_data, pattern->user_data, user_data_len);
+	}
+
+	SYS_LOG_DBG("handle 0x%04x", attr->handle);
+
+	attr_count++;
+	svc_attr_count++;
+
+	return attr++;
+}
+
+/* Convert UUID from BTP command to bt_uuid */
+static u8_t btp2bt_uuid(const u8_t *uuid, u8_t len,
+			   struct bt_uuid *bt_uuid)
+{
+	u16_t le16;
+
+	switch (len) {
+	case 0x02: /* UUID 16 */
+		bt_uuid->type = BT_UUID_TYPE_16;
+		memcpy(&le16, uuid, sizeof(le16));
+		BT_UUID_16(bt_uuid)->val = sys_le16_to_cpu(le16);
+		break;
+	case 0x10: /* UUID 128*/
+		bt_uuid->type = BT_UUID_TYPE_128;
+		memcpy(BT_UUID_128(bt_uuid)->val, uuid, 16);
+		break;
+	default:
+		return BTP_STATUS_FAILED;
+	}
+
+	return BTP_STATUS_SUCCESS;
+}
+
+static void supported_commands(u8_t *data, u16_t len)
+{
+	u8_t cmds[4];
+	struct gatt_read_supported_commands_rp *rp = (void *) cmds;
+
+	memset(cmds, 0, sizeof(cmds));
+
+	tester_set_bit(cmds, GATT_READ_SUPPORTED_COMMANDS);
+	tester_set_bit(cmds, GATT_ADD_SERVICE);
+	tester_set_bit(cmds, GATT_ADD_CHARACTERISTIC);
+	tester_set_bit(cmds, GATT_ADD_DESCRIPTOR);
+	tester_set_bit(cmds, GATT_ADD_INCLUDED_SERVICE);
+	tester_set_bit(cmds, GATT_SET_VALUE);
+	tester_set_bit(cmds, GATT_START_SERVER);
+	tester_set_bit(cmds, GATT_SET_ENC_KEY_SIZE);
+	tester_set_bit(cmds, GATT_EXCHANGE_MTU);
+	tester_set_bit(cmds, GATT_DISC_PRIM_UUID);
+	tester_set_bit(cmds, GATT_FIND_INCLUDED);
+	tester_set_bit(cmds, GATT_DISC_ALL_CHRC);
+	tester_set_bit(cmds, GATT_DISC_CHRC_UUID);
+	tester_set_bit(cmds, GATT_DISC_ALL_DESC);
+	tester_set_bit(cmds, GATT_READ);
+	tester_set_bit(cmds, GATT_READ_LONG);
+	tester_set_bit(cmds, GATT_READ_MULTIPLE);
+	tester_set_bit(cmds, GATT_WRITE_WITHOUT_RSP);
+	tester_set_bit(cmds, GATT_SIGNED_WRITE_WITHOUT_RSP);
+	tester_set_bit(cmds, GATT_WRITE);
+	tester_set_bit(cmds, GATT_WRITE_LONG);
+	tester_set_bit(cmds, GATT_CFG_NOTIFY);
+	tester_set_bit(cmds, GATT_CFG_INDICATE);
+	tester_set_bit(cmds, GATT_GET_ATTRIBUTES);
+	tester_set_bit(cmds, GATT_GET_ATTRIBUTE_VALUE);
+
+	tester_send(BTP_SERVICE_ID_GATT, GATT_READ_SUPPORTED_COMMANDS,
+		    CONTROLLER_INDEX, (u8_t *) rp, sizeof(cmds));
+}
+
+static int register_service(void)
+{
+	server_svcs[svc_count].attrs = server_db +
+				       (attr_count - svc_attr_count);
+	server_svcs[svc_count].attr_count = svc_attr_count;
+
+	return bt_gatt_service_register(&server_svcs[svc_count]);
+}
+
+static void add_service(u8_t *data, u16_t len)
+{
+	const struct gatt_add_service_cmd *cmd = (void *) data;
+	struct gatt_add_service_rp rp;
+	struct bt_gatt_attr *attr_svc = NULL;
+	union uuid uuid;
+	size_t uuid_size;
+
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
+		goto fail;
+	}
+
+	uuid_size = uuid.uuid.type == BT_UUID_TYPE_16 ? sizeof(uuid.u16) :
+							sizeof(uuid.u128);
+
+	/* Register last defined service */
+	if (svc_count) {
+		if (register_service()) {
+			goto fail;
+		}
+	}
+
+	svc_count++;
+	svc_attr_count = 0;
+
+	switch (cmd->type) {
+	case GATT_SERVICE_PRIMARY:
+		attr_svc = gatt_db_add(&(struct bt_gatt_attr)
+				       BT_GATT_PRIMARY_SERVICE(&uuid.uuid),
+				       uuid_size);
+		break;
+	case GATT_SERVICE_SECONDARY:
+		attr_svc = gatt_db_add(&(struct bt_gatt_attr)
+				       BT_GATT_SECONDARY_SERVICE(&uuid.uuid),
+				       uuid_size);
+		break;
+	}
+
+	if (!attr_svc) {
+		svc_count--;
+		goto fail;
+	}
+
+	rp.svc_id = sys_cpu_to_le16(attr_svc->handle);
+
+	tester_send(BTP_SERVICE_ID_GATT, GATT_ADD_SERVICE, CONTROLLER_INDEX,
+		    (u8_t *) &rp, sizeof(rp));
+
+	return;
+fail:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_ADD_SERVICE, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+struct gatt_value {
+	u16_t len;
+	u8_t *data;
+	u8_t enc_key_size;
+	u8_t flags[1];
+};
+
+enum {
+	GATT_VALUE_CCC_FLAG,
+	GATT_VALUE_READ_AUTHOR_FLAG,
+	GATT_VALUE_WRITE_AUTHOR_FLAG,
+};
+
+static ssize_t read_value(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+			  void *buf, u16_t len, u16_t offset)
+{
+	const struct gatt_value *value = attr->user_data;
+
+	if (tester_test_bit(value->flags, GATT_VALUE_READ_AUTHOR_FLAG)) {
+		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
+
+	if ((attr->perm & GATT_PERM_ENC_READ_MASK) &&
+	    (value->enc_key_size > bt_conn_enc_key_size(conn))) {
+		return BT_GATT_ERR(BT_ATT_ERR_ENCRYPTION_KEY_SIZE);
+	}
+
+	return bt_gatt_attr_read(conn, attr, buf, len, offset, value->data,
+				 value->len);
+}
+
+static void attr_value_changed_ev(u16_t handle, const u8_t *value, u16_t len)
+{
+	u8_t buf[len + sizeof(struct gatt_attr_value_changed_ev)];
+	struct gatt_attr_value_changed_ev *ev = (void *) buf;
+
+	ev->handle = sys_cpu_to_le16(handle);
+	ev->data_length = sys_cpu_to_le16(len);
+	memcpy(ev->data, value, len);
+
+	tester_send(BTP_SERVICE_ID_GATT, GATT_EV_ATTR_VALUE_CHANGED,
+		    CONTROLLER_INDEX, buf, sizeof(buf));
+}
+
+static ssize_t write_value(struct bt_conn *conn,
+			   const struct bt_gatt_attr *attr, const void *buf,
+			   u16_t len, u16_t offset, u8_t flags)
+{
+	struct gatt_value *value = attr->user_data;
+
+	if (tester_test_bit(value->flags, GATT_VALUE_WRITE_AUTHOR_FLAG)) {
+		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
+
+	if ((attr->perm & GATT_PERM_ENC_WRITE_MASK) &&
+	    (value->enc_key_size > bt_conn_enc_key_size(conn))) {
+		return BT_GATT_ERR(BT_ATT_ERR_ENCRYPTION_KEY_SIZE);
+	}
+
+	/* Don't write anything if prepare flag is set */
+	if (flags & BT_GATT_WRITE_FLAG_PREPARE) {
+		return 0;
+	}
+
+	if (offset > value->len) {
+		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
+	}
+
+	if (offset + len > value->len) {
+		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
+	}
+
+	memcpy(value->data + offset, buf, len);
+
+	/* Maximum attribute value size is 512 bytes */
+	assert(value->len < 512);
+
+	attr_value_changed_ev(attr->handle, value->data, value->len);
+
+	return len;
+}
+
+struct add_characteristic {
+	u16_t char_id;
+	u8_t properties;
+	u8_t permissions;
+	const struct bt_uuid *uuid;
+};
+
+static int alloc_characteristic(struct add_characteristic *ch)
+{
+	struct bt_gatt_attr *attr_chrc, *attr_value;
+	struct bt_gatt_chrc *chrc_data;
+	struct gatt_value value;
+
+	/* Add Characteristic Declaration */
+	attr_chrc = gatt_db_add(&(struct bt_gatt_attr)
+				BT_GATT_ATTRIBUTE(BT_UUID_GATT_CHRC,
+						  BT_GATT_PERM_READ,
+						  bt_gatt_attr_read_chrc, NULL,
+						  (&(struct bt_gatt_chrc){})),
+				sizeof(*chrc_data));
+	if (!attr_chrc) {
+		return -EINVAL;
+	}
+
+	memset(&value, 0, sizeof(value));
+
+	if (ch->permissions & GATT_PERM_READ_AUTHORIZATION) {
+		tester_set_bit(value.flags, GATT_VALUE_READ_AUTHOR_FLAG);
+
+		/* To maintain backward compatibility, set Read Permission */
+		if (!(ch->permissions & GATT_PERM_ENC_READ_MASK)) {
+			ch->permissions |= BT_GATT_PERM_READ;
+		}
+	}
+
+	if (ch->permissions & GATT_PERM_WRITE_AUTHORIZATION) {
+		tester_set_bit(value.flags, GATT_VALUE_WRITE_AUTHOR_FLAG);
+
+		/* To maintain backward compatibility, set Write Permission */
+		if (!(ch->permissions & GATT_PERM_ENC_WRITE_MASK)) {
+			ch->permissions |= BT_GATT_PERM_WRITE;
+		}
+	}
+
+	/* Allow prepare writes */
+	ch->permissions |= BT_GATT_PERM_PREPARE_WRITE;
+
+	/* Add Characteristic Value */
+	attr_value = gatt_db_add(&(struct bt_gatt_attr)
+				 BT_GATT_ATTRIBUTE(ch->uuid,
+					ch->permissions & GATT_PERM_MASK,
+					read_value, write_value, &value),
+					sizeof(value));
+	if (!attr_value) {
+		server_buf_pull(sizeof(*chrc_data));
+		/* Characteristic attribute uuid has constant length */
+		server_buf_pull(sizeof(uint16_t));
+		return -EINVAL;
+	}
+
+	chrc_data = attr_chrc->user_data;
+	chrc_data->properties = ch->properties;
+	chrc_data->uuid = attr_value->uuid;
+
+	ch->char_id = attr_chrc->handle;
+	return 0;
+}
+
+static void add_characteristic(u8_t *data, u16_t len)
+{
+	const struct gatt_add_characteristic_cmd *cmd = (void *) data;
+	struct gatt_add_characteristic_rp rp;
+	struct add_characteristic cmd_data;
+	union uuid uuid;
+
+	/* Pre-set char_id */
+	cmd_data.char_id = 0;
+	cmd_data.permissions = cmd->permissions;
+	cmd_data.properties = cmd->properties;
+	cmd_data.uuid = &uuid.uuid;
+
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
+		goto fail;
+	}
+
+	/* characterisic must be added only sequential */
+	if (cmd->svc_id) {
+		goto fail;
+	}
+
+	if (alloc_characteristic(&cmd_data)) {
+		goto fail;
+	}
+
+	rp.char_id = sys_cpu_to_le16(cmd_data.char_id);
+	tester_send(BTP_SERVICE_ID_GATT, GATT_ADD_CHARACTERISTIC,
+		    CONTROLLER_INDEX, (u8_t *) &rp, sizeof(rp));
+	return;
+
+fail:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_ADD_CHARACTERISTIC,
+		   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+}
+
+static bool ccc_added;
+
+static struct bt_gatt_ccc_cfg ccc_cfg[BT_GATT_CCC_MAX] = {};
+static u8_t ccc_value;
+
+static void ccc_cfg_changed(const struct bt_gatt_attr *attr, u16_t value)
+{
+	ccc_value = value;
+}
+
+static struct bt_gatt_attr ccc = BT_GATT_CCC(ccc_cfg, ccc_cfg_changed);
+
+static struct bt_gatt_attr *add_ccc(const struct bt_gatt_attr *attr)
+{
+	struct bt_gatt_attr *attr_desc;
+	struct bt_gatt_chrc *chrc = attr->user_data;
+	struct gatt_value *value = NEXT_DB_ATTR(attr)->user_data;
+
+	/* Fail if another CCC already exist on server */
+	if (ccc_added) {
+		return NULL;
+	}
+
+	/* Check characteristic properties */
+	if (!(chrc->properties &
+	    (BT_GATT_CHRC_NOTIFY | BT_GATT_CHRC_INDICATE))) {
+		return NULL;
+	}
+
+	/* Add CCC descriptor to GATT database */
+	attr_desc = gatt_db_add(&ccc, 0);
+	if (!attr_desc) {
+		return NULL;
+	}
+
+	tester_set_bit(value->flags, GATT_VALUE_CCC_FLAG);
+	ccc_added = true;
+
+	return attr_desc;
+}
+
+static struct bt_gatt_attr *add_cep(const struct bt_gatt_attr *attr_chrc)
+{
+	struct bt_gatt_chrc *chrc = attr_chrc->user_data;
+	struct bt_gatt_cep cep_value;
+
+	/* Extended Properties bit shall be set */
+	if (!(chrc->properties & BT_GATT_CHRC_EXT_PROP)) {
+		return NULL;
+	}
+
+	cep_value.properties = 0x0000;
+
+	/* Add CEP descriptor to GATT database */
+	return gatt_db_add(&(struct bt_gatt_attr) BT_GATT_CEP(&cep_value),
+			   sizeof(cep_value));
+}
+
+struct add_descriptor {
+	u16_t desc_id;
+	u8_t permissions;
+	const struct bt_uuid *uuid;
+};
+
+static int alloc_descriptor(const struct bt_gatt_attr *attr,
+			    struct add_descriptor *d)
+{
+	struct bt_gatt_attr *attr_desc;
+	struct gatt_value value;
+
+	if (!bt_uuid_cmp(d->uuid, BT_UUID_GATT_CEP)) {
+		attr_desc = add_cep(attr);
+	} else if (!bt_uuid_cmp(d->uuid, BT_UUID_GATT_CCC)) {
+		attr_desc = add_ccc(attr);
+	} else {
+		memset(&value, 0, sizeof(value));
+
+		if (d->permissions & GATT_PERM_READ_AUTHORIZATION) {
+			tester_set_bit(value.flags,
+				       GATT_VALUE_READ_AUTHOR_FLAG);
+
+			/*
+			 * To maintain backward compatibility,
+			 * set Read Permission
+			 */
+			if (!(d->permissions & GATT_PERM_ENC_READ_MASK)) {
+				d->permissions |= BT_GATT_PERM_READ;
+			}
+		}
+
+		if (d->permissions & GATT_PERM_WRITE_AUTHORIZATION) {
+			tester_set_bit(value.flags,
+				       GATT_VALUE_WRITE_AUTHOR_FLAG);
+
+			/*
+			 * To maintain backward compatibility,
+			 * set Write Permission
+			 */
+			if (!(d->permissions & GATT_PERM_ENC_WRITE_MASK)) {
+				d->permissions |= BT_GATT_PERM_WRITE;
+			}
+		}
+
+		/* Allow prepare writes */
+		d->permissions |= BT_GATT_PERM_PREPARE_WRITE;
+
+		attr_desc = gatt_db_add(&(struct bt_gatt_attr)
+					BT_GATT_DESCRIPTOR(d->uuid,
+						d->permissions & GATT_PERM_MASK,
+						read_value, write_value,
+						&value), sizeof(value));
+	}
+
+	if (!attr_desc) {
+		return -EINVAL;
+	}
+
+	d->desc_id = attr_desc->handle;
+	return 0;
+}
+
+static struct bt_gatt_attr *get_base_chrc(struct bt_gatt_attr *attr)
+{
+	struct bt_gatt_attr *tmp;
+
+	for (tmp = attr; tmp > server_db; tmp--) {
+		/* Service Declaration cannot precede Descriptor declaration */
+		if (!bt_uuid_cmp(tmp->uuid, BT_UUID_GATT_PRIMARY) ||
+		    !bt_uuid_cmp(tmp->uuid, BT_UUID_GATT_SECONDARY)) {
+			break;
+		}
+
+		if (!bt_uuid_cmp(tmp->uuid, BT_UUID_GATT_CHRC)) {
+			return tmp;
+		}
+	}
+
+	return NULL;
+}
+
+static void add_descriptor(u8_t *data, u16_t len)
+{
+	const struct gatt_add_descriptor_cmd *cmd = (void *) data;
+	struct gatt_add_descriptor_rp rp;
+	struct add_descriptor cmd_data;
+	struct bt_gatt_attr *chrc;
+	union uuid uuid;
+
+	/* Must be declared first svc or at least 3 attrs (svc+char+char val) */
+	if (!svc_count || attr_count < 3) {
+		goto fail;
+	}
+
+	/* Pre-set desc_id */
+	cmd_data.desc_id = 0;
+	cmd_data.permissions = cmd->permissions;
+	cmd_data.uuid = &uuid.uuid;
+
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
+		goto fail;
+	}
+
+	/* descriptor can be added only sequential */
+	if (cmd->char_id) {
+		goto fail;
+	}
+
+	/* Lookup preceding Characteristic Declaration here */
+	chrc = get_base_chrc(LAST_DB_ATTR);
+	if (!chrc) {
+		goto fail;
+	}
+
+	if (alloc_descriptor(chrc, &cmd_data)) {
+		goto fail;
+	}
+
+	rp.desc_id = sys_cpu_to_le16(cmd_data.desc_id);
+	tester_send(BTP_SERVICE_ID_GATT, GATT_ADD_DESCRIPTOR, CONTROLLER_INDEX,
+		    (u8_t *) &rp, sizeof(rp));
+	return;
+
+fail:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_ADD_DESCRIPTOR,
+		   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+}
+
+static int alloc_included(struct bt_gatt_attr *attr,
+			  u16_t *included_service_id, u16_t svc_handle)
+{
+	struct bt_gatt_attr *attr_incl;
+
+	/*
+	 * user_data_len is set to 0 to NOT allocate memory in server_buf for
+	 * user_data, just to assign to it attr pointer.
+	 */
+	attr_incl = gatt_db_add(&(struct bt_gatt_attr)
+				BT_GATT_INCLUDE_SERVICE(attr), 0);
+
+	if (!attr_incl) {
+		return -EINVAL;
+	}
+
+	attr_incl->user_data = attr;
+
+	*included_service_id = attr_incl->handle;
+	return 0;
+}
+
+static void add_included(u8_t *data, u16_t len)
+{
+	const struct gatt_add_included_service_cmd *cmd = (void *) data;
+	struct gatt_add_included_service_rp rp;
+	struct bt_gatt_attr *svc;
+	u16_t included_service_id = 0;
+
+	if (!svc_count || !cmd->svc_id) {
+		goto fail;
+	}
+
+	svc = &server_db[cmd->svc_id - 1];
+
+	/* Fail if attribute stored under requested handle is not a service */
+	if (bt_uuid_cmp(svc->uuid, BT_UUID_GATT_PRIMARY) &&
+	    bt_uuid_cmp(svc->uuid, BT_UUID_GATT_SECONDARY)) {
+		goto fail;
+	}
+
+	if (alloc_included(svc, &included_service_id, cmd->svc_id)) {
+		goto fail;
+	}
+
+	rp.included_service_id = sys_cpu_to_le16(included_service_id);
+	tester_send(BTP_SERVICE_ID_GATT, GATT_ADD_INCLUDED_SERVICE,
+		    CONTROLLER_INDEX, (u8_t *) &rp, sizeof(rp));
+	return;
+
+fail:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_ADD_INCLUDED_SERVICE,
+		   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+}
+
+static u8_t set_cep_value(struct bt_gatt_attr *attr, const void *value,
+			     const u16_t len)
+{
+	struct bt_gatt_cep *cep_value = attr->user_data;
+	u16_t properties;
+
+	if (len != sizeof(properties)) {
+		return BTP_STATUS_FAILED;
+	}
+
+	memcpy(&properties, value, len);
+	cep_value->properties = sys_le16_to_cpu(properties);
+
+	return BTP_STATUS_SUCCESS;
+}
+
+struct set_value {
+	const u8_t *value;
+	u16_t len;
+};
+
+struct bt_gatt_indicate_params indicate_params;
+
+static void indicate_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
+			u8_t err)
+{
+	if (err != 0) {
+		SYS_LOG_ERR("Indication fail");
+	} else {
+		SYS_LOG_DBG("Indication success");
+	}
+}
+
+static u8_t alloc_value(struct bt_gatt_attr *attr, struct set_value *data)
+{
+	struct gatt_value *value;
+
+	/* Value has been already set while adding CCC to the gatt_db */
+	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CCC)) {
+		return BTP_STATUS_SUCCESS;
+	}
+
+	/* Set CEP value */
+	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CEP)) {
+		return set_cep_value(attr, data->value, data->len);
+	}
+
+	value = attr->user_data;
+
+	/* Check if attribute value has been already set */
+	if (!value->len) {
+		value->data = server_buf_push(data->len);
+		value->len = data->len;
+	}
+
+	/* Fail if value length doesn't match  */
+	if (value->len != data->len) {
+		return BTP_STATUS_FAILED;
+	}
+
+	memcpy(value->data, data->value, value->len);
+
+	if (tester_test_bit(value->flags, GATT_VALUE_CCC_FLAG) && ccc_value) {
+		if (ccc_value == BT_GATT_CCC_NOTIFY) {
+			bt_gatt_notify(NULL, attr, value->data, value->len);
+		} else {
+			indicate_params.attr = attr;
+			indicate_params.data = value->data;
+			indicate_params.len = value->len;
+			indicate_params.func = indicate_cb;
+
+			bt_gatt_indicate(NULL, &indicate_params);
+		}
+	}
+
+	return BTP_STATUS_SUCCESS;
+}
+
+static void set_value(u8_t *data, u16_t len)
+{
+	const struct gatt_set_value_cmd *cmd = (void *) data;
+	struct set_value cmd_data;
+	u8_t status;
+
+	/* Pre-set btp_status */
+	cmd_data.value = cmd->value;
+	cmd_data.len = sys_le16_to_cpu(cmd->len);
+
+	if (!cmd->attr_id) {
+		status = alloc_value(LAST_DB_ATTR, &cmd_data);
+	} else {
+		/* set value of local attr, corrected by pre set attr handles */
+		status = alloc_value(&server_db[cmd->attr_id -
+				     server_db[0].handle], &cmd_data);
+	}
+
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_SET_VALUE, CONTROLLER_INDEX,
+		   status);
+}
+
+static void start_server(u8_t *data, u16_t len)
+{
+	struct gatt_start_server_rp rp;
+
+	/* Register last defined service */
+	if (svc_count) {
+		if (register_service()) {
+			tester_rsp(BTP_SERVICE_ID_GATT, GATT_START_SERVER,
+				   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+			return;
+		}
+	}
+
+	tester_send(BTP_SERVICE_ID_GATT, GATT_START_SERVER, CONTROLLER_INDEX,
+		    (u8_t *) &rp, sizeof(rp));
+}
+
+static int set_attr_enc_key_size(const struct bt_gatt_attr *attr,
+				 u8_t key_size)
+{
+	struct gatt_value *value;
+
+	/* Fail if requested attribute is a service */
+	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_PRIMARY) ||
+	    !bt_uuid_cmp(attr->uuid, BT_UUID_GATT_SECONDARY) ||
+	    !bt_uuid_cmp(attr->uuid, BT_UUID_GATT_INCLUDE)) {
+		return -EINVAL;
+	}
+
+	/* Fail if permissions are not set */
+	if (!(attr->perm & (GATT_PERM_ENC_READ_MASK |
+			    GATT_PERM_ENC_WRITE_MASK))) {
+		return -EINVAL;
+	}
+
+	value = attr->user_data;
+	value->enc_key_size = key_size;
+
+	return 0;
+}
+
+static void set_enc_key_size(u8_t *data, u16_t len)
+{
+	const struct gatt_set_enc_key_size_cmd *cmd = (void *) data;
+	u8_t status;
+
+	/* Fail if requested key size is invalid */
+	if (cmd->key_size < 0x07 || cmd->key_size > 0x0f) {
+		status = BTP_STATUS_FAILED;
+		goto fail;
+	}
+
+	if (!cmd->attr_id) {
+		status = set_attr_enc_key_size(LAST_DB_ATTR, cmd->key_size);
+	} else {
+		/* set value of local attr, corrected by pre set attr handles */
+		status = set_attr_enc_key_size(&server_db[cmd->attr_id -
+					       server_db[0].handle],
+					       cmd->key_size);
+	}
+
+fail:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_SET_ENC_KEY_SIZE, CONTROLLER_INDEX,
+		   status);
+}
+
+static void exchange_func(struct bt_conn *conn, u8_t err,
+			  struct bt_gatt_exchange_params *params)
+{
+	if (err) {
+		tester_rsp(BTP_SERVICE_ID_GATT, GATT_EXCHANGE_MTU,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+
+		return;
+	}
+
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_EXCHANGE_MTU, CONTROLLER_INDEX,
+		   BTP_STATUS_SUCCESS);
+}
+
+static struct bt_gatt_exchange_params exchange_params;
+
+static void exchange_mtu(u8_t *data, u16_t len)
+{
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail;
+	}
+
+	exchange_params.func = exchange_func;
+
+	if (bt_gatt_exchange_mtu(conn, &exchange_params) < 0) {
+		bt_conn_unref(conn);
+
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_EXCHANGE_MTU,
+		   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+}
+
+static struct bt_gatt_discover_params discover_params;
+static union uuid uuid;
+static u8_t btp_opcode;
+
+static void discover_destroy(struct bt_gatt_discover_params *params)
+{
+	memset(params, 0, sizeof(*params));
+	gatt_buf_clear();
+}
+
+static u8_t disc_prim_uuid_cb(struct bt_conn *conn,
+				 const struct bt_gatt_attr *attr,
+				 struct bt_gatt_discover_params *params)
+{
+	struct bt_gatt_service_val *data;
+	struct gatt_disc_prim_uuid_rp *rp = (void *) gatt_buf.buf;
+	struct gatt_service *service;
+	u8_t uuid_length;
+
+	if (!attr) {
+		tester_send(BTP_SERVICE_ID_GATT, GATT_DISC_PRIM_UUID,
+			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
+		discover_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	data = attr->user_data;
+
+	uuid_length = data->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
+
+	service = gatt_buf_reserve(sizeof(*service) + uuid_length);
+	if (!service) {
+		tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_PRIM_UUID,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+		discover_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	service->start_handle = sys_cpu_to_le16(attr->handle);
+	service->end_handle = sys_cpu_to_le16(data->end_handle);
+	service->uuid_length = uuid_length;
+
+	if (data->uuid->type == BT_UUID_TYPE_16) {
+		u16_t u16 = sys_cpu_to_le16(BT_UUID_16(data->uuid)->val);
+
+		memcpy(service->uuid, &u16, uuid_length);
+	} else {
+		memcpy(service->uuid, BT_UUID_128(data->uuid)->val,
+		       uuid_length);
+	}
+
+	rp->services_count++;
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static void disc_prim_uuid(u8_t *data, u16_t len)
+{
+	const struct gatt_disc_prim_uuid_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail_conn;
+	}
+
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
+		goto fail;
+	}
+
+	if (!gatt_buf_reserve(sizeof(struct gatt_disc_prim_uuid_rp))) {
+		goto fail;
+	}
+
+	discover_params.uuid = &uuid.uuid;
+	discover_params.start_handle = 0x0001;
+	discover_params.end_handle = 0xffff;
+	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
+	discover_params.func = disc_prim_uuid_cb;
+
+	if (bt_gatt_discover(conn, &discover_params) < 0) {
+		discover_destroy(&discover_params);
+
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	bt_conn_unref(conn);
+
+fail_conn:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_PRIM_UUID, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static u8_t find_included_cb(struct bt_conn *conn,
+				const struct bt_gatt_attr *attr,
+				struct bt_gatt_discover_params *params)
+{
+	struct bt_gatt_include *data;
+	struct gatt_find_included_rp *rp = (void *) gatt_buf.buf;
+	struct gatt_included *included;
+	u8_t uuid_length;
+
+	if (!attr) {
+		tester_send(BTP_SERVICE_ID_GATT, GATT_FIND_INCLUDED,
+			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
+		discover_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	data = attr->user_data;
+
+	uuid_length = data->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
+
+	included = gatt_buf_reserve(sizeof(*included) + uuid_length);
+	if (!included) {
+		tester_rsp(BTP_SERVICE_ID_GATT, GATT_FIND_INCLUDED,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+		discover_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	included->included_handle = attr->handle;
+	included->service.start_handle = sys_cpu_to_le16(data->start_handle);
+	included->service.end_handle = sys_cpu_to_le16(data->end_handle);
+	included->service.uuid_length = uuid_length;
+
+	if (data->uuid->type == BT_UUID_TYPE_16) {
+		u16_t u16 = sys_cpu_to_le16(BT_UUID_16(data->uuid)->val);
+
+		memcpy(included->service.uuid, &u16, uuid_length);
+	} else {
+		memcpy(included->service.uuid, BT_UUID_128(data->uuid)->val,
+		       uuid_length);
+	}
+
+	rp->services_count++;
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static void find_included(u8_t *data, u16_t len)
+{
+	const struct gatt_find_included_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail_conn;
+	}
+
+	if (!gatt_buf_reserve(sizeof(struct gatt_find_included_rp))) {
+		goto fail;
+	}
+
+	discover_params.start_handle = sys_le16_to_cpu(cmd->start_handle);
+	discover_params.end_handle = sys_le16_to_cpu(cmd->end_handle);
+	discover_params.type = BT_GATT_DISCOVER_INCLUDE;
+	discover_params.func = find_included_cb;
+
+	if (bt_gatt_discover(conn, &discover_params) < 0) {
+		discover_destroy(&discover_params);
+
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	bt_conn_unref(conn);
+
+fail_conn:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_FIND_INCLUDED, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static u8_t disc_chrc_cb(struct bt_conn *conn,
+			    const struct bt_gatt_attr *attr,
+			    struct bt_gatt_discover_params *params)
+{
+	struct bt_gatt_chrc *data;
+	struct gatt_disc_chrc_rp *rp = (void *) gatt_buf.buf;
+	struct gatt_characteristic *chrc;
+	u8_t uuid_length;
+
+	if (!attr) {
+		tester_send(BTP_SERVICE_ID_GATT, btp_opcode,
+			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
+		discover_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	data = attr->user_data;
+
+	uuid_length = data->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
+
+	chrc = gatt_buf_reserve(sizeof(*chrc) + uuid_length);
+	if (!chrc) {
+		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+		discover_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	chrc->characteristic_handle = sys_cpu_to_le16(attr->handle);
+	chrc->properties = data->properties;
+	chrc->value_handle = sys_cpu_to_le16(attr->handle + 1);
+	chrc->uuid_length = uuid_length;
+
+	if (data->uuid->type == BT_UUID_TYPE_16) {
+		u16_t u16 = sys_cpu_to_le16(BT_UUID_16(data->uuid)->val);
+
+		memcpy(chrc->uuid, &u16, uuid_length);
+	} else {
+		memcpy(chrc->uuid, BT_UUID_128(data->uuid)->val, uuid_length);
+	}
+
+	rp->characteristics_count++;
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static void disc_all_chrc(u8_t *data, u16_t len)
+{
+	const struct gatt_disc_all_chrc_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail_conn;
+	}
+
+	if (!gatt_buf_reserve(sizeof(struct gatt_disc_chrc_rp))) {
+		goto fail;
+	}
+
+	discover_params.start_handle = sys_le16_to_cpu(cmd->start_handle);
+	discover_params.end_handle = sys_le16_to_cpu(cmd->end_handle);
+	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+	discover_params.func = disc_chrc_cb;
+
+	/* TODO should be handled as user_data via CONTAINER_OF macro */
+	btp_opcode = GATT_DISC_ALL_CHRC;
+
+	if (bt_gatt_discover(conn, &discover_params) < 0) {
+		discover_destroy(&discover_params);
+
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	bt_conn_unref(conn);
+
+fail_conn:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_ALL_CHRC, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static void disc_chrc_uuid(u8_t *data, u16_t len)
+{
+	const struct gatt_disc_chrc_uuid_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail_conn;
+	}
+
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
+		goto fail;
+	}
+
+	if (!gatt_buf_reserve(sizeof(struct gatt_disc_chrc_rp))) {
+		goto fail;
+	}
+
+	discover_params.uuid = &uuid.uuid;
+	discover_params.start_handle = sys_le16_to_cpu(cmd->start_handle);
+	discover_params.end_handle = sys_le16_to_cpu(cmd->end_handle);
+	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+	discover_params.func = disc_chrc_cb;
+
+	/* TODO should be handled as user_data via CONTAINER_OF macro */
+	btp_opcode = GATT_DISC_CHRC_UUID;
+
+	if (bt_gatt_discover(conn, &discover_params) < 0) {
+		discover_destroy(&discover_params);
+
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	bt_conn_unref(conn);
+
+fail_conn:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_CHRC_UUID, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static u8_t disc_all_desc_cb(struct bt_conn *conn,
+				const struct bt_gatt_attr *attr,
+				struct bt_gatt_discover_params *params)
+{
+	struct gatt_disc_all_desc_rp *rp = (void *) gatt_buf.buf;
+	struct gatt_descriptor *descriptor;
+	u8_t uuid_length;
+
+	if (!attr) {
+		tester_send(BTP_SERVICE_ID_GATT, GATT_DISC_ALL_DESC,
+			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
+		discover_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	uuid_length = attr->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
+
+	descriptor = gatt_buf_reserve(sizeof(*descriptor) + uuid_length);
+	if (!descriptor) {
+		tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_ALL_DESC,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+		discover_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	descriptor->descriptor_handle = sys_cpu_to_le16(attr->handle);
+	descriptor->uuid_length = uuid_length;
+
+	if (attr->uuid->type == BT_UUID_TYPE_16) {
+		u16_t u16 = sys_cpu_to_le16(BT_UUID_16(attr->uuid)->val);
+
+		memcpy(descriptor->uuid, &u16, uuid_length);
+	} else {
+		memcpy(descriptor->uuid, BT_UUID_128(attr->uuid)->val,
+		       uuid_length);
+	}
+
+	rp->descriptors_count++;
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static void disc_all_desc(u8_t *data, u16_t len)
+{
+	const struct gatt_disc_all_desc_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail_conn;
+	}
+
+	if (!gatt_buf_reserve(sizeof(struct gatt_disc_all_desc_rp))) {
+		goto fail;
+	}
+
+	discover_params.start_handle = sys_le16_to_cpu(cmd->start_handle);
+	discover_params.end_handle = sys_le16_to_cpu(cmd->end_handle);
+	discover_params.type = BT_GATT_DISCOVER_DESCRIPTOR;
+	discover_params.func = disc_all_desc_cb;
+
+	if (bt_gatt_discover(conn, &discover_params) < 0) {
+		discover_destroy(&discover_params);
+
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	bt_conn_unref(conn);
+
+fail_conn:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_ALL_DESC, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static struct bt_gatt_read_params read_params;
+
+static void read_destroy(struct bt_gatt_read_params *params)
+{
+	memset(params, 0, sizeof(*params));
+	gatt_buf_clear();
+}
+
+static u8_t read_cb(struct bt_conn *conn, u8_t err,
+		       struct bt_gatt_read_params *params, const void *data,
+		       u16_t length)
+{
+	struct gatt_read_rp *rp = (void *) gatt_buf.buf;
+
+	/* Respond to the Lower Tester with ATT Error received */
+	if (err) {
+		rp->att_response = err;
+	}
+
+	/* read complete */
+	if (!data) {
+		tester_send(BTP_SERVICE_ID_GATT, btp_opcode, CONTROLLER_INDEX,
+			    gatt_buf.buf, gatt_buf.len);
+		read_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	if (!gatt_buf_add(data, length)) {
+		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+		read_destroy(params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	rp->data_length += length;
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static void read(u8_t *data, u16_t len)
+{
+	const struct gatt_read_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail_conn;
+	}
+
+	if (!gatt_buf_reserve(sizeof(struct gatt_read_rp))) {
+		goto fail;
+	}
+
+	read_params.handle_count = 1;
+	read_params.single.handle = sys_le16_to_cpu(cmd->handle);
+	read_params.single.offset = 0x0000;
+	read_params.func = read_cb;
+
+	/* TODO should be handled as user_data via CONTAINER_OF macro */
+	btp_opcode = GATT_READ;
+
+	if (bt_gatt_read(conn, &read_params) < 0) {
+		read_destroy(&read_params);
+
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	bt_conn_unref(conn);
+
+fail_conn:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_READ, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static void read_long(u8_t *data, u16_t len)
+{
+	const struct gatt_read_long_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail_conn;
+	}
+
+	if (!gatt_buf_reserve(sizeof(struct gatt_read_rp))) {
+		goto fail;
+	}
+
+	read_params.handle_count = 1;
+	read_params.single.handle = sys_le16_to_cpu(cmd->handle);
+	read_params.single.offset = sys_le16_to_cpu(cmd->offset);
+	read_params.func = read_cb;
+
+	/* TODO should be handled as user_data via CONTAINER_OF macro */
+	btp_opcode = GATT_READ_LONG;
+
+	if (bt_gatt_read(conn, &read_params) < 0) {
+		read_destroy(&read_params);
+
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	bt_conn_unref(conn);
+
+fail_conn:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_READ_LONG, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static void read_multiple(u8_t *data, u16_t len)
+{
+	const struct gatt_read_multiple_cmd *cmd = (void *) data;
+	u16_t handles[cmd->handles_count];
+	struct bt_conn *conn;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(handles); i++) {
+		handles[i] = sys_le16_to_cpu(cmd->handles[i]);
+	}
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail_conn;
+	}
+
+	if (!gatt_buf_reserve(sizeof(struct gatt_read_rp))) {
+		goto fail;
+	}
+
+	read_params.func = read_cb;
+	read_params.handle_count = i;
+	read_params.handles = handles; /* not used in read func */
+
+	/* TODO should be handled as user_data via CONTAINER_OF macro */
+	btp_opcode = GATT_READ_MULTIPLE;
+
+	if (bt_gatt_read(conn, &read_params) < 0) {
+		gatt_buf_clear();
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	bt_conn_unref(conn);
+
+fail_conn:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_READ_MULTIPLE, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static void write_without_rsp(u8_t *data, u16_t len, u8_t op,
+			      bool sign)
+{
+	const struct gatt_write_without_rsp_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+	u8_t status = BTP_STATUS_SUCCESS;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
+	if (bt_gatt_write_without_response(conn, sys_le16_to_cpu(cmd->handle),
+					   cmd->data,
+					   sys_le16_to_cpu(cmd->data_length),
+					   sign) < 0) {
+		status = BTP_STATUS_FAILED;
+	}
+
+	bt_conn_unref(conn);
+rsp:
+	tester_rsp(BTP_SERVICE_ID_GATT, op, CONTROLLER_INDEX, status);
+}
+
+static void write_rsp(struct bt_conn *conn, u8_t err,
+		      struct bt_gatt_write_params *params)
+{
+	tester_send(BTP_SERVICE_ID_GATT, GATT_WRITE, CONTROLLER_INDEX, &err,
+		    sizeof(err));
+}
+
+static struct bt_gatt_write_params write_params;
+
+static void write(u8_t *data, u16_t len)
+{
+	const struct gatt_write_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail;
+	}
+
+	write_params.handle = sys_le16_to_cpu(cmd->handle);
+	write_params.func = write_rsp;
+	write_params.offset = 0;
+	write_params.data = cmd->data;
+	write_params.length = sys_le16_to_cpu(cmd->data_length);
+
+	if (bt_gatt_write(conn, &write_params) < 0) {
+		bt_conn_unref(conn);
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_WRITE, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static void write_long_rsp(struct bt_conn *conn, u8_t err,
+			   struct bt_gatt_write_params *params)
+{
+	tester_send(BTP_SERVICE_ID_GATT, GATT_WRITE_LONG, CONTROLLER_INDEX,
+		    &err, sizeof(err));
+}
+
+static void write_long(u8_t *data, u16_t len)
+{
+	const struct gatt_write_long_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail;
+	}
+
+	write_params.handle = sys_le16_to_cpu(cmd->handle);
+	write_params.func = write_long_rsp;
+	write_params.offset = cmd->offset;
+	write_params.data = cmd->data;
+	write_params.length = sys_le16_to_cpu(cmd->data_length);
+
+	if (bt_gatt_write(conn, &write_params) < 0) {
+		bt_conn_unref(conn);
+		goto fail;
+	}
+
+	bt_conn_unref(conn);
+
+	return;
+fail:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_WRITE_LONG, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static struct bt_gatt_subscribe_params subscribe_params;
+
+/* ev header + default MTU_ATT-3 */
+static u8_t ev_buf[33];
+
+static u8_t notify_func(struct bt_conn *conn,
+			   struct bt_gatt_subscribe_params *params,
+			   const void *data, u16_t length)
+{
+	struct gatt_notification_ev *ev = (void *) ev_buf;
+	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
+
+	if (!data) {
+		SYS_LOG_DBG("Unsubscribed");
+		memset(params, 0, sizeof(*params));
+		return BT_GATT_ITER_STOP;
+	}
+
+	ev->type = (u8_t) subscribe_params.value;
+	ev->handle = sys_cpu_to_le16(subscribe_params.value_handle);
+	ev->data_length = sys_cpu_to_le16(length);
+	memcpy(ev->data, data, length);
+	memcpy(ev->address, addr->a.val, sizeof(ev->address));
+	ev->address_type = addr->type;
+
+	tester_send(BTP_SERVICE_ID_GATT, GATT_EV_NOTIFICATION,
+		    CONTROLLER_INDEX, ev_buf, sizeof(*ev) + length);
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static void discover_complete(struct bt_conn *conn,
+			      struct bt_gatt_discover_params *params)
+{
+	u8_t op, status;
+
+	/* If no value handle it means that chrc has not been found */
+	if (!subscribe_params.value_handle) {
+		status = BTP_STATUS_FAILED;
+		goto fail;
+	}
+
+	if (bt_gatt_subscribe(conn, &subscribe_params) < 0) {
+		status = BTP_STATUS_FAILED;
+		goto fail;
+	}
+
+	status = BTP_STATUS_SUCCESS;
+fail:
+	op = subscribe_params.value == BT_GATT_CCC_NOTIFY ? GATT_CFG_NOTIFY :
+							    GATT_CFG_INDICATE;
+
+	if (status == BTP_STATUS_FAILED) {
+		memset(&subscribe_params, 0, sizeof(subscribe_params));
+	}
+
+	tester_rsp(BTP_SERVICE_ID_GATT, op, CONTROLLER_INDEX, status);
+}
+
+static u8_t discover_func(struct bt_conn *conn,
+			     const struct bt_gatt_attr *attr,
+			     struct bt_gatt_discover_params *params)
+{
+	if (!attr) {
+		discover_complete(conn, params);
+		return BT_GATT_ITER_STOP;
+	}
+
+	/* Characteristic Value Handle is the next handle beyond declaration */
+	subscribe_params.value_handle = attr->handle + 1;
+
+	/*
+	 * Continue characteristic discovery to get last characteristic
+	 * preceding this CCC descriptor
+	 */
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static int enable_subscription(struct bt_conn *conn, u16_t ccc_handle,
+			       u16_t value)
+{
+	/* Fail if there is another subscription enabled */
+	if (subscribe_params.ccc_handle) {
+		SYS_LOG_ERR("Another subscription already enabled");
+		return -EEXIST;
+	}
+
+	/* Discover Characteristic Value this CCC Descriptor refers to */
+	discover_params.start_handle = 0x0001;
+	discover_params.end_handle = ccc_handle;
+	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
+	discover_params.func = discover_func;
+
+	subscribe_params.ccc_handle = ccc_handle;
+	subscribe_params.value = value;
+	subscribe_params.notify = notify_func;
+
+	return bt_gatt_discover(conn, &discover_params);
+}
+
+static int disable_subscription(struct bt_conn *conn, u16_t ccc_handle)
+{
+	/* Fail if CCC handle doesn't match */
+	if (ccc_handle != subscribe_params.ccc_handle) {
+		SYS_LOG_ERR("CCC handle doesn't match");
+		return -EINVAL;
+	}
+
+	if (bt_gatt_unsubscribe(conn, &subscribe_params) < 0) {
+		return -EBUSY;
+	}
+
+	subscribe_params.ccc_handle = 0;
+
+	return 0;
+}
+
+static void config_subscription(u8_t *data, u16_t len, u16_t op)
+{
+	const struct gatt_cfg_notify_cmd *cmd = (void *) data;
+	struct bt_conn *conn;
+	u16_t ccc_handle = sys_le16_to_cpu(cmd->ccc_handle);
+	u8_t status;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		tester_rsp(BTP_SERVICE_ID_GATT, op, CONTROLLER_INDEX,
+			   BTP_STATUS_FAILED);
+		return;
+	}
+
+	if (cmd->enable) {
+		u16_t value;
+
+		if (op == GATT_CFG_NOTIFY) {
+			value = BT_GATT_CCC_NOTIFY;
+		} else {
+			value = BT_GATT_CCC_INDICATE;
+		}
+
+		/* on success response will be sent from callback */
+		if (enable_subscription(conn, ccc_handle, value) == 0) {
+			bt_conn_unref(conn);
+			return;
+		}
+
+		status = BTP_STATUS_FAILED;
+	} else {
+		if (disable_subscription(conn, ccc_handle) < 0) {
+			status = BTP_STATUS_FAILED;
+		} else {
+			status = BTP_STATUS_SUCCESS;
+		}
+	}
+
+	SYS_LOG_DBG("Config subscription (op %u) status %u", op, status);
+
+	bt_conn_unref(conn);
+	tester_rsp(BTP_SERVICE_ID_GATT, op, CONTROLLER_INDEX, status);
+}
+
+struct get_attrs_foreach_data {
+	struct net_buf_simple *buf;
+	struct bt_uuid *uuid;
+	u8_t count;
+};
+
+static u8_t get_attrs_rp(const struct bt_gatt_attr *attr, void *user_data)
+{
+	struct get_attrs_foreach_data *foreach = user_data;
+	struct gatt_attr *gatt_attr;
+
+	if (foreach->uuid && bt_uuid_cmp(foreach->uuid, attr->uuid)) {
+
+		return BT_GATT_ITER_CONTINUE;
+	}
+
+	gatt_attr = net_buf_simple_add(foreach->buf, sizeof(*gatt_attr));
+	gatt_attr->handle = sys_cpu_to_le16(attr->handle);
+	gatt_attr->permission = attr->perm;
+
+	if (attr->uuid->type == BT_UUID_TYPE_16) {
+		gatt_attr->type_length = 2;
+		net_buf_simple_add_le16(foreach->buf,
+					BT_UUID_16(attr->uuid)->val);
+	} else {
+		gatt_attr->type_length = 16;
+		net_buf_simple_add_mem(foreach->buf,
+				       BT_UUID_128(attr->uuid)->val,
+				       gatt_attr->type_length);
+	}
+
+	foreach->count++;
+
+	return BT_GATT_ITER_CONTINUE;
+}
+
+static void get_attrs(u8_t *data, u16_t len)
+{
+	const struct gatt_get_attributes_cmd *cmd = (void *) data;
+	struct gatt_get_attributes_rp *rp;
+	struct net_buf_simple *buf = NET_BUF_SIMPLE(BTP_DATA_MAX_SIZE);
+	struct get_attrs_foreach_data foreach;
+	u16_t start_handle, end_handle;
+	union uuid uuid;
+
+	start_handle = sys_le16_to_cpu(cmd->start_handle);
+	end_handle = sys_le16_to_cpu(cmd->end_handle);
+
+	if (cmd->type_length) {
+		if (btp2bt_uuid(cmd->type, cmd->type_length, &uuid.uuid)) {
+			goto fail;
+		}
+
+		SYS_LOG_DBG("start 0x%04x end 0x%04x, uuid %s", start_handle,
+			    end_handle, bt_uuid_str(&uuid.uuid));
+
+		foreach.uuid = &uuid.uuid;
+	} else {
+		SYS_LOG_DBG("start 0x%04x end 0x%04x", start_handle, end_handle);
+
+		foreach.uuid = NULL;
+	}
+
+	net_buf_simple_init(buf, sizeof(*rp));
+
+	foreach.buf = buf;
+	foreach.count = 0;
+
+	bt_gatt_foreach_attr(start_handle, end_handle, get_attrs_rp, &foreach);
+
+	rp = net_buf_simple_push(buf, sizeof(*rp));
+	rp->attrs_count = foreach.count;
+
+	tester_send(BTP_SERVICE_ID_GATT, GATT_GET_ATTRIBUTES, CONTROLLER_INDEX,
+		    buf->data, buf->len);
+
+	return;
+fail:
+	tester_rsp(BTP_SERVICE_ID_GATT, GATT_GET_ATTRIBUTES, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static u8_t err_to_att(int err)
+{
+	if (err < 0 && err >= -0xff) {
+		return -err;
+	}
+
+	return BT_ATT_ERR_UNLIKELY;
+}
+
+static u8_t get_attr_val_rp(const struct bt_gatt_attr *attr, void *user_data)
+{
+	struct net_buf_simple *buf = user_data;
+	struct gatt_get_attribute_value_rp *rp;
+	ssize_t read, to_read;
+
+	rp = net_buf_simple_add(buf, sizeof(*rp));
+	rp->value_length = 0x0000;
+	rp->att_response = 0x00;
+
+	do {
+		to_read = net_buf_simple_tailroom(buf);
+
+		read = attr->read(NULL, attr, buf->data + buf->len, to_read,
+				  rp->value_length);
+		if (read < 0) {
+			rp->att_response = err_to_att(read);
+			break;
+		}
+
+		rp->value_length += read;
+
+		net_buf_simple_add(buf, read);
+	} while (read == to_read);
+
+	return BT_GATT_ITER_STOP;
+}
+
+static void get_attr_val(u8_t *data, u16_t len)
+{
+	const struct gatt_get_attribute_value_cmd *cmd = (void *) data;
+	struct net_buf_simple *buf = NET_BUF_SIMPLE(BTP_DATA_MAX_SIZE);
+	u16_t handle = sys_le16_to_cpu(cmd->handle);
+
+	net_buf_simple_init(buf, 0);
+
+	bt_gatt_foreach_attr(handle, handle, get_attr_val_rp, buf);
+
+	if (buf->len) {
+		tester_send(BTP_SERVICE_ID_GATT, GATT_GET_ATTRIBUTE_VALUE,
+			    CONTROLLER_INDEX, buf->data, buf->len);
+	} else {
+		tester_rsp(BTP_SERVICE_ID_GATT, GATT_GET_ATTRIBUTE_VALUE,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+	}
+}
+
+void tester_handle_gatt(u8_t opcode, u8_t index, u8_t *data,
+			 u16_t len)
+{
+	switch (opcode) {
+	case GATT_READ_SUPPORTED_COMMANDS:
+		supported_commands(data, len);
+		return;
+	case GATT_ADD_SERVICE:
+		add_service(data, len);
+		return;
+	case GATT_ADD_CHARACTERISTIC:
+		add_characteristic(data, len);
+		return;
+	case GATT_ADD_DESCRIPTOR:
+		add_descriptor(data, len);
+		return;
+	case GATT_ADD_INCLUDED_SERVICE:
+		add_included(data, len);
+		return;
+	case GATT_SET_VALUE:
+		set_value(data, len);
+		return;
+	case GATT_START_SERVER:
+		start_server(data, len);
+		return;
+	case GATT_SET_ENC_KEY_SIZE:
+		set_enc_key_size(data, len);
+		return;
+	case GATT_EXCHANGE_MTU:
+		exchange_mtu(data, len);
+		return;
+	case GATT_DISC_PRIM_UUID:
+		disc_prim_uuid(data, len);
+		return;
+	case GATT_FIND_INCLUDED:
+		find_included(data, len);
+		return;
+	case GATT_DISC_ALL_CHRC:
+		disc_all_chrc(data, len);
+		return;
+	case GATT_DISC_CHRC_UUID:
+		disc_chrc_uuid(data, len);
+		return;
+	case GATT_DISC_ALL_DESC:
+		disc_all_desc(data, len);
+		return;
+	case GATT_READ:
+		read(data, len);
+		return;
+	case GATT_READ_LONG:
+		read_long(data, len);
+		return;
+	case GATT_READ_MULTIPLE:
+		read_multiple(data, len);
+		return;
+	case GATT_WRITE_WITHOUT_RSP:
+		write_without_rsp(data, len, opcode, false);
+		return;
+	case GATT_SIGNED_WRITE_WITHOUT_RSP:
+		write_without_rsp(data, len, opcode, true);
+		return;
+	case GATT_WRITE:
+		write(data, len);
+		return;
+	case GATT_WRITE_LONG:
+		write_long(data, len);
+		return;
+	case GATT_CFG_NOTIFY:
+	case GATT_CFG_INDICATE:
+		config_subscription(data, len, opcode);
+		return;
+	case GATT_GET_ATTRIBUTES:
+		get_attrs(data, len);
+		return;
+	case GATT_GET_ATTRIBUTE_VALUE:
+		get_attr_val(data, len);
+		return;
+	default:
+		tester_rsp(BTP_SERVICE_ID_GATT, opcode, index,
+			   BTP_STATUS_UNKNOWN_CMD);
+		return;
+	}
+}
+
+u8_t tester_init_gatt(void)
+{
+	server_buf = net_buf_alloc(&server_pool, K_NO_WAIT);
+	if (!server_buf) {
+		return BTP_STATUS_FAILED;
+	}
+
+	net_buf_reserve(server_buf, SERVER_BUF_SIZE);
+
+	return BTP_STATUS_SUCCESS;
+}
+
+u8_t tester_unregister_gatt(void)
+{
+	return BTP_STATUS_SUCCESS;
+}

--- a/apps/bttester/src/gatt.c
+++ b/apps/bttester/src/gatt.c
@@ -6,61 +6,99 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
 
-#include <toolchain.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/uuid.h>
-#include <misc/byteorder.h>
-#include <misc/printk.h>
-#include <net/buf.h>
+#include "host/ble_gap.h"
+#include "host/ble_gatt.h"
+#include "console/console.h"
+#include "services/gatt/ble_svc_gatt.h"
+#include "../../../../apache-mynewt-nimble/nimble/host/src/ble_gatt_priv.h"
 
 #include "bttester.h"
 
 #define CONTROLLER_INDEX 0
 #define MAX_BUFFER_SIZE 2048
-#define MAX_UUID_LEN 16
 
-/* This masks Permission bits from GATT API */
-#define GATT_PERM_MASK			(BT_GATT_PERM_READ | \
-					 BT_GATT_PERM_READ_AUTHEN | \
-					 BT_GATT_PERM_READ_ENCRYPT | \
-					 BT_GATT_PERM_WRITE | \
-					 BT_GATT_PERM_WRITE_AUTHEN | \
-					 BT_GATT_PERM_WRITE_ENCRYPT | \
-					 BT_GATT_PERM_PREPARE_WRITE)
-#define GATT_PERM_ENC_READ_MASK		(BT_GATT_PERM_READ_ENCRYPT | \
-					 BT_GATT_PERM_READ_AUTHEN)
-#define GATT_PERM_ENC_WRITE_MASK	(BT_GATT_PERM_WRITE_ENCRYPT | \
-					 BT_GATT_PERM_WRITE_AUTHEN)
-#define GATT_PERM_READ_AUTHORIZATION	0x40
-#define GATT_PERM_WRITE_AUTHORIZATION	0x80
+#define BTP_GATT_PERM_READ	0x01
+
+static const ble_uuid16_t BT_UUID_GATT_CEP = BLE_UUID16_INIT(0x2900);
+static const ble_uuid16_t BT_UUID_GATT_CCC = BLE_UUID16_INIT(0x2902);
+
+static const ble_uuid_t *uuid_pri =
+	BLE_UUID16_DECLARE(BLE_ATT_UUID_PRIMARY_SERVICE);
+static const ble_uuid_t *uuid_sec =
+	BLE_UUID16_DECLARE(BLE_ATT_UUID_SECONDARY_SERVICE);
+static const ble_uuid_t *uuid_chr =
+	BLE_UUID16_DECLARE(BLE_ATT_UUID_CHARACTERISTIC);
+static const ble_uuid_t *uuid_ccc =
+	BLE_UUID16_DECLARE(BLE_GATT_DSC_CLT_CFG_UUID16);
+
+static int gatt_chr_perm_map[] = {
+	BLE_GATT_CHR_F_READ,
+	BLE_GATT_CHR_F_WRITE,
+	BLE_GATT_CHR_F_READ_ENC,
+	BLE_GATT_CHR_F_WRITE_ENC,
+	BLE_GATT_CHR_F_READ_AUTHEN,
+	BLE_GATT_CHR_F_WRITE_AUTHEN,
+	BLE_GATT_CHR_F_READ_AUTHOR,
+	BLE_GATT_CHR_F_WRITE_AUTHOR,
+};
+
+static int gatt_dsc_perm_map[] = {
+	BLE_ATT_F_READ,
+	BLE_ATT_F_WRITE,
+	BLE_ATT_F_READ_ENC,
+	BLE_ATT_F_WRITE_ENC,
+	BLE_ATT_F_READ_AUTHEN,
+	BLE_ATT_F_WRITE_AUTHEN,
+	BLE_ATT_F_READ_AUTHOR,
+	BLE_ATT_F_WRITE_AUTHOR,
+};
 
 /* GATT server context */
-#define SERVER_MAX_SERVICES		10
-#define SERVER_MAX_ATTRIBUTES		50
-#define SERVER_BUF_SIZE			2048
+#define SERVER_MAX_VALUES	14
 
-/* bt_gatt_attr_next cannot be used on non-registered services */
-#define NEXT_DB_ATTR(attr) (attr + 1)
-#define LAST_DB_ATTR (server_db + (attr_count - 1))
+struct gatt_value {
+	struct os_mbuf *buf;
+	u8_t enc_key_size;
+	u8_t flags[1];
+	u16_t val_handle;
+	u8_t type;
+	void *ptr;
+};
 
-#define server_buf_push(_len)	net_buf_push(server_buf, ROUND_UP(_len, 4))
-#define server_buf_pull(_len)	net_buf_pull(server_buf, ROUND_UP(_len, 4))
+enum {
+	GATT_VALUE_TYPE_CHR,
+	GATT_VALUE_TYPE_DSC,
+};
 
-static struct bt_gatt_service server_svcs[SERVER_MAX_SERVICES];
-static struct bt_gatt_attr server_db[SERVER_MAX_ATTRIBUTES];
-static struct net_buf *server_buf;
-NET_BUF_POOL_DEFINE(server_pool, 1, SERVER_BUF_SIZE, 0, NULL);
+static struct gatt_value gatt_values[SERVER_MAX_VALUES];
 
-static u8_t attr_count;
-static u8_t svc_attr_count;
-static u8_t svc_count;
+/* 0000xxxx-8c26-476f-89a7-a108033a69c7 */
+#define PTS_UUID_DECLARE(uuid16)                                \
+    ((const ble_uuid_t *) (&(ble_uuid128_t) BLE_UUID128_INIT(   \
+        0xc7, 0x69, 0x3a, 0x03, 0x08, 0xa1, 0xa7, 0x89,         \
+        0x6f, 0x47, 0x26, 0x8c, uuid16, uuid16 >> 8, 0x00, 0x00 \
+    )))
+
+#define  PTS_SVC                         0x0001
+#define  PTS_CHR_NO_PERM                 0x0002
+#define  PTS_CHR_READ                    0x0003
+#define  PTS_CHR_RELIABLE_WRITE          0x0004
+#define  PTS_CHR_WRITE_NO_RSP            0x0005
+#define  PTS_CHR_READ_WRITE              0x0006
+#define  PTS_CHR_READ_WRITE_ENC          0x0007
+#define  PTS_CHR_READ_WRITE_AUTHEN       0x0008
+#define  PTS_CHR_READ_WRITE_AUTHOR       0x0009
+#define  PTS_DSC_READ                    0x000a
+#define  PTS_DSC_WRITE                   0x000b
+#define  PTS_DSC_READ_WRITE              0x000c
+#define  PTS_DSC_READ_WRITE_ENC          0x000d
+#define  PTS_DSC_READ_WRITE_AUTHEN       0x000e
+#define  PTS_INC_SVC                     0x000f
+#define  PTS_CHR_READ_WRITE_ALT          0x0010
 
 /*
  * gatt_buf - cache used by a gatt client (to cache data read/discovered)
@@ -83,7 +121,7 @@ static void *gatt_buf_add(const void *data, size_t len)
 	if (data) {
 		memcpy(ptr, data, len);
 	} else {
-		memset(ptr, 0, len);
+		(void)memset(ptr, 0, len);
 	}
 
 	gatt_buf.len += len;
@@ -100,68 +138,229 @@ static void *gatt_buf_reserve(size_t len)
 
 static void gatt_buf_clear(void)
 {
-	memset(&gatt_buf, 0, sizeof(gatt_buf));
+	(void)memset(&gatt_buf, 0, sizeof(gatt_buf));
 }
 
-union uuid {
-	struct bt_uuid uuid;
-	struct bt_uuid_16 u16;
-	struct bt_uuid_128 u128;
+struct gatt_value *find_gatt_value_by_id(u16_t id)
+{
+	if (id < SERVER_MAX_VALUES) {
+		return &gatt_values[id];
+	}
+
+	return NULL;
+}
+
+static int gatt_svr_access_cb(uint16_t conn_handle, uint16_t attr_handle,
+			      struct ble_gatt_access_ctxt *ctxt,
+			      void *arg);
+
+static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
+	{
+		/*** Service: PTS test. */
+		.type = BLE_GATT_SVC_TYPE_PRIMARY,
+		.uuid = PTS_UUID_DECLARE(PTS_SVC),
+		.characteristics = (struct ble_gatt_chr_def[]) { {
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_NO_PERM),
+			.access_cb = gatt_svr_access_cb,
+			.flags = 0,
+			.arg = &gatt_values[0],
+			.val_handle = &gatt_values[0].val_handle,
+		}, {
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_READ),
+			.access_cb = gatt_svr_access_cb,
+			.flags = BLE_GATT_CHR_F_READ |
+				 BLE_GATT_CHR_F_NOTIFY |
+				 BLE_GATT_CHR_F_INDICATE,
+			.arg = &gatt_values[1],
+			.val_handle = &gatt_values[1].val_handle,
+		}, {
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_RELIABLE_WRITE),
+			.access_cb = gatt_svr_access_cb,
+			.flags = BLE_GATT_CHR_F_WRITE |
+				 BLE_GATT_CHR_F_RELIABLE_WRITE,
+			.arg = &gatt_values[2],
+			.val_handle = &gatt_values[2].val_handle,
+		}, {
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_WRITE_NO_RSP),
+			.access_cb = gatt_svr_access_cb,
+			.flags = BLE_GATT_CHR_F_READ |
+				 BLE_GATT_CHR_F_WRITE_NO_RSP,
+			.arg = &gatt_values[3],
+			.val_handle = &gatt_values[3].val_handle,
+		}, {
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE),
+			.access_cb = gatt_svr_access_cb,
+			.flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE,
+			.arg = &gatt_values[4],
+			.val_handle = &gatt_values[4].val_handle,
+		}, {
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE_ENC),
+			.access_cb = gatt_svr_access_cb,
+			.flags = BLE_GATT_CHR_F_READ |
+				 BLE_GATT_CHR_F_READ_ENC |
+				 BLE_GATT_CHR_F_WRITE |
+				 BLE_GATT_CHR_F_WRITE_ENC,
+			.min_key_size = 0x0f,
+			.arg = &gatt_values[5],
+			.val_handle = &gatt_values[5].val_handle,
+		}, {
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE_AUTHEN),
+			.access_cb = gatt_svr_access_cb,
+			.flags = BLE_GATT_CHR_F_READ |
+				 BLE_GATT_CHR_F_READ_AUTHEN |
+				 BLE_GATT_CHR_F_WRITE |
+				 BLE_GATT_CHR_F_WRITE_AUTHEN,
+			.arg = &gatt_values[6],
+			.val_handle = &gatt_values[6].val_handle,
+		}, {
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE_AUTHOR),
+			.access_cb = gatt_svr_access_cb,
+			.flags = BLE_GATT_CHR_F_READ |
+				 BLE_GATT_CHR_F_READ_AUTHOR |
+				 BLE_GATT_CHR_F_WRITE |
+				 BLE_GATT_CHR_F_WRITE_AUTHOR,
+			.arg = &gatt_values[7],
+			.val_handle = &gatt_values[7].val_handle,
+
+			.descriptors = (struct ble_gatt_dsc_def[]){ {
+				.uuid = PTS_UUID_DECLARE(PTS_DSC_READ),
+				.access_cb = gatt_svr_access_cb,
+				.att_flags = BLE_ATT_F_READ,
+				.arg = &gatt_values[8],
+			}, {
+				.uuid = PTS_UUID_DECLARE(PTS_DSC_WRITE),
+				.access_cb = gatt_svr_access_cb,
+				.att_flags = BLE_ATT_F_WRITE,
+				.arg = &gatt_values[9],
+			}, {
+				.uuid = PTS_UUID_DECLARE(PTS_DSC_READ_WRITE),
+				.access_cb = gatt_svr_access_cb,
+				.att_flags = BLE_ATT_F_READ | BLE_ATT_F_WRITE,
+				.arg = &gatt_values[10],
+			}, {
+				.uuid = PTS_UUID_DECLARE(PTS_DSC_READ_WRITE_ENC),
+				.access_cb = gatt_svr_access_cb,
+				.att_flags = BLE_ATT_F_READ |
+					     BLE_ATT_F_READ_ENC |
+					     BLE_ATT_F_WRITE |
+					     BLE_ATT_F_WRITE_ENC,
+				.min_key_size = 0x0f,
+				.arg = &gatt_values[11],
+			}, {
+				.uuid = PTS_UUID_DECLARE(PTS_DSC_READ_WRITE_AUTHEN),
+				.access_cb = gatt_svr_access_cb,
+				.att_flags = BLE_ATT_F_READ |
+					     BLE_ATT_F_READ_AUTHEN |
+					     BLE_ATT_F_WRITE |
+					     BLE_ATT_F_WRITE_AUTHEN,
+				.arg = &gatt_values[12],
+			}, {
+				0, /* No more descriptors in this characteristic. */
+			} }
+		}, {
+			0, /* No more characteristics in this service. */
+		} },
+	},
+
+	{
+		0, /* No more services. */
+	},
 };
 
-static struct bt_gatt_attr *gatt_db_add(const struct bt_gatt_attr *pattern,
-					size_t user_data_len)
+static const struct ble_gatt_svc_def *inc_svcs[] = {
+	&gatt_svr_svcs[0],
+	NULL,
+};
+
+static const struct ble_gatt_svc_def gatt_svr_inc_svcs[] = {
+	{
+		.type = BLE_GATT_SVC_TYPE_PRIMARY,
+		.uuid = PTS_UUID_DECLARE(PTS_INC_SVC),
+		.includes = inc_svcs,
+		.characteristics = (struct ble_gatt_chr_def[]) {{
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE_ALT),
+			.access_cb = gatt_svr_access_cb,
+			.flags = BLE_GATT_CHR_F_READ |
+				 BLE_GATT_CHR_F_WRITE,
+			.arg = &gatt_values[13],
+			.val_handle = &gatt_values[13].val_handle,
+			},
+			{
+				0,
+			},
+		},
+	},
+
+	{
+		0, /* No more services. */
+	},
+};
+
+static void init_gatt_values(void)
 {
-	static struct bt_gatt_attr *attr = server_db;
-	const union uuid *u = CONTAINER_OF(pattern->uuid, union uuid, uuid);
-	size_t uuid_size = u->uuid.type == BT_UUID_TYPE_16 ? sizeof(u->u16) :
-							     sizeof(u->u128);
+	int i = 0;
+	const struct ble_gatt_svc_def *svc;
+	const struct ble_gatt_chr_def *chr;
+	const struct ble_gatt_dsc_def *dsc;
 
-	/* Return NULL if database is full */
-	if (attr == &server_db[SERVER_MAX_ATTRIBUTES - 1]) {
-		return NULL;
+	/* GATT/SR/GAR/BV-05-C fails when a characteristic value is empty */
+
+	for (svc = gatt_svr_svcs; svc && svc->uuid; svc++) {
+		for (chr = svc->characteristics; chr && chr->uuid; chr++) {
+			assert(i < SERVER_MAX_VALUES);
+			gatt_values[i].type = GATT_VALUE_TYPE_CHR;
+			gatt_values[i].ptr = (void *)chr;
+			gatt_values[i].buf = os_msys_get(0, 0);
+			os_mbuf_extend(gatt_values[i].buf, 1);
+			++i;
+
+			for (dsc = chr->descriptors; dsc && dsc->uuid; dsc++) {
+				assert(i < SERVER_MAX_VALUES);
+				gatt_values[i].type = GATT_VALUE_TYPE_DSC;
+				gatt_values[i].ptr = (void *)dsc;
+				gatt_values[i].buf = os_msys_get(0, 0);
+				os_mbuf_extend(gatt_values[i].buf, 1);
+				++i;
+			}
+		}
 	}
 
-	/* First attribute in db must be service */
-	if (!svc_count) {
-		return NULL;
+	for (svc = gatt_svr_inc_svcs; svc && svc->uuid; svc++) {
+		for (chr = svc->characteristics; chr && chr->uuid; chr++) {
+			assert(i < SERVER_MAX_VALUES);
+			gatt_values[i].type = GATT_VALUE_TYPE_CHR;
+			gatt_values[i].ptr = (void *)chr;
+			gatt_values[i].buf = os_msys_get(0, 0);
+			os_mbuf_extend(gatt_values[i].buf, 1);
+			++i;
+
+			for (dsc = chr->descriptors; dsc && dsc->uuid; dsc++) {
+				assert(i < SERVER_MAX_VALUES);
+				gatt_values[i].type = GATT_VALUE_TYPE_DSC;
+				gatt_values[i].ptr = (void *)dsc;
+				gatt_values[i].buf = os_msys_get(0, 0);
+				os_mbuf_extend(gatt_values[i].buf, 1);
+				++i;
+			}
+		}
 	}
-
-	memcpy(attr, pattern, sizeof(*attr));
-
-	/* Store the UUID. */
-	attr->uuid = server_buf_push(uuid_size);
-	memcpy((void *) attr->uuid, &u->uuid, uuid_size);
-
-	/* Copy user_data to the buffer. */
-	if (user_data_len) {
-		attr->user_data = server_buf_push(user_data_len);
-		memcpy(attr->user_data, pattern->user_data, user_data_len);
-	}
-
-	SYS_LOG_DBG("handle 0x%04x", attr->handle);
-
-	attr_count++;
-	svc_attr_count++;
-
-	return attr++;
 }
 
 /* Convert UUID from BTP command to bt_uuid */
 static u8_t btp2bt_uuid(const u8_t *uuid, u8_t len,
-			   struct bt_uuid *bt_uuid)
+			ble_uuid_any_t *bt_uuid)
 {
 	u16_t le16;
 
 	switch (len) {
 	case 0x02: /* UUID 16 */
-		bt_uuid->type = BT_UUID_TYPE_16;
+		bt_uuid->u.type = BLE_UUID_TYPE_16;
 		memcpy(&le16, uuid, sizeof(le16));
-		BT_UUID_16(bt_uuid)->val = sys_le16_to_cpu(le16);
+		BLE_UUID16(bt_uuid)->value = sys_le16_to_cpu(le16);
 		break;
 	case 0x10: /* UUID 128*/
-		bt_uuid->type = BT_UUID_TYPE_128;
-		memcpy(BT_UUID_128(bt_uuid)->val, uuid, 16);
+		bt_uuid->u.type = BLE_UUID_TYPE_128;
+		memcpy(BLE_UUID128(bt_uuid)->value, uuid, 16);
 		break;
 	default:
 		return BTP_STATUS_FAILED;
@@ -174,6 +373,8 @@ static void supported_commands(u8_t *data, u16_t len)
 {
 	u8_t cmds[4];
 	struct gatt_read_supported_commands_rp *rp = (void *) cmds;
+
+	SYS_LOG_DBG("");
 
 	memset(cmds, 0, sizeof(cmds));
 
@@ -195,7 +396,9 @@ static void supported_commands(u8_t *data, u16_t len)
 	tester_set_bit(cmds, GATT_READ_LONG);
 	tester_set_bit(cmds, GATT_READ_MULTIPLE);
 	tester_set_bit(cmds, GATT_WRITE_WITHOUT_RSP);
+#if 0
 	tester_set_bit(cmds, GATT_SIGNED_WRITE_WITHOUT_RSP);
+#endif
 	tester_set_bit(cmds, GATT_WRITE);
 	tester_set_bit(cmds, GATT_WRITE_LONG);
 	tester_set_bit(cmds, GATT_CFG_NOTIFY);
@@ -207,59 +410,117 @@ static void supported_commands(u8_t *data, u16_t len)
 		    CONTROLLER_INDEX, (u8_t *) rp, sizeof(cmds));
 }
 
-static int register_service(void)
+const struct ble_gatt_svc_def *find_svc(ble_uuid_any_t *uuid)
 {
-	server_svcs[svc_count].attrs = server_db +
-				       (attr_count - svc_attr_count);
-	server_svcs[svc_count].attr_count = svc_attr_count;
+	const struct ble_gatt_svc_def *svc;
 
-	return bt_gatt_service_register(&server_svcs[svc_count]);
+	for (svc = gatt_svr_svcs; svc && svc->uuid; svc++) {
+		if (ble_uuid_cmp(&uuid->u, svc->uuid) == 0) {
+			return svc;
+		}
+	}
+
+	for (svc = gatt_svr_inc_svcs; svc && svc->uuid; svc++) {
+		if (ble_uuid_cmp(&uuid->u, svc->uuid) == 0) {
+			return svc;
+		}
+	}
+
+	return NULL;
+}
+
+const struct ble_gatt_chr_def *find_chr(ble_uuid_any_t *uuid)
+{
+	const struct ble_gatt_svc_def *svc;
+	const struct ble_gatt_chr_def *chr;
+
+	for (svc = gatt_svr_svcs; svc && svc->uuid; svc++) {
+		for (chr = svc->characteristics; chr && chr->uuid; chr++) {
+			if (ble_uuid_cmp(&uuid->u, chr->uuid) == 0) {
+				return chr;
+			}
+		}
+	}
+
+	for (svc = gatt_svr_inc_svcs; svc && svc->uuid; svc++) {
+		for (chr = svc->characteristics; chr && chr->uuid; chr++) {
+			if (ble_uuid_cmp(&uuid->u, chr->uuid) == 0) {
+				return chr;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+const struct ble_gatt_dsc_def *find_dsc(ble_uuid_any_t *uuid)
+{
+	const struct ble_gatt_svc_def *svc;
+	const struct ble_gatt_chr_def *chr;
+	const struct ble_gatt_dsc_def *dsc;
+
+	for (svc = gatt_svr_svcs; svc && svc->uuid; svc++) {
+		for (chr = svc->characteristics; chr && chr->uuid; chr++) {
+			for (dsc = chr->descriptors; dsc && dsc->uuid; dsc++) {
+				if (ble_uuid_cmp(&uuid->u, dsc->uuid) == 0) {
+					return dsc;
+				}
+			}
+		}
+	}
+
+	for (svc = gatt_svr_inc_svcs; svc && svc->uuid; svc++) {
+		for (chr = svc->characteristics; chr && chr->uuid; chr++) {
+			for (dsc = chr->descriptors; dsc && dsc->uuid; dsc++) {
+				if (ble_uuid_cmp(&uuid->u, dsc->uuid) == 0) {
+					return dsc;
+				}
+			}
+		}
+	}
+
+	return NULL;
 }
 
 static void add_service(u8_t *data, u16_t len)
 {
 	const struct gatt_add_service_cmd *cmd = (void *) data;
 	struct gatt_add_service_rp rp;
-	struct bt_gatt_attr *attr_svc = NULL;
-	union uuid uuid;
-	size_t uuid_size;
+	const struct ble_gatt_svc_def *svc;
+	ble_uuid_any_t uuid;
+	int type;
 
-	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
+	SYS_LOG_DBG("");
+
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid)) {
 		goto fail;
 	}
-
-	uuid_size = uuid.uuid.type == BT_UUID_TYPE_16 ? sizeof(uuid.u16) :
-							sizeof(uuid.u128);
-
-	/* Register last defined service */
-	if (svc_count) {
-		if (register_service()) {
-			goto fail;
-		}
-	}
-
-	svc_count++;
-	svc_attr_count = 0;
 
 	switch (cmd->type) {
 	case GATT_SERVICE_PRIMARY:
-		attr_svc = gatt_db_add(&(struct bt_gatt_attr)
-				       BT_GATT_PRIMARY_SERVICE(&uuid.uuid),
-				       uuid_size);
+		type = BLE_GATT_SVC_TYPE_PRIMARY;
 		break;
 	case GATT_SERVICE_SECONDARY:
-		attr_svc = gatt_db_add(&(struct bt_gatt_attr)
-				       BT_GATT_SECONDARY_SERVICE(&uuid.uuid),
-				       uuid_size);
+		type = BLE_GATT_SVC_TYPE_SECONDARY;
 		break;
-	}
-
-	if (!attr_svc) {
-		svc_count--;
+	default:
+		SYS_LOG_ERR("Invalid service type");
 		goto fail;
 	}
 
-	rp.svc_id = sys_cpu_to_le16(attr_svc->handle);
+	svc = find_svc(&uuid);
+	if (svc == NULL) {
+		SYS_LOG_ERR("Invalid service UUID");
+		goto fail;
+	}
+
+	if (type != svc->type) {
+		SYS_LOG_ERR("Invalid service type");
+		goto fail;
+	}
+
+	/* TODO: set svc id */
+	rp.svc_id = 0;
 
 	tester_send(BTP_SERVICE_ID_GATT, GATT_ADD_SERVICE, CONTROLLER_INDEX,
 		    (u8_t *) &rp, sizeof(rp));
@@ -270,41 +531,42 @@ fail:
 		   BTP_STATUS_FAILED);
 }
 
-struct gatt_value {
-	u16_t len;
-	u8_t *data;
-	u8_t enc_key_size;
-	u8_t flags[1];
-};
-
-enum {
-	GATT_VALUE_CCC_FLAG,
-	GATT_VALUE_READ_AUTHOR_FLAG,
-	GATT_VALUE_WRITE_AUTHOR_FLAG,
-};
-
-static ssize_t read_value(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			  void *buf, u16_t len, u16_t offset)
+static size_t read_value(uint16_t conn_handle, uint16_t attr_handle,
+			 struct ble_gatt_access_ctxt *ctxt,
+			 void *arg)
 {
-	const struct gatt_value *value = attr->user_data;
+	const struct gatt_value *value = arg;
+	char str[BLE_UUID_STR_LEN];
+	int rc;
 
-	if (tester_test_bit(value->flags, GATT_VALUE_READ_AUTHOR_FLAG)) {
-		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	SYS_LOG_DBG("");
+
+	memset(str, '\0', sizeof(str));
+
+	if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+		if (ctxt->chr->flags & BLE_GATT_CHR_F_READ_AUTHOR) {
+			return BLE_ATT_ERR_INSUFFICIENT_AUTHOR;
+		}
+
+		ble_uuid_to_str(ctxt->chr->uuid, str);
+	} else {
+		if (ctxt->dsc->att_flags & BLE_ATT_F_READ_AUTHOR) {
+			return BLE_ATT_ERR_INSUFFICIENT_AUTHOR;
+		}
+
+		ble_uuid_to_str(ctxt->dsc->uuid, str);
 	}
 
-	if ((attr->perm & GATT_PERM_ENC_READ_MASK) &&
-	    (value->enc_key_size > bt_conn_enc_key_size(conn))) {
-		return BT_GATT_ERR(BT_ATT_ERR_ENCRYPTION_KEY_SIZE);
-	}
-
-	return bt_gatt_attr_read(conn, attr, buf, len, offset, value->data,
-				 value->len);
+	rc = os_mbuf_append(ctxt->om, value->buf->om_data, value->buf->om_len);
+	return rc == 0 ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
 }
 
 static void attr_value_changed_ev(u16_t handle, const u8_t *value, u16_t len)
 {
 	u8_t buf[len + sizeof(struct gatt_attr_value_changed_ev)];
 	struct gatt_attr_value_changed_ev *ev = (void *) buf;
+
+	SYS_LOG_DBG("");
 
 	ev->handle = sys_cpu_to_le16(handle);
 	ev->data_length = sys_cpu_to_le16(len);
@@ -314,139 +576,114 @@ static void attr_value_changed_ev(u16_t handle, const u8_t *value, u16_t len)
 		    CONTROLLER_INDEX, buf, sizeof(buf));
 }
 
-static ssize_t write_value(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr, const void *buf,
-			   u16_t len, u16_t offset, u8_t flags)
+static size_t write_value(uint16_t conn_handle, uint16_t attr_handle,
+			  struct ble_gatt_access_ctxt *ctxt,
+			  void *arg)
 {
-	struct gatt_value *value = attr->user_data;
+	struct gatt_value *value = arg;
+	uint16_t om_len, len;
+	int rc;
 
-	if (tester_test_bit(value->flags, GATT_VALUE_WRITE_AUTHOR_FLAG)) {
-		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	SYS_LOG_DBG("");
+
+	if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+		if (ctxt->chr->flags & BLE_GATT_CHR_F_WRITE_AUTHOR) {
+			return BLE_ATT_ERR_INSUFFICIENT_AUTHOR;
+		}
+	} else {
+		if (ctxt->dsc->att_flags & BLE_ATT_F_WRITE_AUTHOR) {
+			return BLE_ATT_ERR_INSUFFICIENT_AUTHOR;
+		}
 	}
 
-	if ((attr->perm & GATT_PERM_ENC_WRITE_MASK) &&
-	    (value->enc_key_size > bt_conn_enc_key_size(conn))) {
-		return BT_GATT_ERR(BT_ATT_ERR_ENCRYPTION_KEY_SIZE);
+	om_len = OS_MBUF_PKTLEN(ctxt->om);
+	if (om_len > value->buf->om_len) {
+		return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
 	}
 
-	/* Don't write anything if prepare flag is set */
-	if (flags & BT_GATT_WRITE_FLAG_PREPARE) {
-		return 0;
+	rc = ble_hs_mbuf_to_flat(ctxt->om, value->buf->om_data,
+				 value->buf->om_len, &len);
+	if (rc != 0) {
+		return BLE_ATT_ERR_UNLIKELY;
 	}
-
-	if (offset > value->len) {
-		return BT_GATT_ERR(BT_ATT_ERR_INVALID_OFFSET);
-	}
-
-	if (offset + len > value->len) {
-		return BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
-	}
-
-	memcpy(value->data + offset, buf, len);
 
 	/* Maximum attribute value size is 512 bytes */
-	assert(value->len < 512);
+	assert(value->buf->om_len < 512);
 
-	attr_value_changed_ev(attr->handle, value->data, value->len);
+	attr_value_changed_ev(attr_handle, value->buf->om_data,
+			      value->buf->om_len);
 
-	return len;
+	return 0;
 }
 
-struct add_characteristic {
-	u16_t char_id;
-	u8_t properties;
-	u8_t permissions;
-	const struct bt_uuid *uuid;
-};
 
-static int alloc_characteristic(struct add_characteristic *ch)
+static int gatt_svr_access_cb(uint16_t conn_handle, uint16_t attr_handle,
+			      struct ble_gatt_access_ctxt *ctxt,
+			      void *arg)
 {
-	struct bt_gatt_attr *attr_chrc, *attr_value;
-	struct bt_gatt_chrc *chrc_data;
-	struct gatt_value value;
+	SYS_LOG_DBG("");
 
-	/* Add Characteristic Declaration */
-	attr_chrc = gatt_db_add(&(struct bt_gatt_attr)
-				BT_GATT_ATTRIBUTE(BT_UUID_GATT_CHRC,
-						  BT_GATT_PERM_READ,
-						  bt_gatt_attr_read_chrc, NULL,
-						  (&(struct bt_gatt_chrc){})),
-				sizeof(*chrc_data));
-	if (!attr_chrc) {
-		return -EINVAL;
+	switch (ctxt->op) {
+		case BLE_GATT_ACCESS_OP_READ_CHR:
+		case BLE_GATT_ACCESS_OP_READ_DSC:
+			return read_value(conn_handle, attr_handle,
+					  ctxt, arg);
+		case BLE_GATT_ACCESS_OP_WRITE_CHR:
+		case BLE_GATT_ACCESS_OP_WRITE_DSC:
+			return write_value(conn_handle, attr_handle,
+					   ctxt, arg);
+		default:
+			assert(0);
+			return BLE_ATT_ERR_UNLIKELY;
 	}
 
-	memset(&value, 0, sizeof(value));
-
-	if (ch->permissions & GATT_PERM_READ_AUTHORIZATION) {
-		tester_set_bit(value.flags, GATT_VALUE_READ_AUTHOR_FLAG);
-
-		/* To maintain backward compatibility, set Read Permission */
-		if (!(ch->permissions & GATT_PERM_ENC_READ_MASK)) {
-			ch->permissions |= BT_GATT_PERM_READ;
-		}
-	}
-
-	if (ch->permissions & GATT_PERM_WRITE_AUTHORIZATION) {
-		tester_set_bit(value.flags, GATT_VALUE_WRITE_AUTHOR_FLAG);
-
-		/* To maintain backward compatibility, set Write Permission */
-		if (!(ch->permissions & GATT_PERM_ENC_WRITE_MASK)) {
-			ch->permissions |= BT_GATT_PERM_WRITE;
-		}
-	}
-
-	/* Allow prepare writes */
-	ch->permissions |= BT_GATT_PERM_PREPARE_WRITE;
-
-	/* Add Characteristic Value */
-	attr_value = gatt_db_add(&(struct bt_gatt_attr)
-				 BT_GATT_ATTRIBUTE(ch->uuid,
-					ch->permissions & GATT_PERM_MASK,
-					read_value, write_value, &value),
-					sizeof(value));
-	if (!attr_value) {
-		server_buf_pull(sizeof(*chrc_data));
-		/* Characteristic attribute uuid has constant length */
-		server_buf_pull(sizeof(uint16_t));
-		return -EINVAL;
-	}
-
-	chrc_data = attr_chrc->user_data;
-	chrc_data->properties = ch->properties;
-	chrc_data->uuid = attr_value->uuid;
-
-	ch->char_id = attr_chrc->handle;
-	return 0;
+	/* Unknown characteristic; the nimble stack should not have called this
+	 * function.
+	 */
+	assert(0);
+	return BLE_ATT_ERR_UNLIKELY;
 }
 
 static void add_characteristic(u8_t *data, u16_t len)
 {
 	const struct gatt_add_characteristic_cmd *cmd = (void *) data;
 	struct gatt_add_characteristic_rp rp;
-	struct add_characteristic cmd_data;
-	union uuid uuid;
+	const struct ble_gatt_chr_def *chr;
+	ble_uuid_any_t uuid;
+	uint16_t flags = 0;
+	int i;
 
-	/* Pre-set char_id */
-	cmd_data.char_id = 0;
-	cmd_data.permissions = cmd->permissions;
-	cmd_data.properties = cmd->properties;
-	cmd_data.uuid = &uuid.uuid;
+	SYS_LOG_DBG("");
 
-	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid)) {
 		goto fail;
 	}
 
-	/* characterisic must be added only sequential */
+	/* characterisic must be added sequentially */
 	if (cmd->svc_id) {
 		goto fail;
 	}
 
-	if (alloc_characteristic(&cmd_data)) {
+	for (i = 0; i < 8; ++i) {
+		if (cmd->permissions & BIT(i)) {
+			flags |= gatt_chr_perm_map[i];
+		}
+	}
+
+	chr = find_chr(&uuid);
+	if (chr == NULL) {
+		SYS_LOG_ERR("Invalid characteristic UUID");
 		goto fail;
 	}
 
-	rp.char_id = sys_cpu_to_le16(cmd_data.char_id);
+	if ((chr->flags > 0) && ((flags & chr->flags) == 0)) {
+		SYS_LOG_ERR("Invalid flags");
+		goto fail;
+	}
+
+	/* TODO: Set char id */
+	rp.char_id = 0;
+
 	tester_send(BTP_SERVICE_ID_GATT, GATT_ADD_CHARACTERISTIC,
 		    CONTROLLER_INDEX, (u8_t *) &rp, sizeof(rp));
 	return;
@@ -456,184 +693,52 @@ fail:
 		   CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
-static bool ccc_added;
-
-static struct bt_gatt_ccc_cfg ccc_cfg[BT_GATT_CCC_MAX] = {};
-static u8_t ccc_value;
-
-static void ccc_cfg_changed(const struct bt_gatt_attr *attr, u16_t value)
-{
-	ccc_value = value;
-}
-
-static struct bt_gatt_attr ccc = BT_GATT_CCC(ccc_cfg, ccc_cfg_changed);
-
-static struct bt_gatt_attr *add_ccc(const struct bt_gatt_attr *attr)
-{
-	struct bt_gatt_attr *attr_desc;
-	struct bt_gatt_chrc *chrc = attr->user_data;
-	struct gatt_value *value = NEXT_DB_ATTR(attr)->user_data;
-
-	/* Fail if another CCC already exist on server */
-	if (ccc_added) {
-		return NULL;
-	}
-
-	/* Check characteristic properties */
-	if (!(chrc->properties &
-	    (BT_GATT_CHRC_NOTIFY | BT_GATT_CHRC_INDICATE))) {
-		return NULL;
-	}
-
-	/* Add CCC descriptor to GATT database */
-	attr_desc = gatt_db_add(&ccc, 0);
-	if (!attr_desc) {
-		return NULL;
-	}
-
-	tester_set_bit(value->flags, GATT_VALUE_CCC_FLAG);
-	ccc_added = true;
-
-	return attr_desc;
-}
-
-static struct bt_gatt_attr *add_cep(const struct bt_gatt_attr *attr_chrc)
-{
-	struct bt_gatt_chrc *chrc = attr_chrc->user_data;
-	struct bt_gatt_cep cep_value;
-
-	/* Extended Properties bit shall be set */
-	if (!(chrc->properties & BT_GATT_CHRC_EXT_PROP)) {
-		return NULL;
-	}
-
-	cep_value.properties = 0x0000;
-
-	/* Add CEP descriptor to GATT database */
-	return gatt_db_add(&(struct bt_gatt_attr) BT_GATT_CEP(&cep_value),
-			   sizeof(cep_value));
-}
-
-struct add_descriptor {
-	u16_t desc_id;
-	u8_t permissions;
-	const struct bt_uuid *uuid;
-};
-
-static int alloc_descriptor(const struct bt_gatt_attr *attr,
-			    struct add_descriptor *d)
-{
-	struct bt_gatt_attr *attr_desc;
-	struct gatt_value value;
-
-	if (!bt_uuid_cmp(d->uuid, BT_UUID_GATT_CEP)) {
-		attr_desc = add_cep(attr);
-	} else if (!bt_uuid_cmp(d->uuid, BT_UUID_GATT_CCC)) {
-		attr_desc = add_ccc(attr);
-	} else {
-		memset(&value, 0, sizeof(value));
-
-		if (d->permissions & GATT_PERM_READ_AUTHORIZATION) {
-			tester_set_bit(value.flags,
-				       GATT_VALUE_READ_AUTHOR_FLAG);
-
-			/*
-			 * To maintain backward compatibility,
-			 * set Read Permission
-			 */
-			if (!(d->permissions & GATT_PERM_ENC_READ_MASK)) {
-				d->permissions |= BT_GATT_PERM_READ;
-			}
-		}
-
-		if (d->permissions & GATT_PERM_WRITE_AUTHORIZATION) {
-			tester_set_bit(value.flags,
-				       GATT_VALUE_WRITE_AUTHOR_FLAG);
-
-			/*
-			 * To maintain backward compatibility,
-			 * set Write Permission
-			 */
-			if (!(d->permissions & GATT_PERM_ENC_WRITE_MASK)) {
-				d->permissions |= BT_GATT_PERM_WRITE;
-			}
-		}
-
-		/* Allow prepare writes */
-		d->permissions |= BT_GATT_PERM_PREPARE_WRITE;
-
-		attr_desc = gatt_db_add(&(struct bt_gatt_attr)
-					BT_GATT_DESCRIPTOR(d->uuid,
-						d->permissions & GATT_PERM_MASK,
-						read_value, write_value,
-						&value), sizeof(value));
-	}
-
-	if (!attr_desc) {
-		return -EINVAL;
-	}
-
-	d->desc_id = attr_desc->handle;
-	return 0;
-}
-
-static struct bt_gatt_attr *get_base_chrc(struct bt_gatt_attr *attr)
-{
-	struct bt_gatt_attr *tmp;
-
-	for (tmp = attr; tmp > server_db; tmp--) {
-		/* Service Declaration cannot precede Descriptor declaration */
-		if (!bt_uuid_cmp(tmp->uuid, BT_UUID_GATT_PRIMARY) ||
-		    !bt_uuid_cmp(tmp->uuid, BT_UUID_GATT_SECONDARY)) {
-			break;
-		}
-
-		if (!bt_uuid_cmp(tmp->uuid, BT_UUID_GATT_CHRC)) {
-			return tmp;
-		}
-	}
-
-	return NULL;
-}
-
 static void add_descriptor(u8_t *data, u16_t len)
 {
 	const struct gatt_add_descriptor_cmd *cmd = (void *) data;
 	struct gatt_add_descriptor_rp rp;
-	struct add_descriptor cmd_data;
-	struct bt_gatt_attr *chrc;
-	union uuid uuid;
+	const struct ble_gatt_dsc_def *dsc;
+	ble_uuid_any_t uuid;
+	uint16_t att_flags = 0;
+	int i;
 
-	/* Must be declared first svc or at least 3 attrs (svc+char+char val) */
-	if (!svc_count || attr_count < 3) {
+	SYS_LOG_DBG("");
+
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid)) {
 		goto fail;
 	}
 
-	/* Pre-set desc_id */
-	cmd_data.desc_id = 0;
-	cmd_data.permissions = cmd->permissions;
-	cmd_data.uuid = &uuid.uuid;
-
-	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
-		goto fail;
-	}
-
-	/* descriptor can be added only sequential */
+	/* descriptor can be added only sequentially */
 	if (cmd->char_id) {
 		goto fail;
 	}
 
-	/* Lookup preceding Characteristic Declaration here */
-	chrc = get_base_chrc(LAST_DB_ATTR);
-	if (!chrc) {
-		goto fail;
+	att_flags = cmd->permissions;
+
+	if (!ble_uuid_cmp(&uuid.u, &BT_UUID_GATT_CEP.u)) {
+		/* TODO: */
+	} else if (!ble_uuid_cmp(&uuid.u, &BT_UUID_GATT_CCC.u)) {
+		/* handled by host */
+	} else {
+		dsc = find_dsc(&uuid);
+		if (dsc == NULL) {
+			SYS_LOG_ERR("Invalid characteristic UUID");
+			goto fail;
+		}
+
+		for (i = 0; i < 8; ++i) {
+			if (cmd->permissions & BIT(i)) {
+				att_flags |= gatt_dsc_perm_map[i];
+			}
+		}
+
+		if ((att_flags & dsc->att_flags) == 0) {
+			SYS_LOG_ERR("Invalid flags");
+			goto fail;
+		}
 	}
 
-	if (alloc_descriptor(chrc, &cmd_data)) {
-		goto fail;
-	}
-
-	rp.desc_id = sys_cpu_to_le16(cmd_data.desc_id);
+	rp.desc_id = 0;
 	tester_send(BTP_SERVICE_ID_GATT, GATT_ADD_DESCRIPTOR, CONTROLLER_INDEX,
 		    (u8_t *) &rp, sizeof(rp));
 	return;
@@ -643,206 +748,74 @@ fail:
 		   CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
-static int alloc_included(struct bt_gatt_attr *attr,
-			  u16_t *included_service_id, u16_t svc_handle)
-{
-	struct bt_gatt_attr *attr_incl;
-
-	/*
-	 * user_data_len is set to 0 to NOT allocate memory in server_buf for
-	 * user_data, just to assign to it attr pointer.
-	 */
-	attr_incl = gatt_db_add(&(struct bt_gatt_attr)
-				BT_GATT_INCLUDE_SERVICE(attr), 0);
-
-	if (!attr_incl) {
-		return -EINVAL;
-	}
-
-	attr_incl->user_data = attr;
-
-	*included_service_id = attr_incl->handle;
-	return 0;
-}
-
 static void add_included(u8_t *data, u16_t len)
 {
 	const struct gatt_add_included_service_cmd *cmd = (void *) data;
 	struct gatt_add_included_service_rp rp;
-	struct bt_gatt_attr *svc;
 	u16_t included_service_id = 0;
 
-	if (!svc_count || !cmd->svc_id) {
-		goto fail;
-	}
-
-	svc = &server_db[cmd->svc_id - 1];
-
-	/* Fail if attribute stored under requested handle is not a service */
-	if (bt_uuid_cmp(svc->uuid, BT_UUID_GATT_PRIMARY) &&
-	    bt_uuid_cmp(svc->uuid, BT_UUID_GATT_SECONDARY)) {
-		goto fail;
-	}
-
-	if (alloc_included(svc, &included_service_id, cmd->svc_id)) {
-		goto fail;
-	}
+	included_service_id = cmd->svc_id;
 
 	rp.included_service_id = sys_cpu_to_le16(included_service_id);
 	tester_send(BTP_SERVICE_ID_GATT, GATT_ADD_INCLUDED_SERVICE,
 		    CONTROLLER_INDEX, (u8_t *) &rp, sizeof(rp));
-	return;
-
-fail:
-	tester_rsp(BTP_SERVICE_ID_GATT, GATT_ADD_INCLUDED_SERVICE,
-		   CONTROLLER_INDEX, BTP_STATUS_FAILED);
-}
-
-static u8_t set_cep_value(struct bt_gatt_attr *attr, const void *value,
-			     const u16_t len)
-{
-	struct bt_gatt_cep *cep_value = attr->user_data;
-	u16_t properties;
-
-	if (len != sizeof(properties)) {
-		return BTP_STATUS_FAILED;
-	}
-
-	memcpy(&properties, value, len);
-	cep_value->properties = sys_le16_to_cpu(properties);
-
-	return BTP_STATUS_SUCCESS;
-}
-
-struct set_value {
-	const u8_t *value;
-	u16_t len;
-};
-
-struct bt_gatt_indicate_params indicate_params;
-
-static void indicate_cb(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			u8_t err)
-{
-	if (err != 0) {
-		SYS_LOG_ERR("Indication fail");
-	} else {
-		SYS_LOG_DBG("Indication success");
-	}
-}
-
-static u8_t alloc_value(struct bt_gatt_attr *attr, struct set_value *data)
-{
-	struct gatt_value *value;
-
-	/* Value has been already set while adding CCC to the gatt_db */
-	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CCC)) {
-		return BTP_STATUS_SUCCESS;
-	}
-
-	/* Set CEP value */
-	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CEP)) {
-		return set_cep_value(attr, data->value, data->len);
-	}
-
-	value = attr->user_data;
-
-	/* Check if attribute value has been already set */
-	if (!value->len) {
-		value->data = server_buf_push(data->len);
-		value->len = data->len;
-	}
-
-	/* Fail if value length doesn't match  */
-	if (value->len != data->len) {
-		return BTP_STATUS_FAILED;
-	}
-
-	memcpy(value->data, data->value, value->len);
-
-	if (tester_test_bit(value->flags, GATT_VALUE_CCC_FLAG) && ccc_value) {
-		if (ccc_value == BT_GATT_CCC_NOTIFY) {
-			bt_gatt_notify(NULL, attr, value->data, value->len);
-		} else {
-			indicate_params.attr = attr;
-			indicate_params.data = value->data;
-			indicate_params.len = value->len;
-			indicate_params.func = indicate_cb;
-
-			bt_gatt_indicate(NULL, &indicate_params);
-		}
-	}
-
-	return BTP_STATUS_SUCCESS;
 }
 
 static void set_value(u8_t *data, u16_t len)
 {
 	const struct gatt_set_value_cmd *cmd = (void *) data;
-	struct set_value cmd_data;
-	u8_t status;
+	const struct ble_gatt_chr_def *chr;
+	struct gatt_value *gatt_value;
+	u16_t value_len;
+	const u8_t *value;
 
-	/* Pre-set btp_status */
-	cmd_data.value = cmd->value;
-	cmd_data.len = sys_le16_to_cpu(cmd->len);
+	SYS_LOG_DBG("%d id", cmd->attr_id);
 
-	if (!cmd->attr_id) {
-		status = alloc_value(LAST_DB_ATTR, &cmd_data);
-	} else {
-		/* set value of local attr, corrected by pre set attr handles */
-		status = alloc_value(&server_db[cmd->attr_id -
-				     server_db[0].handle], &cmd_data);
+	gatt_value = find_gatt_value_by_id(
+		sys_le16_to_cpu(cmd->attr_id));
+	assert(gatt_value != NULL);
+
+	value_len = sys_le16_to_cpu(cmd->len);
+	value = cmd->value;
+
+	if (value_len > gatt_value->buf->om_len) {
+		os_mbuf_extend(gatt_value->buf,
+			       (value_len - gatt_value->buf->om_len));
+	}
+
+	memcpy(gatt_value->buf->om_data, value, value_len);
+
+	if (gatt_value->type == GATT_VALUE_TYPE_CHR) {
+		chr = gatt_value->ptr;
+		if (chr->flags & BLE_GATT_CHR_F_INDICATE ||
+		    chr->flags & BLE_GATT_CHR_F_NOTIFY) {
+			ble_gatts_chr_updated(*chr->val_handle);
+		}
 	}
 
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_SET_VALUE, CONTROLLER_INDEX,
-		   status);
+		   BTP_STATUS_SUCCESS);
 }
 
 static void start_server(u8_t *data, u16_t len)
 {
 	struct gatt_start_server_rp rp;
 
-	/* Register last defined service */
-	if (svc_count) {
-		if (register_service()) {
-			tester_rsp(BTP_SERVICE_ID_GATT, GATT_START_SERVER,
-				   CONTROLLER_INDEX, BTP_STATUS_FAILED);
-			return;
-		}
-	}
+	SYS_LOG_DBG("");
+
+	ble_gatts_show_local();
+
+	ble_svc_gatt_changed(0x0001, 0xffff);
 
 	tester_send(BTP_SERVICE_ID_GATT, GATT_START_SERVER, CONTROLLER_INDEX,
 		    (u8_t *) &rp, sizeof(rp));
 }
 
-static int set_attr_enc_key_size(const struct bt_gatt_attr *attr,
-				 u8_t key_size)
-{
-	struct gatt_value *value;
-
-	/* Fail if requested attribute is a service */
-	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_PRIMARY) ||
-	    !bt_uuid_cmp(attr->uuid, BT_UUID_GATT_SECONDARY) ||
-	    !bt_uuid_cmp(attr->uuid, BT_UUID_GATT_INCLUDE)) {
-		return -EINVAL;
-	}
-
-	/* Fail if permissions are not set */
-	if (!(attr->perm & (GATT_PERM_ENC_READ_MASK |
-			    GATT_PERM_ENC_WRITE_MASK))) {
-		return -EINVAL;
-	}
-
-	value = attr->user_data;
-	value->enc_key_size = key_size;
-
-	return 0;
-}
-
 static void set_enc_key_size(u8_t *data, u16_t len)
 {
 	const struct gatt_set_enc_key_size_cmd *cmd = (void *) data;
-	u8_t status;
+	struct gatt_value *val;
+	u8_t status = 0;
 
 	/* Fail if requested key size is invalid */
 	if (cmd->key_size < 0x07 || cmd->key_size > 0x0f) {
@@ -850,13 +823,21 @@ static void set_enc_key_size(u8_t *data, u16_t len)
 		goto fail;
 	}
 
-	if (!cmd->attr_id) {
-		status = set_attr_enc_key_size(LAST_DB_ATTR, cmd->key_size);
-	} else {
-		/* set value of local attr, corrected by pre set attr handles */
-		status = set_attr_enc_key_size(&server_db[cmd->attr_id -
-					       server_db[0].handle],
-					       cmd->key_size);
+	val = find_gatt_value_by_id(sys_le16_to_cpu(cmd->attr_id));
+	assert(val != NULL);
+	assert(val->ptr != NULL);
+
+	switch(val->type) {
+	case GATT_VALUE_TYPE_CHR:
+		((struct ble_gatt_chr_def *) val->ptr)->min_key_size =
+			cmd->key_size;
+		break;
+	case GATT_VALUE_TYPE_DSC:
+		((struct ble_gatt_dsc_def *) val->ptr)->min_key_size =
+			cmd->key_size;
+		break;
+	default:
+		break;
 	}
 
 fail:
@@ -864,40 +845,40 @@ fail:
 		   status);
 }
 
-static void exchange_func(struct bt_conn *conn, u8_t err,
-			  struct bt_gatt_exchange_params *params)
+static int exchange_func(uint16_t conn_handle,
+			 const struct ble_gatt_error *error,
+			 uint16_t mtu, void *arg)
 {
-	if (err) {
+	SYS_LOG_DBG("");
+
+	if (error->status) {
 		tester_rsp(BTP_SERVICE_ID_GATT, GATT_EXCHANGE_MTU,
 			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
 
-		return;
+		return 0;
 	}
 
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_EXCHANGE_MTU, CONTROLLER_INDEX,
 		   BTP_STATUS_SUCCESS);
-}
 
-static struct bt_gatt_exchange_params exchange_params;
+	return 0;
+}
 
 static void exchange_mtu(u8_t *data, u16_t len)
 {
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
 		goto fail;
 	}
 
-	exchange_params.func = exchange_func;
-
-	if (bt_gatt_exchange_mtu(conn, &exchange_params) < 0) {
-		bt_conn_unref(conn);
-
+	if (ble_gattc_exchange_mtu(conn.conn_handle, exchange_func, NULL)) {
 		goto fail;
 	}
-
-	bt_conn_unref(conn);
 
 	return;
 fail:
@@ -905,73 +886,74 @@ fail:
 		   CONTROLLER_INDEX, BTP_STATUS_FAILED);
 }
 
-static struct bt_gatt_discover_params discover_params;
-static union uuid uuid;
-static u8_t btp_opcode;
 
-static void discover_destroy(struct bt_gatt_discover_params *params)
+static void discover_destroy(void)
 {
-	memset(params, 0, sizeof(*params));
 	gatt_buf_clear();
 }
 
-static u8_t disc_prim_uuid_cb(struct bt_conn *conn,
-				 const struct bt_gatt_attr *attr,
-				 struct bt_gatt_discover_params *params)
+static int disc_prim_uuid_cb(uint16_t conn_handle,
+			     const struct ble_gatt_error *error,
+			     const struct ble_gatt_svc *gatt_svc, void *arg)
 {
-	struct bt_gatt_service_val *data;
 	struct gatt_disc_prim_uuid_rp *rp = (void *) gatt_buf.buf;
 	struct gatt_service *service;
+	const ble_uuid_any_t *uuid;
 	u8_t uuid_length;
 
-	if (!attr) {
+	SYS_LOG_DBG("");
+
+	if (error->status != 0) {
 		tester_send(BTP_SERVICE_ID_GATT, GATT_DISC_PRIM_UUID,
 			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
-		discover_destroy(params);
-		return BT_GATT_ITER_STOP;
+		discover_destroy();
+		return 0;
 	}
 
-	data = attr->user_data;
-
-	uuid_length = data->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
+	uuid = &gatt_svc->uuid;
+	uuid_length = (uint8_t) (uuid->u.type == BLE_UUID_TYPE_16 ? 2 : 16);
 
 	service = gatt_buf_reserve(sizeof(*service) + uuid_length);
 	if (!service) {
 		tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_PRIM_UUID,
 			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
-		discover_destroy(params);
-		return BT_GATT_ITER_STOP;
+		discover_destroy();
+		return BLE_HS_EDONE;
 	}
 
-	service->start_handle = sys_cpu_to_le16(attr->handle);
-	service->end_handle = sys_cpu_to_le16(data->end_handle);
+	service->start_handle = sys_cpu_to_le16(gatt_svc->start_handle);
+	service->end_handle = sys_cpu_to_le16(gatt_svc->end_handle);
 	service->uuid_length = uuid_length;
 
-	if (data->uuid->type == BT_UUID_TYPE_16) {
-		u16_t u16 = sys_cpu_to_le16(BT_UUID_16(data->uuid)->val);
+	if (uuid->u.type == BLE_UUID_TYPE_16) {
+		u16_t u16 = sys_cpu_to_le16(BLE_UUID16(uuid)->value);
 
 		memcpy(service->uuid, &u16, uuid_length);
 	} else {
-		memcpy(service->uuid, BT_UUID_128(data->uuid)->val,
+		memcpy(service->uuid, BLE_UUID128(uuid)->value,
 		       uuid_length);
 	}
 
 	rp->services_count++;
 
-	return BT_GATT_ITER_CONTINUE;
+	return 0;
 }
 
 static void disc_prim_uuid(u8_t *data, u16_t len)
 {
 	const struct gatt_disc_prim_uuid_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	ble_uuid_any_t uuid;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
-		goto fail_conn;
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
+		goto fail;
 	}
 
-	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid)) {
 		goto fail;
 	}
 
@@ -979,193 +961,185 @@ static void disc_prim_uuid(u8_t *data, u16_t len)
 		goto fail;
 	}
 
-	discover_params.uuid = &uuid.uuid;
-	discover_params.start_handle = 0x0001;
-	discover_params.end_handle = 0xffff;
-	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
-	discover_params.func = disc_prim_uuid_cb;
-
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
-		discover_destroy(&discover_params);
-
+	if (ble_gattc_disc_svc_by_uuid(conn.conn_handle, &uuid.u,
+				       disc_prim_uuid_cb, NULL)) {
+		discover_destroy();
 		goto fail;
 	}
 
-	bt_conn_unref(conn);
-
 	return;
-fail:
-	bt_conn_unref(conn);
 
-fail_conn:
+fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_PRIM_UUID, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
 
-static u8_t find_included_cb(struct bt_conn *conn,
-				const struct bt_gatt_attr *attr,
-				struct bt_gatt_discover_params *params)
+static int find_included_cb(uint16_t conn_handle,
+			    const struct ble_gatt_error *error,
+			    const struct ble_gatt_svc *gatt_svc, void *arg)
 {
-	struct bt_gatt_include *data;
 	struct gatt_find_included_rp *rp = (void *) gatt_buf.buf;
 	struct gatt_included *included;
+	const ble_uuid_any_t *uuid;
 	u8_t uuid_length;
 
-	if (!attr) {
+	SYS_LOG_DBG("");
+
+	if (error->status != 0) {
 		tester_send(BTP_SERVICE_ID_GATT, GATT_FIND_INCLUDED,
 			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
-		discover_destroy(params);
-		return BT_GATT_ITER_STOP;
+		discover_destroy();
+		return 0;
 	}
 
-	data = attr->user_data;
+	uuid = &gatt_svc->uuid;
+	uuid_length = (uint8_t) (uuid->u.type == BLE_UUID_TYPE_16 ? 2 : 16);
 
-	uuid_length = data->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
 
 	included = gatt_buf_reserve(sizeof(*included) + uuid_length);
 	if (!included) {
 		tester_rsp(BTP_SERVICE_ID_GATT, GATT_FIND_INCLUDED,
 			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
-		discover_destroy(params);
-		return BT_GATT_ITER_STOP;
+		discover_destroy();
+		return BLE_HS_EDONE;
 	}
 
-	included->included_handle = attr->handle;
-	included->service.start_handle = sys_cpu_to_le16(data->start_handle);
-	included->service.end_handle = sys_cpu_to_le16(data->end_handle);
+	/* FIXME */
+	included->included_handle = sys_cpu_to_le16(gatt_svc->start_handle);
+	included->service.start_handle = sys_cpu_to_le16(gatt_svc->start_handle);
+	included->service.end_handle = sys_cpu_to_le16(gatt_svc->start_handle);
 	included->service.uuid_length = uuid_length;
 
-	if (data->uuid->type == BT_UUID_TYPE_16) {
-		u16_t u16 = sys_cpu_to_le16(BT_UUID_16(data->uuid)->val);
+	if (uuid->u.type == BLE_UUID_TYPE_16) {
+		u16_t u16 = sys_cpu_to_le16(BLE_UUID16(uuid)->value);
 
 		memcpy(included->service.uuid, &u16, uuid_length);
 	} else {
-		memcpy(included->service.uuid, BT_UUID_128(data->uuid)->val,
+		memcpy(included->service.uuid, BLE_UUID128(uuid)->value,
 		       uuid_length);
 	}
 
 	rp->services_count++;
 
-	return BT_GATT_ITER_CONTINUE;
+	return 0;
 }
 
 static void find_included(u8_t *data, u16_t len)
 {
 	const struct gatt_find_included_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	uint16_t start_handle, end_handle;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
-		goto fail_conn;
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
+		goto fail;
 	}
 
 	if (!gatt_buf_reserve(sizeof(struct gatt_find_included_rp))) {
 		goto fail;
 	}
 
-	discover_params.start_handle = sys_le16_to_cpu(cmd->start_handle);
-	discover_params.end_handle = sys_le16_to_cpu(cmd->end_handle);
-	discover_params.type = BT_GATT_DISCOVER_INCLUDE;
-	discover_params.func = find_included_cb;
+	start_handle = sys_le16_to_cpu(cmd->start_handle);
+	end_handle = sys_le16_to_cpu(cmd->end_handle);
 
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
-		discover_destroy(&discover_params);
-
+	if (ble_gattc_find_inc_svcs(conn.conn_handle, start_handle, end_handle,
+				    find_included_cb, NULL)) {
+		discover_destroy();
 		goto fail;
 	}
 
-	bt_conn_unref(conn);
-
 	return;
-fail:
-	bt_conn_unref(conn);
 
-fail_conn:
+fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_FIND_INCLUDED, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
 
-static u8_t disc_chrc_cb(struct bt_conn *conn,
-			    const struct bt_gatt_attr *attr,
-			    struct bt_gatt_discover_params *params)
+static int disc_chrc_cb(uint16_t conn_handle,
+			const struct ble_gatt_error *error,
+			const struct ble_gatt_chr *gatt_chr, void *arg)
 {
-	struct bt_gatt_chrc *data;
 	struct gatt_disc_chrc_rp *rp = (void *) gatt_buf.buf;
 	struct gatt_characteristic *chrc;
+	const ble_uuid_any_t *uuid;
+	u8_t btp_opcode = (uint8_t) (int) arg;
 	u8_t uuid_length;
 
-	if (!attr) {
+	SYS_LOG_DBG("");
+
+	if (error->status != 0) {
 		tester_send(BTP_SERVICE_ID_GATT, btp_opcode,
 			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
-		discover_destroy(params);
-		return BT_GATT_ITER_STOP;
+		discover_destroy();
+		return 0;
 	}
 
-	data = attr->user_data;
-
-	uuid_length = data->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
+	uuid = &gatt_chr->uuid;
+	uuid_length = (uint8_t) (uuid->u.type == BLE_UUID_TYPE_16 ? 2 : 16);
 
 	chrc = gatt_buf_reserve(sizeof(*chrc) + uuid_length);
 	if (!chrc) {
 		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode,
 			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
-		discover_destroy(params);
-		return BT_GATT_ITER_STOP;
+		discover_destroy();
+		return BLE_HS_EDONE;
 	}
 
-	chrc->characteristic_handle = sys_cpu_to_le16(attr->handle);
-	chrc->properties = data->properties;
-	chrc->value_handle = sys_cpu_to_le16(attr->handle + 1);
+	chrc->characteristic_handle = sys_cpu_to_le16(gatt_chr->def_handle);
+	chrc->properties = gatt_chr->properties;
+	chrc->value_handle = sys_cpu_to_le16(gatt_chr->val_handle);
 	chrc->uuid_length = uuid_length;
 
-	if (data->uuid->type == BT_UUID_TYPE_16) {
-		u16_t u16 = sys_cpu_to_le16(BT_UUID_16(data->uuid)->val);
+	if (uuid->u.type == BLE_UUID_TYPE_16) {
+		u16_t u16 = sys_cpu_to_le16(BLE_UUID16(uuid)->value);
 
 		memcpy(chrc->uuid, &u16, uuid_length);
 	} else {
-		memcpy(chrc->uuid, BT_UUID_128(data->uuid)->val, uuid_length);
+		memcpy(chrc->uuid, BLE_UUID128(uuid)->value,
+		       uuid_length);
 	}
 
 	rp->characteristics_count++;
 
-	return BT_GATT_ITER_CONTINUE;
+	return 0;
 }
 
 static void disc_all_chrc(u8_t *data, u16_t len)
 {
 	const struct gatt_disc_all_chrc_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	uint16_t start_handle, end_handle;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
-		goto fail_conn;
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
+		SYS_LOG_DBG("Conn find failed");
+		goto fail;
 	}
 
 	if (!gatt_buf_reserve(sizeof(struct gatt_disc_chrc_rp))) {
+		SYS_LOG_DBG("Buf reserve failed");
 		goto fail;
 	}
 
-	discover_params.start_handle = sys_le16_to_cpu(cmd->start_handle);
-	discover_params.end_handle = sys_le16_to_cpu(cmd->end_handle);
-	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-	discover_params.func = disc_chrc_cb;
+	start_handle = sys_le16_to_cpu(cmd->start_handle);
+	end_handle = sys_le16_to_cpu(cmd->end_handle);
 
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = GATT_DISC_ALL_CHRC;
-
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
-		discover_destroy(&discover_params);
-
+	rc = ble_gattc_disc_all_chrs(conn.conn_handle, start_handle, end_handle,
+				     disc_chrc_cb, (void *)GATT_DISC_ALL_CHRC);
+	if (rc) {
+		discover_destroy();
 		goto fail;
 	}
-
-	bt_conn_unref(conn);
 
 	return;
-fail:
-	bt_conn_unref(conn);
 
-fail_conn:
+fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_ALL_CHRC, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
@@ -1173,14 +1147,19 @@ fail_conn:
 static void disc_chrc_uuid(u8_t *data, u16_t len)
 {
 	const struct gatt_disc_chrc_uuid_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	uint16_t start_handle, end_handle;
+	ble_uuid_any_t uuid;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
-		goto fail_conn;
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
+		goto fail;
 	}
 
-	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid.uuid)) {
+	if (btp2bt_uuid(cmd->uuid, cmd->uuid_length, &uuid)) {
 		goto fail;
 	}
 
@@ -1188,184 +1167,210 @@ static void disc_chrc_uuid(u8_t *data, u16_t len)
 		goto fail;
 	}
 
-	discover_params.uuid = &uuid.uuid;
-	discover_params.start_handle = sys_le16_to_cpu(cmd->start_handle);
-	discover_params.end_handle = sys_le16_to_cpu(cmd->end_handle);
-	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-	discover_params.func = disc_chrc_cb;
+	start_handle = sys_le16_to_cpu(cmd->start_handle);
+	end_handle = sys_le16_to_cpu(cmd->end_handle);
 
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = GATT_DISC_CHRC_UUID;
-
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
-		discover_destroy(&discover_params);
-
+	if (ble_gattc_disc_chrs_by_uuid(conn.conn_handle, start_handle,
+					end_handle, &uuid.u, disc_chrc_cb,
+					(void *)GATT_DISC_CHRC_UUID)) {
+		discover_destroy();
 		goto fail;
 	}
 
-	bt_conn_unref(conn);
-
 	return;
-fail:
-	bt_conn_unref(conn);
 
-fail_conn:
+fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_CHRC_UUID, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
 
-static u8_t disc_all_desc_cb(struct bt_conn *conn,
-				const struct bt_gatt_attr *attr,
-				struct bt_gatt_discover_params *params)
+static int disc_all_desc_cb(uint16_t conn_handle,
+			    const struct ble_gatt_error *error,
+			    uint16_t chr_def_handle,
+			    const struct ble_gatt_dsc *gatt_dsc,
+			    void *arg)
 {
 	struct gatt_disc_all_desc_rp *rp = (void *) gatt_buf.buf;
-	struct gatt_descriptor *descriptor;
+	struct gatt_descriptor *dsc;
+	const ble_uuid_any_t *uuid;
 	u8_t uuid_length;
 
-	if (!attr) {
+	SYS_LOG_DBG("");
+
+	if (error->status != 0) {
 		tester_send(BTP_SERVICE_ID_GATT, GATT_DISC_ALL_DESC,
 			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
-		discover_destroy(params);
-		return BT_GATT_ITER_STOP;
+		discover_destroy();
+		return 0;
 	}
 
-	uuid_length = attr->uuid->type == BT_UUID_TYPE_16 ? 2 : 16;
+	uuid = &gatt_dsc->uuid;
+	uuid_length = (uint8_t) (uuid->u.type == BLE_UUID_TYPE_16 ? 2 : 16);
 
-	descriptor = gatt_buf_reserve(sizeof(*descriptor) + uuid_length);
-	if (!descriptor) {
+	dsc = gatt_buf_reserve(sizeof(*dsc) + uuid_length);
+	if (!dsc) {
 		tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_ALL_DESC,
 			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
-		discover_destroy(params);
-		return BT_GATT_ITER_STOP;
+		discover_destroy();
+		return BLE_HS_EDONE;
 	}
 
-	descriptor->descriptor_handle = sys_cpu_to_le16(attr->handle);
-	descriptor->uuid_length = uuid_length;
+	dsc->descriptor_handle = sys_cpu_to_le16(gatt_dsc->handle);
+	dsc->uuid_length = uuid_length;
 
-	if (attr->uuid->type == BT_UUID_TYPE_16) {
-		u16_t u16 = sys_cpu_to_le16(BT_UUID_16(attr->uuid)->val);
+	if (uuid->u.type == BLE_UUID_TYPE_16) {
+		u16_t u16 = sys_cpu_to_le16(BLE_UUID16(uuid)->value);
 
-		memcpy(descriptor->uuid, &u16, uuid_length);
+		memcpy(dsc->uuid, &u16, uuid_length);
 	} else {
-		memcpy(descriptor->uuid, BT_UUID_128(attr->uuid)->val,
+		memcpy(dsc->uuid, BLE_UUID128(uuid)->value,
 		       uuid_length);
 	}
 
 	rp->descriptors_count++;
 
-	return BT_GATT_ITER_CONTINUE;
+	return 0;
 }
 
 static void disc_all_desc(u8_t *data, u16_t len)
 {
 	const struct gatt_disc_all_desc_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	uint16_t start_handle, end_handle;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
-		goto fail_conn;
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
+		goto fail;
 	}
 
 	if (!gatt_buf_reserve(sizeof(struct gatt_disc_all_desc_rp))) {
 		goto fail;
 	}
 
-	discover_params.start_handle = sys_le16_to_cpu(cmd->start_handle);
-	discover_params.end_handle = sys_le16_to_cpu(cmd->end_handle);
-	discover_params.type = BT_GATT_DISCOVER_DESCRIPTOR;
-	discover_params.func = disc_all_desc_cb;
+	start_handle = sys_le16_to_cpu(cmd->start_handle) - 1;
+	end_handle = sys_le16_to_cpu(cmd->end_handle);
 
-	if (bt_gatt_discover(conn, &discover_params) < 0) {
-		discover_destroy(&discover_params);
+	rc = ble_gattc_disc_all_dscs(conn.conn_handle, start_handle, end_handle,
+				     disc_all_desc_cb, NULL);
 
+	SYS_LOG_DBG("rc=%d", rc);
+
+	if (rc) {
+		discover_destroy();
 		goto fail;
 	}
 
-	bt_conn_unref(conn);
-
 	return;
-fail:
-	bt_conn_unref(conn);
 
-fail_conn:
+fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_DISC_ALL_DESC, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
 
-static struct bt_gatt_read_params read_params;
-
-static void read_destroy(struct bt_gatt_read_params *params)
+static void read_destroy()
 {
-	memset(params, 0, sizeof(*params));
 	gatt_buf_clear();
 }
 
-static u8_t read_cb(struct bt_conn *conn, u8_t err,
-		       struct bt_gatt_read_params *params, const void *data,
-		       u16_t length)
+static int read_cb(uint16_t conn_handle,
+		   const struct ble_gatt_error *error,
+		   struct ble_gatt_attr *attr,
+		   void *arg)
+{
+	struct gatt_read_rp *rp = (void *) gatt_buf.buf;
+	u8_t btp_opcode = (uint8_t) (int) arg;
+
+	SYS_LOG_DBG("status=%d", error->status);
+
+	if (error->status != 0 && error->status != BLE_HS_EDONE) {
+		rp->att_response = (uint8_t) BLE_HS_ATT_ERR(error->status);
+		tester_send(BTP_SERVICE_ID_GATT, btp_opcode,
+			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
+		read_destroy();
+		return 0;
+	}
+
+	if (!gatt_buf_add(attr->om->om_data, attr->om->om_len)) {
+		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode,
+			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
+		read_destroy();
+		return 0;
+	}
+
+	rp->data_length += attr->om->om_len;
+
+	tester_send(BTP_SERVICE_ID_GATT, btp_opcode,
+		    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
+	read_destroy();
+
+	return 0;
+}
+
+static int read_long_cb(uint16_t conn_handle,
+			const struct ble_gatt_error *error,
+			struct ble_gatt_attr *attr,
+			void *arg)
 {
 	struct gatt_read_rp *rp = (void *) gatt_buf.buf;
 
-	/* Respond to the Lower Tester with ATT Error received */
-	if (err) {
-		rp->att_response = err;
+	SYS_LOG_DBG("status=%d", error->status);
+
+	if (error->status != 0 && error->status != BLE_HS_EDONE) {
+		rp->att_response = (uint8_t) BLE_HS_ATT_ERR(error->status);
+		tester_send(BTP_SERVICE_ID_GATT, GATT_READ_LONG,
+			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
+		read_destroy();
+		return 0;
 	}
 
-	/* read complete */
-	if (!data) {
-		tester_send(BTP_SERVICE_ID_GATT, btp_opcode, CONTROLLER_INDEX,
-			    gatt_buf.buf, gatt_buf.len);
-		read_destroy(params);
-		return BT_GATT_ITER_STOP;
+	if (error->status == BLE_HS_EDONE) {
+		tester_send(BTP_SERVICE_ID_GATT, GATT_READ_LONG,
+			    CONTROLLER_INDEX, gatt_buf.buf, gatt_buf.len);
+		read_destroy();
+		return 0;
 	}
 
-	if (!gatt_buf_add(data, length)) {
-		tester_rsp(BTP_SERVICE_ID_GATT, btp_opcode,
+	if (gatt_buf_add(attr->om->om_data, attr->om->om_len) == NULL) {
+		tester_rsp(BTP_SERVICE_ID_GATT, GATT_READ_LONG,
 			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
-		read_destroy(params);
-		return BT_GATT_ITER_STOP;
+		read_destroy();
+		return 0;
 	}
 
-	rp->data_length += length;
+	rp->data_length += attr->om->om_len;
 
-	return BT_GATT_ITER_CONTINUE;
+	return 0;
 }
 
 static void read(u8_t *data, u16_t len)
 {
 	const struct gatt_read_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
-		goto fail_conn;
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
+		goto fail;
 	}
 
 	if (!gatt_buf_reserve(sizeof(struct gatt_read_rp))) {
 		goto fail;
 	}
 
-	read_params.handle_count = 1;
-	read_params.single.handle = sys_le16_to_cpu(cmd->handle);
-	read_params.single.offset = 0x0000;
-	read_params.func = read_cb;
-
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = GATT_READ;
-
-	if (bt_gatt_read(conn, &read_params) < 0) {
-		read_destroy(&read_params);
-
+	if (ble_gattc_read(conn.conn_handle, sys_le16_to_cpu(cmd->handle),
+			   read_cb, (void *)GATT_READ)) {
+		discover_destroy();
 		goto fail;
 	}
 
-	bt_conn_unref(conn);
-
 	return;
-fail:
-	bt_conn_unref(conn);
 
-fail_conn:
+fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_READ, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
@@ -1373,38 +1378,31 @@ fail_conn:
 static void read_long(u8_t *data, u16_t len)
 {
 	const struct gatt_read_long_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
-		goto fail_conn;
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
+		goto fail;
 	}
 
 	if (!gatt_buf_reserve(sizeof(struct gatt_read_rp))) {
 		goto fail;
 	}
 
-	read_params.handle_count = 1;
-	read_params.single.handle = sys_le16_to_cpu(cmd->handle);
-	read_params.single.offset = sys_le16_to_cpu(cmd->offset);
-	read_params.func = read_cb;
-
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = GATT_READ_LONG;
-
-	if (bt_gatt_read(conn, &read_params) < 0) {
-		read_destroy(&read_params);
-
+	if (ble_gattc_read_long(conn.conn_handle,
+				sys_le16_to_cpu(cmd->handle),
+				sys_le16_to_cpu(cmd->offset),
+				read_long_cb, NULL)) {
+		discover_destroy();
 		goto fail;
 	}
 
-	bt_conn_unref(conn);
-
 	return;
-fail:
-	bt_conn_unref(conn);
 
-fail_conn:
+fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_READ_LONG, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
@@ -1413,41 +1411,34 @@ static void read_multiple(u8_t *data, u16_t len)
 {
 	const struct gatt_read_multiple_cmd *cmd = (void *) data;
 	u16_t handles[cmd->handles_count];
-	struct bt_conn *conn;
-	int i;
+	struct ble_gap_conn_desc conn;
+	int rc, i;
+
+	SYS_LOG_DBG("");
 
 	for (i = 0; i < ARRAY_SIZE(handles); i++) {
 		handles[i] = sys_le16_to_cpu(cmd->handles[i]);
 	}
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
-		goto fail_conn;
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
+		goto fail;
 	}
 
 	if (!gatt_buf_reserve(sizeof(struct gatt_read_rp))) {
 		goto fail;
 	}
 
-	read_params.func = read_cb;
-	read_params.handle_count = i;
-	read_params.handles = handles; /* not used in read func */
-
-	/* TODO should be handled as user_data via CONTAINER_OF macro */
-	btp_opcode = GATT_READ_MULTIPLE;
-
-	if (bt_gatt_read(conn, &read_params) < 0) {
-		gatt_buf_clear();
+	if (ble_gattc_read_mult(conn.conn_handle, handles,
+				cmd->handles_count, read_cb,
+				(void *)GATT_READ_MULTIPLE)) {
+		discover_destroy();
 		goto fail;
 	}
 
-	bt_conn_unref(conn);
-
 	return;
-fail:
-	bt_conn_unref(conn);
 
-fail_conn:
+fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_READ_MULTIPLE, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
@@ -1456,211 +1447,216 @@ static void write_without_rsp(u8_t *data, u16_t len, u8_t op,
 			      bool sign)
 {
 	const struct gatt_write_without_rsp_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
 	u8_t status = BTP_STATUS_SUCCESS;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
 		status = BTP_STATUS_FAILED;
 		goto rsp;
 	}
 
-	if (bt_gatt_write_without_response(conn, sys_le16_to_cpu(cmd->handle),
-					   cmd->data,
-					   sys_le16_to_cpu(cmd->data_length),
-					   sign) < 0) {
+	if (ble_gattc_write_no_rsp_flat(conn.conn_handle,
+					sys_le16_to_cpu(cmd->handle),
+					cmd->data,
+					sys_le16_to_cpu(cmd->data_length))) {
 		status = BTP_STATUS_FAILED;
 	}
 
-	bt_conn_unref(conn);
 rsp:
 	tester_rsp(BTP_SERVICE_ID_GATT, op, CONTROLLER_INDEX, status);
 }
 
-static void write_rsp(struct bt_conn *conn, u8_t err,
-		      struct bt_gatt_write_params *params)
+static int write_rsp(uint16_t conn_handle,
+		     const struct ble_gatt_error *error,
+		     struct ble_gatt_attr *attr,
+		     void *arg)
 {
-	tester_send(BTP_SERVICE_ID_GATT, GATT_WRITE, CONTROLLER_INDEX, &err,
-		    sizeof(err));
-}
+	uint8_t err = (uint8_t) error->status;
+	u8_t btp_opcode = (uint8_t) (int) arg;
 
-static struct bt_gatt_write_params write_params;
+	SYS_LOG_DBG("");
+
+	tester_send(BTP_SERVICE_ID_GATT, btp_opcode,
+		    CONTROLLER_INDEX, &err,
+		    sizeof(err));
+	return 0;
+}
 
 static void write(u8_t *data, u16_t len)
 {
 	const struct gatt_write_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
 		goto fail;
 	}
 
-	write_params.handle = sys_le16_to_cpu(cmd->handle);
-	write_params.func = write_rsp;
-	write_params.offset = 0;
-	write_params.data = cmd->data;
-	write_params.length = sys_le16_to_cpu(cmd->data_length);
-
-	if (bt_gatt_write(conn, &write_params) < 0) {
-		bt_conn_unref(conn);
+	if (ble_gattc_write_flat(conn.conn_handle, sys_le16_to_cpu(cmd->handle),
+				 cmd->data, sys_le16_to_cpu(cmd->data_length),
+				 write_rsp, (void *) GATT_WRITE)) {
 		goto fail;
 	}
-
-	bt_conn_unref(conn);
 
 	return;
+
 fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_WRITE, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
 
-static void write_long_rsp(struct bt_conn *conn, u8_t err,
-			   struct bt_gatt_write_params *params)
-{
-	tester_send(BTP_SERVICE_ID_GATT, GATT_WRITE_LONG, CONTROLLER_INDEX,
-		    &err, sizeof(err));
-}
-
 static void write_long(u8_t *data, u16_t len)
 {
 	const struct gatt_write_long_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
+	struct os_mbuf *om = NULL;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
 		goto fail;
 	}
 
-	write_params.handle = sys_le16_to_cpu(cmd->handle);
-	write_params.func = write_long_rsp;
-	write_params.offset = cmd->offset;
-	write_params.data = cmd->data;
-	write_params.length = sys_le16_to_cpu(cmd->data_length);
-
-	if (bt_gatt_write(conn, &write_params) < 0) {
-		bt_conn_unref(conn);
+	om = ble_hs_mbuf_from_flat(cmd->data, sys_le16_to_cpu(cmd->data_length));
+	/* This is required, because Nimble checks if
+	 * the data is longer than offset
+	 */
+	if (os_mbuf_extend(om, cmd->offset + 1) == NULL) {
 		goto fail;
 	}
 
-	bt_conn_unref(conn);
+	if (ble_gattc_write_long(conn.conn_handle, sys_le16_to_cpu(cmd->handle),
+				 sys_le16_to_cpu(cmd->offset), om, write_rsp,
+				 (void *) GATT_WRITE_LONG)) {
+		goto fail;
+	}
 
 	return;
+
 fail:
+	os_mbuf_free_chain(om);
+
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_WRITE_LONG, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
 }
 
-static struct bt_gatt_subscribe_params subscribe_params;
+static struct bt_gatt_subscribe_params {
+	u16_t ccc_handle;
+	u16_t value;
+	u16_t value_handle;
+} subscribe_params;
 
 /* ev header + default MTU_ATT-3 */
 static u8_t ev_buf[33];
 
-static u8_t notify_func(struct bt_conn *conn,
-			   struct bt_gatt_subscribe_params *params,
-			   const void *data, u16_t length)
+int tester_gatt_notify_rx_ev(u16_t conn_handle, u16_t attr_handle,
+			     u8_t indication, struct os_mbuf *om)
 {
 	struct gatt_notification_ev *ev = (void *) ev_buf;
-	const bt_addr_le_t *addr = bt_conn_get_dst(conn);
+	struct ble_gap_conn_desc conn;
+	const ble_addr_t *addr;
+	int rc;
 
-	if (!data) {
-		SYS_LOG_DBG("Unsubscribed");
-		memset(params, 0, sizeof(*params));
-		return BT_GATT_ITER_STOP;
+	SYS_LOG_DBG("");
+
+	if (!subscribe_params.ccc_handle) {
+		return 0;
 	}
 
-	ev->type = (u8_t) subscribe_params.value;
-	ev->handle = sys_cpu_to_le16(subscribe_params.value_handle);
-	ev->data_length = sys_cpu_to_le16(length);
-	memcpy(ev->data, data, length);
-	memcpy(ev->address, addr->a.val, sizeof(ev->address));
+	rc = ble_gap_conn_find(conn_handle, &conn);
+	if (rc) {
+		return -1;
+	}
+
+	addr = &conn.peer_ota_addr;
+
+	ev->type = (u8_t) (indication ? 0x02 : 0x01);
+	ev->handle = sys_cpu_to_le16(attr_handle);
+	ev->data_length = sys_cpu_to_le16(om->om_len);
+	memcpy(ev->data, om->om_data, om->om_len);
+	memcpy(ev->address, addr->val, sizeof(ev->address));
 	ev->address_type = addr->type;
 
 	tester_send(BTP_SERVICE_ID_GATT, GATT_EV_NOTIFICATION,
-		    CONTROLLER_INDEX, ev_buf, sizeof(*ev) + length);
+		    CONTROLLER_INDEX, ev_buf, sizeof(*ev) + om->om_len);
 
-	return BT_GATT_ITER_CONTINUE;
+	return 0;
+
 }
 
-static void discover_complete(struct bt_conn *conn,
-			      struct bt_gatt_discover_params *params)
+int tester_gatt_subscribe_ev(u16_t conn_handle, u16_t attr_handle, u8_t reason,
+			     u8_t prev_notify, u8_t cur_notify,
+			     u8_t prev_indicate, u8_t cur_indicate)
 {
-	u8_t op, status;
+	SYS_LOG_DBG("");
 
-	/* If no value handle it means that chrc has not been found */
-	if (!subscribe_params.value_handle) {
-		status = BTP_STATUS_FAILED;
-		goto fail;
+	if (cur_notify == 0 && cur_indicate == 0) {
+		SYS_LOG_INF("Unsubscribed");
+		memset(&subscribe_params, 0, sizeof(subscribe_params));
+		return 0;
 	}
 
-	if (bt_gatt_subscribe(conn, &subscribe_params) < 0) {
+	if (cur_notify) {
+		SYS_LOG_INF("Subscribed to notifications");
+	}
+
+	if (cur_indicate) {
+		SYS_LOG_INF("Subscribed to indications");
+	}
+
+	return 0;
+}
+
+static int enable_subscription(u16_t conn_handle, u16_t ccc_handle,
+			       u16_t value)
+{
+	u8_t op, status;
+	SYS_LOG_DBG("");
+
+	op = (uint8_t) (value == 0x0001 ? GATT_CFG_NOTIFY :
+			GATT_CFG_INDICATE);
+
+	if (ble_gattc_write_no_rsp_flat(conn_handle,
+					ccc_handle,
+					&value,
+					sizeof(value))) {
 		status = BTP_STATUS_FAILED;
-		goto fail;
+		goto rsp;
 	}
 
 	status = BTP_STATUS_SUCCESS;
-fail:
-	op = subscribe_params.value == BT_GATT_CCC_NOTIFY ? GATT_CFG_NOTIFY :
-							    GATT_CFG_INDICATE;
 
-	if (status == BTP_STATUS_FAILED) {
-		memset(&subscribe_params, 0, sizeof(subscribe_params));
-	}
+	subscribe_params.ccc_handle = value;
 
+rsp:
 	tester_rsp(BTP_SERVICE_ID_GATT, op, CONTROLLER_INDEX, status);
+	return 0;
 }
 
-static u8_t discover_func(struct bt_conn *conn,
-			     const struct bt_gatt_attr *attr,
-			     struct bt_gatt_discover_params *params)
+static int disable_subscription(u16_t conn_handle, u16_t ccc_handle)
 {
-	if (!attr) {
-		discover_complete(conn, params);
-		return BT_GATT_ITER_STOP;
-	}
+	u16_t value = 0x00;
 
-	/* Characteristic Value Handle is the next handle beyond declaration */
-	subscribe_params.value_handle = attr->handle + 1;
+	SYS_LOG_DBG("");
 
-	/*
-	 * Continue characteristic discovery to get last characteristic
-	 * preceding this CCC descriptor
-	 */
-	return BT_GATT_ITER_CONTINUE;
-}
-
-static int enable_subscription(struct bt_conn *conn, u16_t ccc_handle,
-			       u16_t value)
-{
-	/* Fail if there is another subscription enabled */
-	if (subscribe_params.ccc_handle) {
-		SYS_LOG_ERR("Another subscription already enabled");
-		return -EEXIST;
-	}
-
-	/* Discover Characteristic Value this CCC Descriptor refers to */
-	discover_params.start_handle = 0x0001;
-	discover_params.end_handle = ccc_handle;
-	discover_params.type = BT_GATT_DISCOVER_CHARACTERISTIC;
-	discover_params.func = discover_func;
-
-	subscribe_params.ccc_handle = ccc_handle;
-	subscribe_params.value = value;
-	subscribe_params.notify = notify_func;
-
-	return bt_gatt_discover(conn, &discover_params);
-}
-
-static int disable_subscription(struct bt_conn *conn, u16_t ccc_handle)
-{
 	/* Fail if CCC handle doesn't match */
 	if (ccc_handle != subscribe_params.ccc_handle) {
 		SYS_LOG_ERR("CCC handle doesn't match");
 		return -EINVAL;
 	}
 
-	if (bt_gatt_unsubscribe(conn, &subscribe_params) < 0) {
-		return -EBUSY;
+	if (ble_gattc_write_no_rsp_flat(conn_handle, ccc_handle,
+					&value, sizeof(value))) {
+		return -EINVAL;
 	}
 
 	subscribe_params.ccc_handle = 0;
@@ -1668,15 +1664,18 @@ static int disable_subscription(struct bt_conn *conn, u16_t ccc_handle)
 	return 0;
 }
 
-static void config_subscription(u8_t *data, u16_t len, u16_t op)
+static void config_subscription(u8_t *data, u16_t len, u8_t op)
 {
 	const struct gatt_cfg_notify_cmd *cmd = (void *) data;
-	struct bt_conn *conn;
+	struct ble_gap_conn_desc conn;
 	u16_t ccc_handle = sys_le16_to_cpu(cmd->ccc_handle);
 	u8_t status;
+	int rc;
 
-	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
-	if (!conn) {
+	SYS_LOG_DBG("");
+
+	rc = ble_gap_conn_find_by_addr((ble_addr_t *)data, &conn);
+	if (rc) {
 		tester_rsp(BTP_SERVICE_ID_GATT, op, CONTROLLER_INDEX,
 			   BTP_STATUS_FAILED);
 		return;
@@ -1686,20 +1685,20 @@ static void config_subscription(u8_t *data, u16_t len, u16_t op)
 		u16_t value;
 
 		if (op == GATT_CFG_NOTIFY) {
-			value = BT_GATT_CCC_NOTIFY;
+			value = 0x0001;
 		} else {
-			value = BT_GATT_CCC_INDICATE;
+			value = 0x0002;
 		}
 
 		/* on success response will be sent from callback */
-		if (enable_subscription(conn, ccc_handle, value) == 0) {
-			bt_conn_unref(conn);
+		if (enable_subscription(conn.conn_handle,
+					ccc_handle, value) == 0) {
 			return;
 		}
 
 		status = BTP_STATUS_FAILED;
 	} else {
-		if (disable_subscription(conn, ccc_handle) < 0) {
+		if (disable_subscription(conn.conn_handle, ccc_handle) < 0) {
 			status = BTP_STATUS_FAILED;
 		} else {
 			status = BTP_STATUS_SUCCESS;
@@ -1708,150 +1707,361 @@ static void config_subscription(u8_t *data, u16_t len, u16_t op)
 
 	SYS_LOG_DBG("Config subscription (op %u) status %u", op, status);
 
-	bt_conn_unref(conn);
 	tester_rsp(BTP_SERVICE_ID_GATT, op, CONTROLLER_INDEX, status);
 }
 
 struct get_attrs_foreach_data {
-	struct net_buf_simple *buf;
-	struct bt_uuid *uuid;
+	ble_uuid_any_t *uuid;
+	u16_t start_handle, end_handle;
+	struct os_mbuf *buf;
 	u8_t count;
 };
 
-static u8_t get_attrs_rp(const struct bt_gatt_attr *attr, void *user_data)
+static u8_t foreach_get_attrs(u16_t handle,
+			      u8_t permission,
+			      const ble_uuid_t *uuid,
+			      struct get_attrs_foreach_data *foreach)
 {
-	struct get_attrs_foreach_data *foreach = user_data;
 	struct gatt_attr *gatt_attr;
+	char uuid_buf[BLE_UUID_STR_LEN];
 
-	if (foreach->uuid && bt_uuid_cmp(foreach->uuid, attr->uuid)) {
-
-		return BT_GATT_ITER_CONTINUE;
+	if (handle < foreach->start_handle && handle > foreach->end_handle) {
+		return 0;
 	}
 
-	gatt_attr = net_buf_simple_add(foreach->buf, sizeof(*gatt_attr));
-	gatt_attr->handle = sys_cpu_to_le16(attr->handle);
-	gatt_attr->permission = attr->perm;
+	if (foreach->uuid && ble_uuid_cmp(&foreach->uuid->u, uuid)) {
+		return 0;
+	}
 
-	if (attr->uuid->type == BT_UUID_TYPE_16) {
+	SYS_LOG_DBG("hdl 0x%04x perm 0x%02x uuid %s", handle, permission,
+		    ble_uuid_to_str(uuid, uuid_buf));
+
+	gatt_attr = net_buf_simple_add(foreach->buf, sizeof(*gatt_attr));
+	gatt_attr->handle = sys_cpu_to_le16(handle);
+	gatt_attr->permission = permission;
+
+	if (uuid->type == BLE_UUID_TYPE_16) {
 		gatt_attr->type_length = 2;
 		net_buf_simple_add_le16(foreach->buf,
-					BT_UUID_16(attr->uuid)->val);
+					BLE_UUID16(uuid)->value);
 	} else {
 		gatt_attr->type_length = 16;
 		net_buf_simple_add_mem(foreach->buf,
-				       BT_UUID_128(attr->uuid)->val,
+				       BLE_UUID128(uuid)->value,
 				       gatt_attr->type_length);
 	}
 
 	foreach->count++;
 
-	return BT_GATT_ITER_CONTINUE;
+	return 0;
+}
+
+static u8_t flags2perm(u16_t flags, bool chr)
+{
+	u8_t permission = 0;
+	int *flag_arr;
+	int flag_arr_len;
+	int i;
+
+	if (chr) {
+		flag_arr = gatt_chr_perm_map;
+		flag_arr_len = ARRAY_SIZE(gatt_chr_perm_map);
+
+		/* FIXME: Handle WRITE_NO_RSP */
+		if (flags & BLE_GATT_CHR_F_WRITE_NO_RSP) {
+			permission |= BIT(1);
+		}
+	} else {
+		flag_arr = gatt_dsc_perm_map;
+		flag_arr_len = ARRAY_SIZE(gatt_dsc_perm_map);
+	}
+
+	for (i = 0; i < flag_arr_len; ++i) {
+		if (flags & flag_arr[i]) {
+			permission |= BIT(i);
+		}
+	}
+
+	return permission;
+}
+
+static void get_attrs_cb(const struct ble_gatt_svc_def *svc,
+			 uint16_t handle, uint16_t end_group_handle,
+			 void *arg)
+{
+	struct get_attrs_foreach_data *foreach = arg;
+	const struct ble_gatt_chr_def *chr;
+	const struct ble_gatt_dsc_def *dsc;
+
+	SYS_LOG_DBG("");
+
+	if (svc->type == BLE_GATT_SVC_TYPE_PRIMARY) {
+		foreach_get_attrs(handle, BTP_GATT_PERM_READ,
+				  uuid_pri, foreach);
+	} else if (svc->type == BLE_GATT_SVC_TYPE_SECONDARY) {
+		foreach_get_attrs(handle, BTP_GATT_PERM_READ,
+				  uuid_sec, foreach);
+	}
+
+	/* TODO: iterate over included services*/
+
+	for (chr = svc->characteristics; chr && chr->uuid; ++chr) {
+		handle += 1;
+		foreach_get_attrs(handle, BTP_GATT_PERM_READ,
+				  uuid_chr, foreach);
+		handle += 1;
+		foreach_get_attrs(handle, flags2perm(chr->flags, true),
+				  chr->uuid, foreach);
+
+		if ((chr->flags & BLE_GATT_CHR_F_NOTIFY) ||
+		    (chr->flags & BLE_GATT_CHR_F_INDICATE)) {
+			handle += 1;
+
+			foreach_get_attrs(handle,
+					  flags2perm(BLE_ATT_F_READ |
+						     BLE_ATT_F_WRITE,
+						     false), uuid_ccc, foreach);
+		}
+
+		for (dsc = chr->descriptors; dsc && dsc->uuid; ++dsc) {
+			handle += 1;
+			foreach_get_attrs(handle, flags2perm(chr->flags, false),
+					  dsc->uuid, foreach);
+		}
+	}
 }
 
 static void get_attrs(u8_t *data, u16_t len)
 {
 	const struct gatt_get_attributes_cmd *cmd = (void *) data;
 	struct gatt_get_attributes_rp *rp;
-	struct net_buf_simple *buf = NET_BUF_SIMPLE(BTP_DATA_MAX_SIZE);
+	struct os_mbuf *buf = os_msys_get(0, 0);
 	struct get_attrs_foreach_data foreach;
 	u16_t start_handle, end_handle;
-	union uuid uuid;
+	ble_uuid_any_t uuid;
+	char str[BLE_UUID_STR_LEN];
 
+	SYS_LOG_DBG("");
+
+	memset(str, 0, sizeof(str));
+	memset(&uuid, 0, sizeof(uuid));
 	start_handle = sys_le16_to_cpu(cmd->start_handle);
 	end_handle = sys_le16_to_cpu(cmd->end_handle);
 
 	if (cmd->type_length) {
-		if (btp2bt_uuid(cmd->type, cmd->type_length, &uuid.uuid)) {
+		if (btp2bt_uuid(cmd->type, cmd->type_length, &uuid)) {
 			goto fail;
 		}
 
+		ble_uuid_to_str(&uuid.u, str);
 		SYS_LOG_DBG("start 0x%04x end 0x%04x, uuid %s", start_handle,
-			    end_handle, bt_uuid_str(&uuid.uuid));
+			    end_handle, str);
 
-		foreach.uuid = &uuid.uuid;
+		foreach.uuid = &uuid;
 	} else {
 		SYS_LOG_DBG("start 0x%04x end 0x%04x", start_handle, end_handle);
-
 		foreach.uuid = NULL;
 	}
 
 	net_buf_simple_init(buf, sizeof(*rp));
 
+	foreach.start_handle = start_handle;
+	foreach.end_handle = end_handle;
 	foreach.buf = buf;
 	foreach.count = 0;
 
-	bt_gatt_foreach_attr(start_handle, end_handle, get_attrs_rp, &foreach);
+	ble_gatts_lcl_svc_foreach(get_attrs_cb, &foreach);
 
-	rp = net_buf_simple_push(buf, sizeof(*rp));
+	rp = (void *) net_buf_simple_push(buf, sizeof(*rp));
 	rp->attrs_count = foreach.count;
 
 	tester_send(BTP_SERVICE_ID_GATT, GATT_GET_ATTRIBUTES, CONTROLLER_INDEX,
-		    buf->data, buf->len);
+		    buf->om_data, buf->om_len);
 
-	return;
+	goto free;
 fail:
 	tester_rsp(BTP_SERVICE_ID_GATT, GATT_GET_ATTRIBUTES, CONTROLLER_INDEX,
 		   BTP_STATUS_FAILED);
+free:
+	os_mbuf_free_chain(buf);
 }
 
-static u8_t err_to_att(int err)
+static int access_svc(uint16_t conn_handle, uint16_t attr_handle,
+		      struct ble_gatt_access_ctxt *ctxt, void *arg)
 {
-	if (err < 0 && err >= -0xff) {
-		return -err;
+	const struct ble_gatt_svc_def *svc = arg;
+
+	if (svc->uuid->type == BLE_UUID_TYPE_16) {
+		net_buf_simple_add_le16(ctxt->om,
+					BLE_UUID16(svc->uuid)->value);
+	} else {
+		os_mbuf_append(ctxt->om,
+			       BLE_UUID128(svc->uuid)->value,
+			       16);
 	}
 
-	return BT_ATT_ERR_UNLIKELY;
+	return 0;
 }
 
-static u8_t get_attr_val_rp(const struct bt_gatt_attr *attr, void *user_data)
+static int access_chr(uint16_t conn_handle, uint16_t attr_handle,
+		      struct ble_gatt_access_ctxt *ctxt, void *arg)
 {
-	struct net_buf_simple *buf = user_data;
+	const struct ble_gatt_chr_def *chr = arg;
+
+	net_buf_simple_add_u8(ctxt->om, flags2perm(chr->flags, true));
+	net_buf_simple_add_le16(ctxt->om, *chr->val_handle);
+
+	if (chr->uuid->type == BLE_UUID_TYPE_16) {
+		net_buf_simple_add_le16(ctxt->om,
+					BLE_UUID16(chr->uuid)->value);
+	} else {
+		os_mbuf_append(ctxt->om,
+			       BLE_UUID128(chr->uuid)->value,
+			       16);
+	}
+
+	return 0;
+}
+
+static int access_cccd(uint16_t conn_handle, uint16_t attr_handle,
+		       struct ble_gatt_access_ctxt *ctxt, void *arg)
+{
+	return ble_gatts_clt_cfg_access(conn_handle, attr_handle,
+					ctxt->op, 0, &ctxt->om, arg);
+}
+
+static int foreach_get_attr_val(u16_t handle,
+				ble_gatt_access_fn access_cb,
+				void *arg,
+				struct ble_gatt_access_ctxt *ctxt,
+				u16_t rx_handle)
+
+{
 	struct gatt_get_attribute_value_rp *rp;
-	ssize_t read, to_read;
+	uint16_t hdr_len;
+	int rc;
 
-	rp = net_buf_simple_add(buf, sizeof(*rp));
-	rp->value_length = 0x0000;
-	rp->att_response = 0x00;
+	if (handle != rx_handle) {
+		return 0;
+	}
 
-	do {
-		to_read = net_buf_simple_tailroom(buf);
+	SYS_LOG_DBG("handle=%d", handle);
 
-		read = attr->read(NULL, attr, buf->data + buf->len, to_read,
-				  rp->value_length);
-		if (read < 0) {
-			rp->att_response = err_to_att(read);
-			break;
+	rp = net_buf_simple_add(ctxt->om, sizeof(*rp));
+
+	SYS_LOG_DBG("len=%d", ctxt->om->om_len);
+	hdr_len = ctxt->om->om_len;
+
+	rc = access_cb(1, handle, ctxt, arg);
+
+	rp->att_response = (uint8_t) rc;
+	SYS_LOG_DBG("len=%d", ctxt->om->om_len);
+	rp->value_length = ctxt->om->om_len - hdr_len;
+
+	return BLE_HS_EDONE;
+}
+
+static void get_attr_val_cb(const struct ble_gatt_svc_def *svc,
+			    uint16_t handle, uint16_t end_group_handle,
+			    void *arg)
+{
+	struct get_attrs_foreach_data *foreach = arg;
+	struct os_mbuf *buf = foreach->buf;
+	struct ble_gatt_access_ctxt ctxt;
+	const struct ble_gatt_chr_def *chr;
+	const struct ble_gatt_dsc_def *dsc;
+	int rc;
+
+	SYS_LOG_DBG("");
+
+	ctxt.om = buf;
+
+	rc = foreach_get_attr_val(handle, access_svc, (void *) svc,
+				  &ctxt, foreach->start_handle);
+	if (rc == BLE_HS_EDONE) {
+		return;
+	}
+
+	/* TODO: iterate over included services*/
+
+	for (chr = svc->characteristics; chr && chr->uuid; ++chr) {
+		handle += 1;
+		rc = foreach_get_attr_val(handle, access_chr, (void *) chr,
+					  &ctxt, foreach->start_handle);
+		if (rc == BLE_HS_EDONE) {
+			return;
 		}
 
-		rp->value_length += read;
+		handle += 1;
+		ctxt.op = BLE_GATT_ACCESS_OP_READ_CHR;
+		ctxt.chr = chr;
 
-		net_buf_simple_add(buf, read);
-	} while (read == to_read);
+		rc = foreach_get_attr_val(handle,
+					  chr->access_cb, chr->arg,
+					  &ctxt, foreach->start_handle);
+		if (rc == BLE_HS_EDONE) {
+			return;
+		}
 
-	return BT_GATT_ITER_STOP;
+		if ((chr->flags & BLE_GATT_CHR_F_NOTIFY) ||
+		    (chr->flags & BLE_GATT_CHR_F_INDICATE)) {
+			handle += 1;
+			ctxt.op = BLE_GATT_ACCESS_OP_READ_CHR;
+
+			rc = foreach_get_attr_val(handle,
+						  access_cccd, NULL,
+						  &ctxt, foreach->start_handle);
+			if (rc == BLE_HS_EDONE) {
+				return;
+			}
+		}
+
+		for (dsc = chr->descriptors; dsc && dsc->uuid; ++dsc) {
+			handle += 1;
+
+			ctxt.op = BLE_GATT_ACCESS_OP_READ_DSC;
+			ctxt.dsc = dsc;
+
+			rc = foreach_get_attr_val(handle,
+						  dsc->access_cb, dsc->arg,
+						  &ctxt, foreach->start_handle);
+			if (rc == BLE_HS_EDONE) {
+				return;
+			}
+		}
+	}
 }
 
 static void get_attr_val(u8_t *data, u16_t len)
 {
 	const struct gatt_get_attribute_value_cmd *cmd = (void *) data;
-	struct net_buf_simple *buf = NET_BUF_SIMPLE(BTP_DATA_MAX_SIZE);
-	u16_t handle = sys_le16_to_cpu(cmd->handle);
+	struct os_mbuf *buf = os_msys_get(0, 0);
+	struct get_attrs_foreach_data foreach;
+	u16_t handle = sys_cpu_to_le16(cmd->handle);
 
+	SYS_LOG_DBG("handle=%d", handle);
+
+	memset(&foreach, 0, sizeof(foreach));
 	net_buf_simple_init(buf, 0);
 
-	bt_gatt_foreach_attr(handle, handle, get_attr_val_rp, buf);
+	foreach.buf = buf;
+	foreach.start_handle = handle;
 
-	if (buf->len) {
+	ble_gatts_lcl_svc_foreach(get_attr_val_cb, &foreach);
+
+	if (buf->om_len) {
 		tester_send(BTP_SERVICE_ID_GATT, GATT_GET_ATTRIBUTE_VALUE,
-			    CONTROLLER_INDEX, buf->data, buf->len);
+			    CONTROLLER_INDEX, buf->om_data, buf->om_len);
 	} else {
 		tester_rsp(BTP_SERVICE_ID_GATT, GATT_GET_ATTRIBUTE_VALUE,
 			   CONTROLLER_INDEX, BTP_STATUS_FAILED);
 	}
+
+	os_mbuf_free_chain(buf);
 }
 
 void tester_handle_gatt(u8_t opcode, u8_t index, u8_t *data,
-			 u16_t len)
+			u16_t len)
 {
 	switch (opcode) {
 	case GATT_READ_SUPPORTED_COMMANDS:
@@ -1908,9 +2118,11 @@ void tester_handle_gatt(u8_t opcode, u8_t index, u8_t *data,
 	case GATT_WRITE_WITHOUT_RSP:
 		write_without_rsp(data, len, opcode, false);
 		return;
+#if 0
 	case GATT_SIGNED_WRITE_WITHOUT_RSP:
 		write_without_rsp(data, len, opcode, true);
 		return;
+#endif
 	case GATT_WRITE:
 		write(data, len);
 		return;
@@ -1934,15 +2146,68 @@ void tester_handle_gatt(u8_t opcode, u8_t index, u8_t *data,
 	}
 }
 
-u8_t tester_init_gatt(void)
+void gatt_svr_register_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
 {
-	server_buf = net_buf_alloc(&server_pool, K_NO_WAIT);
-	if (!server_buf) {
-		return BTP_STATUS_FAILED;
+	char buf[BLE_UUID_STR_LEN];
+
+	switch (ctxt->op) {
+		case BLE_GATT_REGISTER_OP_SVC:
+		MODLOG_DFLT(DEBUG, "registered service %s with handle=%d\n",
+			    ble_uuid_to_str(ctxt->svc.svc_def->uuid, buf),
+			    ctxt->svc.handle);
+			break;
+
+		case BLE_GATT_REGISTER_OP_CHR:
+		MODLOG_DFLT(DEBUG, "registering characteristic %s with "
+				   "def_handle=%d val_handle=%d\n",
+			    ble_uuid_to_str(ctxt->chr.chr_def->uuid, buf),
+			    ctxt->chr.def_handle,
+			    ctxt->chr.val_handle);
+			break;
+
+		case BLE_GATT_REGISTER_OP_DSC:
+		MODLOG_DFLT(DEBUG, "registering descriptor %s with handle=%d\n",
+			    ble_uuid_to_str(ctxt->dsc.dsc_def->uuid, buf),
+			    ctxt->dsc.handle);
+			break;
+
+		default:
+			assert(0);
+			break;
+	}
+}
+
+int gatt_svr_init(void)
+{
+	int rc;
+
+	rc = ble_gatts_count_cfg(gatt_svr_svcs);
+	if (rc != 0) {
+		return rc;
 	}
 
-	net_buf_reserve(server_buf, SERVER_BUF_SIZE);
+	rc = ble_gatts_add_svcs(gatt_svr_svcs);
+	if (rc != 0) {
+		return rc;
+	}
 
+	rc = ble_gatts_count_cfg(gatt_svr_inc_svcs);
+	if (rc != 0) {
+		return rc;
+	}
+
+	rc = ble_gatts_add_svcs(gatt_svr_inc_svcs);
+	if (rc != 0) {
+		return rc;
+	}
+
+	init_gatt_values();
+
+	return 0;
+}
+
+u8_t tester_init_gatt(void)
+{
 	return BTP_STATUS_SUCCESS;
 }
 

--- a/apps/bttester/src/glue.c
+++ b/apps/bttester/src/glue.c
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "syscfg/syscfg.h"
+
+#if !MYNEWT_VAL(BLE_MESH)
+#include <assert.h>
+#include <string.h>
+#include "os/os.h"
+#include "os/os_mbuf.h"
+#include "glue.h"
+
+
+#define ASSERT_NOT_CHAIN(om) assert(SLIST_NEXT(om, om_next) == NULL)
+
+const char *bt_hex(const void *buf, size_t len)
+{
+	static const char hex[] = "0123456789abcdef";
+	static char hexbufs[4][137];
+	static u8_t curbuf;
+	const u8_t *b = buf;
+	char *str;
+	int i;
+
+	str = hexbufs[curbuf++];
+	curbuf %= ARRAY_SIZE(hexbufs);
+
+	len = min(len, (sizeof(hexbufs[0]) - 1) / 2);
+
+	for (i = 0; i < len; i++) {
+		str[i * 2] = hex[b[i] >> 4];
+		str[i * 2 + 1] = hex[b[i] & 0xf];
+	}
+
+	str[i * 2] = '\0';
+
+	return str;
+}
+
+struct os_mbuf * NET_BUF_SIMPLE(uint16_t size)
+{
+	struct os_mbuf *buf;
+
+	buf = os_msys_get(size, 0);
+	assert(buf);
+
+	return buf;
+}
+
+/* This is by purpose */
+void net_buf_simple_init(struct os_mbuf *buf,
+			 size_t reserve_head)
+{
+	/* This is called in Zephyr after init.
+	 * Note in Mynewt case we don't care abour reserved head*/
+	buf->om_data = &buf->om_databuf[buf->om_pkthdr_len] + reserve_head;
+	buf->om_len = 0;
+}
+
+void
+net_buf_simple_add_le16(struct os_mbuf *om, uint16_t val)
+{
+	val = htole16(val);
+	os_mbuf_append(om, &val, sizeof(val));
+	ASSERT_NOT_CHAIN(om);
+}
+
+void
+net_buf_simple_add_be16(struct os_mbuf *om, uint16_t val)
+{
+	val = htobe16(val);
+	os_mbuf_append(om, &val, sizeof(val));
+	ASSERT_NOT_CHAIN(om);
+}
+
+void
+net_buf_simple_add_be32(struct os_mbuf *om, uint32_t val)
+{
+	val = htobe32(val);
+	os_mbuf_append(om, &val, sizeof(val));
+	ASSERT_NOT_CHAIN(om);
+}
+
+void
+net_buf_simple_add_u8(struct os_mbuf *om, uint8_t val)
+{
+	os_mbuf_append(om, &val, 1);
+	ASSERT_NOT_CHAIN(om);
+}
+
+void*
+net_buf_simple_add(struct os_mbuf *om, uint8_t len)
+{
+	void * tmp;
+
+	tmp = os_mbuf_extend(om, len);
+	ASSERT_NOT_CHAIN(om);
+
+	return tmp;
+}
+
+uint8_t *
+net_buf_simple_push(struct os_mbuf *om, uint8_t len)
+{
+	uint8_t headroom = om->om_data - &om->om_databuf[om->om_pkthdr_len];
+
+	assert(headroom >= len);
+	om->om_data -= len;
+	om->om_len += len;
+
+	return om->om_data;
+}
+#endif

--- a/apps/bttester/src/glue.h
+++ b/apps/bttester/src/glue.h
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __GLUE_H__
+#define __GLUE_H__
+
+#include "os/endian.h"
+
+#define u8_t    uint8_t
+#define s8_t    int8_t
+#define u16_t   uint16_t
+#define u32_t   uint32_t
+#define s32_t   int32_t
+
+#ifndef BIT
+#define BIT(n)  (1UL << (n))
+#endif
+
+#define __packed    __attribute__((__packed__))
+
+#define sys_le16_to_cpu le16toh
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+struct bt_data {
+    u8_t type;
+    u8_t data_len;
+    const u8_t *data;
+};
+
+#define BT_DATA(_type, _data, _data_len) \
+    { \
+        .type = (_type), \
+        .data_len = (_data_len), \
+        .data = (const u8_t *)(_data), \
+    }
+
+struct os_mbuf * NET_BUF_SIMPLE(uint16_t size);
+void net_buf_simple_init(struct os_mbuf *buf, size_t reserve_head);
+void net_buf_simple_add_le16(struct os_mbuf *om, uint16_t val);
+void net_buf_simple_add_u8(struct os_mbuf *om, uint8_t val);
+void *net_buf_simple_add(struct os_mbuf *om, uint8_t len);
+uint8_t *net_buf_simple_push(struct os_mbuf *om, uint8_t len);
+
+#define net_buf_simple_add_mem(a,b,c) os_mbuf_append(a,b,c)
+
+const char *bt_hex(const void *buf, size_t len);
+
+#endif /* __GLUE_H__ */

--- a/apps/bttester/src/l2cap.c
+++ b/apps/bttester/src/l2cap.c
@@ -1,0 +1,357 @@
+/* l2cap.c - Bluetooth L2CAP Tester */
+
+/*
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <bluetooth/bluetooth.h>
+
+#include <errno.h>
+#include <bluetooth/l2cap.h>
+#include <misc/byteorder.h>
+#include "bttester.h"
+
+#define CONTROLLER_INDEX 0
+#define DATA_MTU 230
+#define CHANNELS 2
+#define SERVERS 1
+
+NET_BUF_POOL_DEFINE(data_pool, 1, DATA_MTU, BT_BUF_USER_DATA_MIN, NULL);
+
+static struct channel {
+	u8_t chan_id; /* Internal number that identifies L2CAP channel. */
+	struct bt_l2cap_le_chan le;
+} channels[CHANNELS];
+
+/* TODO Extend to support multiple servers */
+static struct bt_l2cap_server servers[SERVERS];
+
+static struct net_buf *alloc_buf_cb(struct bt_l2cap_chan *chan)
+{
+	return net_buf_alloc(&data_pool, K_FOREVER);
+}
+
+static u8_t recv_cb_buf[DATA_MTU + sizeof(struct l2cap_data_received_ev)];
+
+static void recv_cb(struct bt_l2cap_chan *l2cap_chan, struct net_buf *buf)
+{
+	struct l2cap_data_received_ev *ev = (void *) recv_cb_buf;
+	struct channel *chan = CONTAINER_OF(l2cap_chan, struct channel, le);
+
+	ev->chan_id = chan->chan_id;
+	ev->data_length = sys_cpu_to_le16(buf->len);
+	memcpy(ev->data, buf->data, buf->len);
+
+	tester_send(BTP_SERVICE_ID_L2CAP, L2CAP_EV_DATA_RECEIVED,
+		    CONTROLLER_INDEX, recv_cb_buf, sizeof(*ev) + buf->len);
+}
+
+static void connected_cb(struct bt_l2cap_chan *l2cap_chan)
+{
+	struct l2cap_connected_ev ev;
+	struct channel *chan = CONTAINER_OF(l2cap_chan, struct channel, le);
+	struct bt_conn_info info;
+
+	ev.chan_id = chan->chan_id;
+	/* TODO: ev.psm */
+	if (!bt_conn_get_info(l2cap_chan->conn, &info)) {
+		switch (info.type) {
+		case BT_CONN_TYPE_LE:
+			ev.address_type = info.le.dst->type;
+			memcpy(ev.address, info.le.dst->a.val,
+			       sizeof(ev.address));
+			break;
+		case BT_CONN_TYPE_BR:
+			memcpy(ev.address, info.br.dst->val,
+			       sizeof(ev.address));
+			break;
+		}
+	}
+
+	tester_send(BTP_SERVICE_ID_L2CAP, L2CAP_EV_CONNECTED, CONTROLLER_INDEX,
+		    (u8_t *) &ev, sizeof(ev));
+}
+
+static void disconnected_cb(struct bt_l2cap_chan *l2cap_chan)
+{
+	struct l2cap_disconnected_ev ev;
+	struct channel *chan = CONTAINER_OF(l2cap_chan, struct channel, le);
+	struct bt_conn_info info;
+
+	memset(&ev, 0, sizeof(struct l2cap_disconnected_ev));
+
+	/* TODO: ev.result */
+	ev.chan_id = chan->chan_id;
+	/* TODO: ev.psm */
+	if (!bt_conn_get_info(l2cap_chan->conn, &info)) {
+		switch (info.type) {
+		case BT_CONN_TYPE_LE:
+			ev.address_type = info.le.dst->type;
+			memcpy(ev.address, info.le.dst->a.val,
+			       sizeof(ev.address));
+			break;
+		case BT_CONN_TYPE_BR:
+			memcpy(ev.address, info.br.dst->val,
+			       sizeof(ev.address));
+			break;
+		}
+	}
+
+	tester_send(BTP_SERVICE_ID_L2CAP, L2CAP_EV_DISCONNECTED,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static struct bt_l2cap_chan_ops l2cap_ops = {
+	.alloc_buf	= alloc_buf_cb,
+	.recv		= recv_cb,
+	.connected	= connected_cb,
+	.disconnected	= disconnected_cb,
+};
+
+static struct channel *get_free_channel()
+{
+	u8_t i;
+	struct channel *chan;
+
+	for (i = 0; i < CHANNELS; i++) {
+		if (channels[i].le.chan.state != BT_L2CAP_DISCONNECTED) {
+			continue;
+		}
+
+		chan = &channels[i];
+		chan->chan_id = i;
+
+		return chan;
+	}
+
+	return NULL;
+}
+
+static void connect(u8_t *data, u16_t len)
+{
+	const struct l2cap_connect_cmd *cmd = (void *) data;
+	struct l2cap_connect_rp rp;
+	struct bt_conn *conn;
+	struct channel *chan;
+	int err;
+
+	conn = bt_conn_lookup_addr_le(BT_ID_DEFAULT, (bt_addr_le_t *)data);
+	if (!conn) {
+		goto fail;
+	}
+
+	chan = get_free_channel();
+	if (!chan) {
+		goto fail;
+	}
+
+	chan->le.chan.ops = &l2cap_ops;
+	chan->le.rx.mtu = DATA_MTU;
+
+	err = bt_l2cap_chan_connect(conn, &chan->le.chan, cmd->psm);
+	if (err < 0) {
+		goto fail;
+	}
+
+	rp.chan_id = chan->chan_id;
+
+	tester_send(BTP_SERVICE_ID_L2CAP, L2CAP_CONNECT, CONTROLLER_INDEX,
+		    (u8_t *) &rp, sizeof(rp));
+
+	return;
+
+fail:
+	tester_rsp(BTP_SERVICE_ID_L2CAP, L2CAP_CONNECT, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static void disconnect(u8_t *data, u16_t len)
+{
+	const struct l2cap_disconnect_cmd *cmd = (void *) data;
+	struct channel *chan = &channels[cmd->chan_id];
+	u8_t status;
+	int err;
+
+	err = bt_l2cap_chan_disconnect(&chan->le.chan);
+	if (err) {
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
+	status = BTP_STATUS_SUCCESS;
+
+rsp:
+	tester_rsp(BTP_SERVICE_ID_L2CAP, L2CAP_DISCONNECT, CONTROLLER_INDEX,
+		   status);
+}
+
+static void send_data(u8_t *data, u16_t len)
+{
+	const struct l2cap_send_data_cmd *cmd = (void *) data;
+	struct channel *chan = &channels[cmd->chan_id];
+	struct net_buf *buf;
+	int ret;
+	u16_t data_len = sys_le16_to_cpu(cmd->data_len);
+
+	/* FIXME: For now, fail if data length exceeds buffer length */
+	if (data_len > DATA_MTU - BT_L2CAP_CHAN_SEND_RESERVE) {
+		goto fail;
+	}
+
+	/* FIXME: For now, fail if data length exceeds remote's L2CAP SDU */
+	if (data_len > chan->le.tx.mtu) {
+		goto fail;
+	}
+
+	buf = net_buf_alloc(&data_pool, K_FOREVER);
+	net_buf_reserve(buf, BT_L2CAP_CHAN_SEND_RESERVE);
+
+	net_buf_add_mem(buf, cmd->data, data_len);
+	ret = bt_l2cap_chan_send(&chan->le.chan, buf);
+	if (ret < 0) {
+		SYS_LOG_ERR("Unable to send data: %d", -ret);
+		net_buf_unref(buf);
+		goto fail;
+	}
+
+	tester_rsp(BTP_SERVICE_ID_L2CAP, L2CAP_SEND_DATA, CONTROLLER_INDEX,
+			BTP_STATUS_SUCCESS);
+	return;
+
+fail:
+	tester_rsp(BTP_SERVICE_ID_L2CAP, L2CAP_SEND_DATA, CONTROLLER_INDEX,
+			BTP_STATUS_FAILED);
+}
+
+static struct bt_l2cap_server *get_free_server(void)
+{
+	u8_t i;
+
+	for (i = 0; i < SERVERS ; i++) {
+		if (servers[i].psm) {
+			continue;
+		}
+
+		return &servers[i];
+	}
+
+	return NULL;
+}
+
+static bool is_free_psm(u16_t psm)
+{
+	u8_t i;
+
+	for (i = 0; i < ARRAY_SIZE(servers); i++) {
+		if (servers[i].psm == psm) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static int accept(struct bt_conn *conn, struct bt_l2cap_chan **l2cap_chan)
+{
+	struct channel *chan;
+
+	chan = get_free_channel();
+	if (!chan) {
+		return -ENOMEM;
+	}
+
+	chan->le.chan.ops = &l2cap_ops;
+	chan->le.rx.mtu = DATA_MTU;
+
+	*l2cap_chan = &chan->le.chan;
+
+	return 0;
+}
+
+static void listen(u8_t *data, u16_t len)
+{
+	const struct l2cap_listen_cmd *cmd = (void *) data;
+	struct bt_l2cap_server *server;
+
+	/* TODO: Handle cmd->transport flag */
+
+	if (!is_free_psm(cmd->psm)) {
+		goto fail;
+	}
+
+	server = get_free_server();
+	if (!server) {
+		goto fail;
+	}
+
+	server->accept = accept;
+	server->psm = cmd->psm;
+
+	if (bt_l2cap_server_register(server) < 0) {
+		server->psm = 0;
+		goto fail;
+	}
+
+	tester_rsp(BTP_SERVICE_ID_L2CAP, L2CAP_LISTEN, CONTROLLER_INDEX,
+		   BTP_STATUS_SUCCESS);
+	return;
+
+fail:
+	tester_rsp(BTP_SERVICE_ID_L2CAP, L2CAP_LISTEN, CONTROLLER_INDEX,
+		   BTP_STATUS_FAILED);
+}
+
+static void supported_commands(u8_t *data, u16_t len)
+{
+	u8_t cmds[1];
+	struct l2cap_read_supported_commands_rp *rp = (void *) cmds;
+
+	memset(cmds, 0, sizeof(cmds));
+
+	tester_set_bit(cmds, L2CAP_READ_SUPPORTED_COMMANDS);
+	tester_set_bit(cmds, L2CAP_CONNECT);
+	tester_set_bit(cmds, L2CAP_DISCONNECT);
+	tester_set_bit(cmds, L2CAP_LISTEN);
+	tester_set_bit(cmds, L2CAP_SEND_DATA);
+
+	tester_send(BTP_SERVICE_ID_L2CAP, L2CAP_READ_SUPPORTED_COMMANDS,
+		    CONTROLLER_INDEX, (u8_t *) rp, sizeof(cmds));
+}
+
+void tester_handle_l2cap(u8_t opcode, u8_t index, u8_t *data,
+			 u16_t len)
+{
+	switch (opcode) {
+	case L2CAP_READ_SUPPORTED_COMMANDS:
+		supported_commands(data, len);
+		return;
+	case L2CAP_CONNECT:
+		connect(data, len);
+		return;
+	case L2CAP_DISCONNECT:
+		disconnect(data, len);
+		return;
+	case L2CAP_SEND_DATA:
+		send_data(data, len);
+		return;
+	case L2CAP_LISTEN:
+		listen(data, len);
+		return;
+	default:
+		tester_rsp(BTP_SERVICE_ID_L2CAP, opcode, index,
+			   BTP_STATUS_UNKNOWN_CMD);
+		return;
+	}
+}
+
+u8_t tester_init_l2cap(void)
+{
+	return BTP_STATUS_SUCCESS;
+}
+
+u8_t tester_unregister_l2cap(void)
+{
+	return BTP_STATUS_SUCCESS;
+}

--- a/apps/bttester/src/main.c
+++ b/apps/bttester/src/main.c
@@ -1,0 +1,18 @@
+/* main.c - Application main entry point */
+
+/*
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <zephyr/types.h>
+#include <toolchain.h>
+
+#include "bttester.h"
+
+void main(void)
+{
+	tester_init();
+}

--- a/apps/bttester/src/mesh.c
+++ b/apps/bttester/src/mesh.c
@@ -1,0 +1,927 @@
+/* mesh.c - Bluetooth Mesh Tester */
+
+/*
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <bluetooth/bluetooth.h>
+
+#include <errno.h>
+#include <bluetooth/mesh.h>
+#include <bluetooth/testing.h>
+#include <misc/byteorder.h>
+#include "bttester.h"
+
+#define CONTROLLER_INDEX 0
+#define CID_LOCAL 0xffff
+
+/* Health server data */
+#define CUR_FAULTS_MAX 4
+#define HEALTH_TEST_ID 0x00
+
+static u8_t cur_faults[CUR_FAULTS_MAX];
+static u8_t reg_faults[CUR_FAULTS_MAX * 2];
+
+/* Provision node data */
+static u8_t net_key[16];
+static u16_t net_key_idx;
+static u8_t flags;
+static u32_t iv_index;
+static u16_t addr;
+static u8_t dev_key[16];
+static u8_t input_size;
+
+/* Configured provisioning data */
+static u8_t dev_uuid[16];
+static u8_t static_auth[16];
+
+/* Vendor Model data */
+#define VND_MODEL_ID_1 0x1234
+
+/* Model send data */
+#define MODEL_BOUNDS_MAX 2
+
+static struct model_data {
+	struct bt_mesh_model *model;
+	u16_t addr;
+	u16_t appkey_idx;
+} model_bound[MODEL_BOUNDS_MAX];
+
+static struct {
+	u16_t local;
+	u16_t dst;
+	u16_t net_idx;
+} net = {
+	.local = BT_MESH_ADDR_UNASSIGNED,
+	.dst = BT_MESH_ADDR_UNASSIGNED,
+};
+
+static void supported_commands(u8_t *data, u16_t len)
+{
+	struct net_buf_simple *buf = NET_BUF_SIMPLE(BTP_DATA_MAX_SIZE);
+
+	net_buf_simple_init(buf, 0);
+
+	/* 1st octet */
+	memset(net_buf_simple_add(buf, 1), 0, 1);
+	tester_set_bit(buf->data, MESH_READ_SUPPORTED_COMMANDS);
+	tester_set_bit(buf->data, MESH_CONFIG_PROVISIONING);
+	tester_set_bit(buf->data, MESH_PROVISION_NODE);
+	tester_set_bit(buf->data, MESH_INIT);
+	tester_set_bit(buf->data, MESH_RESET);
+	tester_set_bit(buf->data, MESH_INPUT_NUMBER);
+	tester_set_bit(buf->data, MESH_INPUT_STRING);
+	/* 2nd octet */
+	tester_set_bit(buf->data, MESH_IVU_TEST_MODE);
+	tester_set_bit(buf->data, MESH_IVU_TOGGLE_STATE);
+	tester_set_bit(buf->data, MESH_NET_SEND);
+	tester_set_bit(buf->data, MESH_HEALTH_GENERATE_FAULTS);
+	tester_set_bit(buf->data, MESH_HEALTH_CLEAR_FAULTS);
+	tester_set_bit(buf->data, MESH_LPN);
+	tester_set_bit(buf->data, MESH_LPN_POLL);
+	tester_set_bit(buf->data, MESH_MODEL_SEND);
+	/* 3rd octet */
+	memset(net_buf_simple_add(buf, 1), 0, 1);
+#if defined(CONFIG_BT_TESTING)
+	tester_set_bit(buf->data, MESH_LPN_SUBSCRIBE);
+	tester_set_bit(buf->data, MESH_LPN_UNSUBSCRIBE);
+	tester_set_bit(buf->data, MESH_RPL_CLEAR);
+#endif /* CONFIG_BT_TESTING */
+	tester_set_bit(buf->data, MESH_PROXY_IDENTITY);
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_READ_SUPPORTED_COMMANDS,
+		    CONTROLLER_INDEX, buf->data, buf->len);
+}
+
+static struct bt_mesh_cfg_srv cfg_srv = {
+	.relay = BT_MESH_RELAY_ENABLED,
+	.beacon = BT_MESH_BEACON_ENABLED,
+#if defined(CONFIG_BT_MESH_FRIEND)
+	.frnd = BT_MESH_FRIEND_DISABLED,
+#else
+	.frnd = BT_MESH_FRIEND_NOT_SUPPORTED,
+#endif
+#if defined(CONFIG_BT_MESH_GATT_PROXY)
+	.gatt_proxy = BT_MESH_GATT_PROXY_ENABLED,
+#else
+	.gatt_proxy = BT_MESH_GATT_PROXY_NOT_SUPPORTED,
+#endif
+	.default_ttl = 7,
+
+	/* 3 transmissions with 20ms interval */
+	.net_transmit = BT_MESH_TRANSMIT(2, 20),
+	.relay_retransmit = BT_MESH_TRANSMIT(2, 20),
+};
+
+static void get_faults(u8_t *faults, u8_t faults_size, u8_t *dst, u8_t *count)
+{
+	u8_t i, limit = *count;
+
+	for (i = 0, *count = 0; i < faults_size && *count < limit; i++) {
+		if (faults[i]) {
+			*dst++ = faults[i];
+			(*count)++;
+		}
+	}
+}
+
+static int fault_get_cur(struct bt_mesh_model *model, u8_t *test_id,
+			 u16_t *company_id, u8_t *faults, u8_t *fault_count)
+{
+	SYS_LOG_DBG("");
+
+	*test_id = HEALTH_TEST_ID;
+	*company_id = CID_LOCAL;
+
+	get_faults(cur_faults, sizeof(cur_faults), faults, fault_count);
+
+	return 0;
+}
+
+static int fault_get_reg(struct bt_mesh_model *model, u16_t company_id,
+			 u8_t *test_id, u8_t *faults, u8_t *fault_count)
+{
+	SYS_LOG_DBG("company_id 0x%04x", company_id);
+
+	if (company_id != CID_LOCAL) {
+		return -EINVAL;
+	}
+
+	*test_id = HEALTH_TEST_ID;
+
+	get_faults(reg_faults, sizeof(reg_faults), faults, fault_count);
+
+	return 0;
+}
+
+static int fault_clear(struct bt_mesh_model *model, uint16_t company_id)
+{
+	SYS_LOG_DBG("company_id 0x%04x", company_id);
+
+	if (company_id != CID_LOCAL) {
+		return -EINVAL;
+	}
+
+	memset(reg_faults, 0, sizeof(reg_faults));
+
+	return 0;
+}
+
+static int fault_test(struct bt_mesh_model *model, uint8_t test_id,
+		      uint16_t company_id)
+{
+	SYS_LOG_DBG("test_id 0x%02x company_id 0x%04x", test_id, company_id);
+
+	if (company_id != CID_LOCAL || test_id != HEALTH_TEST_ID) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static const struct bt_mesh_health_srv_cb health_srv_cb = {
+	.fault_get_cur = fault_get_cur,
+	.fault_get_reg = fault_get_reg,
+	.fault_clear = fault_clear,
+	.fault_test = fault_test,
+};
+
+static struct bt_mesh_health_srv health_srv = {
+	.cb = &health_srv_cb,
+};
+
+BT_MESH_HEALTH_PUB_DEFINE(health_pub, CUR_FAULTS_MAX);
+
+static struct bt_mesh_cfg_cli cfg_cli = {
+};
+
+void show_faults(u8_t test_id, u16_t cid, u8_t *faults, size_t fault_count)
+{
+	size_t i;
+
+	if (!fault_count) {
+		SYS_LOG_DBG("Health Test ID 0x%02x Company ID 0x%04x: "
+			    "no faults", test_id, cid);
+		return;
+	}
+
+	SYS_LOG_DBG("Health Test ID 0x%02x Company ID 0x%04x Fault Count %zu: ",
+		    test_id, cid, fault_count);
+
+	for (i = 0; i < fault_count; i++) {
+		SYS_LOG_DBG("0x%02x", faults[i]);
+	}
+}
+
+static void health_current_status(struct bt_mesh_health_cli *cli, u16_t addr,
+				  u8_t test_id, u16_t cid, u8_t *faults,
+				  size_t fault_count)
+{
+	SYS_LOG_DBG("Health Current Status from 0x%04x", addr);
+	show_faults(test_id, cid, faults, fault_count);
+}
+
+static struct bt_mesh_health_cli health_cli = {
+	.current_status = health_current_status,
+};
+
+static struct bt_mesh_model root_models[] = {
+	BT_MESH_MODEL_CFG_SRV(&cfg_srv),
+	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
+	BT_MESH_MODEL_HEALTH_SRV(&health_srv, &health_pub),
+	BT_MESH_MODEL_HEALTH_CLI(&health_cli),
+};
+
+static struct bt_mesh_model vnd_models[] = {
+	BT_MESH_MODEL_VND(CID_LOCAL, VND_MODEL_ID_1, BT_MESH_MODEL_NO_OPS, NULL,
+			  NULL),
+};
+
+static struct bt_mesh_elem elements[] = {
+	BT_MESH_ELEM(0, root_models, vnd_models),
+};
+
+static void link_open(bt_mesh_prov_bearer_t bearer)
+{
+	struct mesh_prov_link_open_ev ev;
+
+	SYS_LOG_DBG("bearer 0x%02x", bearer);
+
+	switch (bearer) {
+	case BT_MESH_PROV_ADV:
+		ev.bearer = MESH_PROV_BEARER_PB_ADV;
+		break;
+	case BT_MESH_PROV_GATT:
+		ev.bearer = MESH_PROV_BEARER_PB_GATT;
+		break;
+	default:
+		SYS_LOG_ERR("Invalid bearer");
+
+		return;
+	}
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_PROV_LINK_OPEN,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void link_close(bt_mesh_prov_bearer_t bearer)
+{
+	struct mesh_prov_link_closed_ev ev;
+
+	SYS_LOG_DBG("bearer 0x%02x", bearer);
+
+	switch (bearer) {
+	case BT_MESH_PROV_ADV:
+		ev.bearer = MESH_PROV_BEARER_PB_ADV;
+		break;
+	case BT_MESH_PROV_GATT:
+		ev.bearer = MESH_PROV_BEARER_PB_GATT;
+		break;
+	default:
+		SYS_LOG_ERR("Invalid bearer");
+
+		return;
+	}
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_PROV_LINK_CLOSED,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static int output_number(bt_mesh_output_action_t action, u32_t number)
+{
+	struct mesh_out_number_action_ev ev;
+
+	SYS_LOG_DBG("action 0x%04x number 0x%08x", action, number);
+
+	ev.action = sys_cpu_to_le16(action);
+	ev.number = sys_cpu_to_le32(number);
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_OUT_NUMBER_ACTION,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+
+	return 0;
+}
+
+static int output_string(const char *str)
+{
+	struct mesh_out_string_action_ev *ev;
+	struct net_buf_simple *buf = NET_BUF_SIMPLE(BTP_DATA_MAX_SIZE);
+
+	SYS_LOG_DBG("str %s", str);
+
+	net_buf_simple_init(buf, 0);
+
+	ev = net_buf_simple_add(buf, sizeof(*ev));
+	ev->string_len = strlen(str);
+
+	net_buf_simple_add_mem(buf, str, ev->string_len);
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_OUT_STRING_ACTION,
+		    CONTROLLER_INDEX, buf->data, buf->len);
+
+	return 0;
+}
+
+static int input(bt_mesh_input_action_t action, u8_t size)
+{
+	struct mesh_in_action_ev ev;
+
+	SYS_LOG_DBG("action 0x%04x number 0x%02x", action, size);
+
+	input_size = size;
+
+	ev.action = sys_cpu_to_le16(action);
+	ev.size = size;
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_IN_ACTION, CONTROLLER_INDEX,
+		    (u8_t *) &ev, sizeof(ev));
+
+	return 0;
+}
+
+static void prov_complete(u16_t net_idx, u16_t addr)
+{
+	SYS_LOG_DBG("net_idx 0x%04x addr 0x%04x", net_idx, addr);
+
+	net.net_idx = net_idx,
+	net.local = addr;
+	net.dst = addr;
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_PROVISIONED, CONTROLLER_INDEX,
+		    NULL, 0);
+}
+
+static void prov_reset(void)
+{
+	SYS_LOG_DBG("");
+
+	bt_mesh_prov_enable(BT_MESH_PROV_ADV | BT_MESH_PROV_GATT);
+}
+
+static const struct bt_mesh_comp comp = {
+	.cid = CID_LOCAL,
+	.elem = elements,
+	.elem_count = ARRAY_SIZE(elements),
+};
+
+static struct bt_mesh_prov prov = {
+	.uuid = dev_uuid,
+	.static_val = static_auth,
+	.static_val_len = sizeof(static_auth),
+	.output_number = output_number,
+	.output_string = output_string,
+	.input = input,
+	.link_open = link_open,
+	.link_close = link_close,
+	.complete = prov_complete,
+	.reset = prov_reset,
+};
+
+static void config_prov(u8_t *data, u16_t len)
+{
+	const struct mesh_config_provisioning_cmd *cmd = (void *) data;
+
+	SYS_LOG_DBG("");
+
+	memcpy(dev_uuid, cmd->uuid, sizeof(dev_uuid));
+	memcpy(static_auth, cmd->static_auth, sizeof(static_auth));
+
+	prov.output_size = cmd->out_size;
+	prov.output_actions = sys_le16_to_cpu(cmd->out_actions);
+	prov.input_size = cmd->in_size;
+	prov.input_actions = sys_le16_to_cpu(cmd->in_actions);
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_CONFIG_PROVISIONING,
+		   CONTROLLER_INDEX, BTP_STATUS_SUCCESS);
+}
+
+static void provision_node(u8_t *data, u16_t len)
+{
+	const struct mesh_provision_node_cmd *cmd = (void *) data;
+
+	SYS_LOG_DBG("");
+
+	memcpy(dev_key, cmd->dev_key, sizeof(dev_key));
+	memcpy(net_key, cmd->net_key, sizeof(net_key));
+
+	addr = sys_le16_to_cpu(cmd->addr);
+	flags = cmd->flags;
+	iv_index = sys_le32_to_cpu(cmd->iv_index);
+	net_key_idx = sys_le16_to_cpu(cmd->net_key_idx);
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_PROVISION_NODE,
+		   CONTROLLER_INDEX, BTP_STATUS_SUCCESS);
+}
+
+static void init(u8_t *data, u16_t len)
+{
+	u8_t status = BTP_STATUS_SUCCESS;
+	int err;
+
+	SYS_LOG_DBG("");
+
+	err = bt_mesh_init(&prov, &comp);
+	if (err) {
+		status = BTP_STATUS_FAILED;
+
+		goto rsp;
+	}
+
+	if (addr) {
+		err = bt_mesh_provision(net_key, net_key_idx, flags, iv_index,
+					addr, dev_key);
+		if (err) {
+			status = BTP_STATUS_FAILED;
+		}
+	} else {
+		err = bt_mesh_prov_enable(BT_MESH_PROV_ADV | BT_MESH_PROV_GATT);
+		if (err) {
+			status = BTP_STATUS_FAILED;
+		}
+	}
+
+	/* Set device key for vendor model */
+	vnd_models[0].keys[0] = BT_MESH_KEY_DEV;
+
+rsp:
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_INIT, CONTROLLER_INDEX,
+		   status);
+}
+
+static void reset(u8_t *data, u16_t len)
+{
+	SYS_LOG_DBG("");
+
+	bt_mesh_reset();
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_RESET, CONTROLLER_INDEX,
+		   BTP_STATUS_SUCCESS);
+}
+
+static void input_number(u8_t *data, u16_t len)
+{
+	const struct mesh_input_number_cmd *cmd = (void *) data;
+	u8_t status = BTP_STATUS_SUCCESS;
+	u32_t number;
+	int err;
+
+	number = sys_le32_to_cpu(cmd->number);
+
+	SYS_LOG_DBG("number 0x%04x", number);
+
+	err = bt_mesh_input_number(number);
+	if (err) {
+		status = BTP_STATUS_FAILED;
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_INPUT_NUMBER, CONTROLLER_INDEX,
+		   status);
+}
+
+static void input_string(u8_t *data, u16_t len)
+{
+	const struct mesh_input_string_cmd *cmd = (void *) data;
+	u8_t status = BTP_STATUS_SUCCESS;
+	u8_t str_auth[16];
+	int err;
+
+	SYS_LOG_DBG("");
+
+	if (cmd->string_len > sizeof(str_auth)) {
+		SYS_LOG_ERR("Too long input (%u chars required)", input_size);
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	} else if (cmd->string_len < input_size) {
+		SYS_LOG_ERR("Too short input (%u chars required)", input_size);
+		status = BTP_STATUS_FAILED;
+		goto rsp;
+	}
+
+	strncpy(str_auth, cmd->string, cmd->string_len);
+
+	err = bt_mesh_input_string(str_auth);
+	if (err) {
+		status = BTP_STATUS_FAILED;
+	}
+
+rsp:
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_INPUT_STRING, CONTROLLER_INDEX,
+		   status);
+}
+
+static void ivu_test_mode(u8_t *data, u16_t len)
+{
+	const struct mesh_ivu_test_mode_cmd *cmd = (void *) data;
+
+	SYS_LOG_DBG("enable 0x%02x", cmd->enable);
+
+	bt_mesh_iv_update_test(cmd->enable ? true : false);
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_IVU_TEST_MODE, CONTROLLER_INDEX,
+		   BTP_STATUS_SUCCESS);
+}
+
+static void ivu_toggle_state(u8_t *data, u16_t len)
+{
+	bool result;
+
+	SYS_LOG_DBG("");
+
+	result = bt_mesh_iv_update();
+	if (!result) {
+		SYS_LOG_ERR("Failed to toggle the IV Update state");
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_IVU_TOGGLE_STATE, CONTROLLER_INDEX,
+		   result ? BTP_STATUS_SUCCESS : BTP_STATUS_FAILED);
+}
+
+static void lpn(u8_t *data, u16_t len)
+{
+	struct mesh_lpn_set_cmd *cmd = (void *) data;
+	bool enable;
+	int err;
+
+	SYS_LOG_DBG("enable 0x%02x", cmd->enable);
+
+	enable = cmd->enable ? true : false;
+	err = bt_mesh_lpn_set(enable);
+	if (err) {
+		SYS_LOG_ERR("Failed to toggle LPN (err %d)", err);
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_LPN, CONTROLLER_INDEX,
+		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+}
+
+static void lpn_poll(u8_t *data, u16_t len)
+{
+	int err;
+
+	SYS_LOG_DBG("");
+
+	err = bt_mesh_lpn_poll();
+	if (err) {
+		SYS_LOG_ERR("Failed to send poll msg (err %d)", err);
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_LPN_POLL, CONTROLLER_INDEX,
+		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+}
+
+static void net_send(u8_t *data, u16_t len)
+{
+	struct mesh_net_send_cmd *cmd = (void *) data;
+	NET_BUF_SIMPLE_DEFINE(msg, UINT8_MAX);
+	struct bt_mesh_msg_ctx ctx = {
+		.net_idx = net.net_idx,
+		.app_idx = BT_MESH_KEY_DEV,
+		.addr = sys_le16_to_cpu(cmd->dst),
+		.send_ttl = cmd->ttl,
+	};
+	int err;
+
+	SYS_LOG_DBG("ttl 0x%02x dst 0x%04x payload_len %d", ctx.send_ttl,
+		    ctx.addr, cmd->payload_len);
+
+	net_buf_simple_add_mem(&msg, cmd->payload, cmd->payload_len);
+
+	err = bt_mesh_model_send(&vnd_models[0], &ctx, &msg, NULL, NULL);
+	if (err) {
+		SYS_LOG_ERR("Failed to send (err %d)", err);
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_NET_SEND, CONTROLLER_INDEX,
+		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+}
+
+static void health_generate_faults(u8_t *data, u16_t len)
+{
+	struct mesh_health_generate_faults_rp *rp;
+	NET_BUF_SIMPLE_DEFINE(buf, sizeof(*rp) + sizeof(cur_faults) +
+			      sizeof(reg_faults));
+	u8_t some_faults[] = { 0x01, 0x02, 0x03, 0xff, 0x06 };
+	u8_t cur_faults_count, reg_faults_count;
+
+	rp = net_buf_simple_add(&buf, sizeof(*rp));
+
+	cur_faults_count = min(sizeof(cur_faults), sizeof(some_faults));
+	memcpy(cur_faults, some_faults, cur_faults_count);
+	net_buf_simple_add_mem(&buf, cur_faults, cur_faults_count);
+	rp->cur_faults_count = cur_faults_count;
+
+	reg_faults_count = min(sizeof(reg_faults), sizeof(some_faults));
+	memcpy(reg_faults, some_faults, reg_faults_count);
+	net_buf_simple_add_mem(&buf, reg_faults, reg_faults_count);
+	rp->reg_faults_count = reg_faults_count;
+
+	bt_mesh_fault_update(&elements[0]);
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_HEALTH_GENERATE_FAULTS,
+		    CONTROLLER_INDEX, buf.data, buf.len);
+}
+
+static void health_clear_faults(u8_t *data, u16_t len)
+{
+	SYS_LOG_DBG("");
+
+	memset(cur_faults, 0, sizeof(cur_faults));
+	memset(reg_faults, 0, sizeof(reg_faults));
+
+	bt_mesh_fault_update(&elements[0]);
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_HEALTH_CLEAR_FAULTS,
+		   CONTROLLER_INDEX, BTP_STATUS_SUCCESS);
+}
+
+static void model_send(u8_t *data, u16_t len)
+{
+	struct mesh_model_send_cmd *cmd = (void *) data;
+	NET_BUF_SIMPLE_DEFINE(msg, UINT8_MAX);
+	struct bt_mesh_msg_ctx ctx = {
+		.net_idx = net.net_idx,
+		.app_idx = BT_MESH_KEY_DEV,
+		.addr = sys_le16_to_cpu(cmd->dst),
+		.send_ttl = BT_MESH_TTL_DEFAULT,
+	};
+	struct bt_mesh_model *model = NULL;
+	int err, i;
+	u16_t src = sys_le16_to_cpu(cmd->src);
+
+	/* Lookup source address */
+	for (i = 0; i < ARRAY_SIZE(model_bound); i++) {
+		if (bt_mesh_model_elem(model_bound[i].model)->addr == src) {
+			model = model_bound[i].model;
+			ctx.app_idx = model_bound[i].appkey_idx;
+
+			break;
+		}
+	}
+
+	if (!model) {
+		SYS_LOG_ERR("Model not found");
+		err = -EINVAL;
+
+		goto fail;
+	}
+
+	SYS_LOG_DBG("src 0x%04x dst 0x%04x model %p payload_len %d", src,
+		    ctx.addr, model, cmd->payload_len);
+
+	net_buf_simple_add_mem(&msg, cmd->payload, cmd->payload_len);
+
+	err = bt_mesh_model_send(model, &ctx, &msg, NULL, NULL);
+	if (err) {
+		SYS_LOG_ERR("Failed to send (err %d)", err);
+	}
+
+fail:
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_MODEL_SEND, CONTROLLER_INDEX,
+		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+}
+
+#if defined(CONFIG_BT_TESTING)
+static void lpn_subscribe(u8_t *data, u16_t len)
+{
+	struct mesh_lpn_subscribe_cmd *cmd = (void *) data;
+	u16_t address = sys_le16_to_cpu(cmd->address);
+	int err;
+
+	SYS_LOG_DBG("address 0x%04x", address);
+
+	err = bt_test_mesh_lpn_group_add(address);
+	if (err) {
+		SYS_LOG_ERR("Failed to subscribe (err %d)", err);
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_LPN_SUBSCRIBE, CONTROLLER_INDEX,
+		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+}
+
+static void lpn_unsubscribe(u8_t *data, u16_t len)
+{
+	struct mesh_lpn_unsubscribe_cmd *cmd = (void *) data;
+	u16_t address = sys_le16_to_cpu(cmd->address);
+	int err;
+
+	SYS_LOG_DBG("address 0x%04x", address);
+
+	err = bt_test_mesh_lpn_group_remove(&address, 1);
+	if (err) {
+		SYS_LOG_ERR("Failed to unsubscribe (err %d)", err);
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_LPN_UNSUBSCRIBE, CONTROLLER_INDEX,
+		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+}
+
+static void rpl_clear(u8_t *data, u16_t len)
+{
+	int err;
+
+	SYS_LOG_DBG("");
+
+	err = bt_test_mesh_rpl_clear();
+	if (err) {
+		SYS_LOG_ERR("Failed to clear RPL (err %d)", err);
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_RPL_CLEAR, CONTROLLER_INDEX,
+		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+}
+#endif /* CONFIG_BT_TESTING */
+
+static void proxy_identity_enable(u8_t *data, u16_t len)
+{
+	int err;
+
+	SYS_LOG_DBG("");
+
+	err = bt_mesh_proxy_identity_enable();
+	if (err) {
+		SYS_LOG_ERR("Failed to enable proxy identity (err %d)", err);
+	}
+
+	tester_rsp(BTP_SERVICE_ID_MESH, MESH_PROXY_IDENTITY, CONTROLLER_INDEX,
+		   err ? BTP_STATUS_FAILED : BTP_STATUS_SUCCESS);
+}
+
+void tester_handle_mesh(u8_t opcode, u8_t index, u8_t *data, u16_t len)
+{
+	switch (opcode) {
+	case MESH_READ_SUPPORTED_COMMANDS:
+		supported_commands(data, len);
+		break;
+	case MESH_CONFIG_PROVISIONING:
+		config_prov(data, len);
+		break;
+	case MESH_PROVISION_NODE:
+		provision_node(data, len);
+		break;
+	case MESH_INIT:
+		init(data, len);
+		break;
+	case MESH_RESET:
+		reset(data, len);
+		break;
+	case MESH_INPUT_NUMBER:
+		input_number(data, len);
+		break;
+	case MESH_INPUT_STRING:
+		input_string(data, len);
+		break;
+	case MESH_IVU_TEST_MODE:
+		ivu_test_mode(data, len);
+		break;
+	case MESH_IVU_TOGGLE_STATE:
+		ivu_toggle_state(data, len);
+		break;
+	case MESH_LPN:
+		lpn(data, len);
+		break;
+	case MESH_LPN_POLL:
+		lpn_poll(data, len);
+		break;
+	case MESH_NET_SEND:
+		net_send(data, len);
+		break;
+	case MESH_HEALTH_GENERATE_FAULTS:
+		health_generate_faults(data, len);
+		break;
+	case MESH_HEALTH_CLEAR_FAULTS:
+		health_clear_faults(data, len);
+		break;
+	case MESH_MODEL_SEND:
+		model_send(data, len);
+		break;
+#if defined(CONFIG_BT_TESTING)
+	case MESH_LPN_SUBSCRIBE:
+		lpn_subscribe(data, len);
+		break;
+	case MESH_LPN_UNSUBSCRIBE:
+		lpn_unsubscribe(data, len);
+		break;
+	case MESH_RPL_CLEAR:
+		rpl_clear(data, len);
+		break;
+#endif /* CONFIG_BT_TESTING */
+	case MESH_PROXY_IDENTITY:
+		proxy_identity_enable(data, len);
+		break;
+	default:
+		tester_rsp(BTP_SERVICE_ID_MESH, opcode, index,
+			   BTP_STATUS_UNKNOWN_CMD);
+		break;
+	}
+}
+
+void net_recv_ev(u8_t ttl, u8_t ctl, u16_t src, u16_t dst, const void *payload,
+		 size_t payload_len)
+{
+	NET_BUF_SIMPLE_DEFINE(buf, UINT8_MAX);
+	struct mesh_net_recv_ev *ev;
+
+	SYS_LOG_DBG("ttl 0x%02x ctl 0x%02x src 0x%04x dst 0x%04x "
+		    "payload_len %d", ttl, ctl, src, dst, payload_len);
+
+	if (payload_len > net_buf_simple_tailroom(&buf)) {
+		SYS_LOG_ERR("Payload size exceeds buffer size");
+
+		return;
+	}
+
+	ev = net_buf_simple_add(&buf, sizeof(*ev));
+	ev->ttl = ttl;
+	ev->ctl = ctl;
+	ev->src = sys_cpu_to_le16(src);
+	ev->dst = sys_cpu_to_le16(dst);
+	ev->payload_len = payload_len;
+	net_buf_simple_add_mem(&buf, payload, payload_len);
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_NET_RECV, CONTROLLER_INDEX,
+		    buf.data, buf.len);
+}
+
+static void model_bound_cb(u16_t addr, struct bt_mesh_model *model,
+			   u16_t key_idx)
+{
+	int i;
+
+	SYS_LOG_DBG("remote addr 0x%04x key_idx 0x%04x model %p",
+		    addr, key_idx, model);
+
+	for (i = 0; i < ARRAY_SIZE(model_bound); i++) {
+		if (!model_bound[i].model) {
+			model_bound[i].model = model;
+			model_bound[i].addr = addr;
+			model_bound[i].appkey_idx = key_idx;
+
+			return;
+		}
+	}
+
+	SYS_LOG_ERR("model_bound is full");
+}
+
+static void model_unbound_cb(u16_t addr, struct bt_mesh_model *model,
+			     u16_t key_idx)
+{
+	int i;
+
+	SYS_LOG_DBG("remote addr 0x%04x key_idx 0x%04x model %p",
+		    addr, key_idx, model);
+
+	for (i = 0; i < ARRAY_SIZE(model_bound); i++) {
+		if (model_bound[i].model == model) {
+			model_bound[i].model = NULL;
+			model_bound[i].addr = 0x0000;
+			model_bound[i].appkey_idx = BT_MESH_KEY_UNUSED;
+
+			return;
+		}
+	}
+
+	SYS_LOG_INF("model not found");
+}
+
+static void invalid_bearer_cb(u8_t opcode)
+{
+	struct mesh_invalid_bearer_ev ev = {
+		.opcode = opcode,
+	};
+
+	SYS_LOG_DBG("opcode 0x%02x", opcode);
+
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_INVALID_BEARER,
+		    CONTROLLER_INDEX, (u8_t *) &ev, sizeof(ev));
+}
+
+static void incomp_timer_exp_cb(void)
+{
+	tester_send(BTP_SERVICE_ID_MESH, MESH_EV_INCOMP_TIMER_EXP,
+		    CONTROLLER_INDEX, NULL, 0);
+}
+
+static struct bt_test_cb bt_test_cb = {
+	.mesh_net_recv = net_recv_ev,
+	.mesh_model_bound = model_bound_cb,
+	.mesh_model_unbound = model_unbound_cb,
+	.mesh_prov_invalid_bearer = invalid_bearer_cb,
+	.mesh_trans_incomp_timer_exp = incomp_timer_exp_cb,
+};
+
+u8_t tester_init_mesh(void)
+{
+	if (IS_ENABLED(CONFIG_BT_TESTING)) {
+		bt_test_cb_register(&bt_test_cb);
+	}
+
+	return BTP_STATUS_SUCCESS;
+}
+
+u8_t tester_unregister_mesh(void)
+{
+	return BTP_STATUS_SUCCESS;
+}

--- a/apps/bttester/src/rtt_pipe.c
+++ b/apps/bttester/src/rtt_pipe.c
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "syscfg/syscfg.h"
+
+#if MYNEWT_VAL(BTTESTER_PIPE_RTT)
+
+#include "os/mynewt.h"
+#include "console/console.h"
+#include "rtt/SEGGER_RTT.h"
+
+#include "bttester_pipe.h"
+
+static struct hal_timer rtt_timer;
+
+static bttester_pipe_recv_cb app_cb;
+
+static u8_t *recv_buf;
+static size_t recv_buf_len;
+static size_t recv_off;
+
+static uint8_t rtt_buf_up[MYNEWT_VAL(BTTESTER_RTT_BUFFER_SIZE_UP)];
+static uint8_t rtt_buf_down[MYNEWT_VAL(BTTESTER_RTT_BUFFER_SIZE_DOWN)];
+static int rtt_index_up, rtt_index_down;
+
+#define RTT_INPUT_POLL_INTERVAL_MIN     10 /* ms */
+#define RTT_INPUT_POLL_INTERVAL_STEP    10 /* ms */
+#define RTT_INPUT_POLL_INTERVAL_MAX     250 /* ms */
+
+static int rtt_pipe_get_char(unsigned int index)
+{
+    char c;
+    int r;
+
+    r = (int)SEGGER_RTT_Read(index, &c, 1u);
+    if (r == 1) {
+        r = (int)(unsigned char)c;
+    } else {
+        r = -1;
+    }
+
+    return r;
+}
+
+static void
+rtt_pipe_poll_func(void *arg)
+{
+    static uint32_t itvl_ms = RTT_INPUT_POLL_INTERVAL_MIN;
+    static int key = -1;
+    int avail = recv_buf_len - recv_off;
+
+    if (key < 0) {
+        key = rtt_pipe_get_char((unsigned int) rtt_index_down);
+    }
+
+    if (key < 0) {
+        itvl_ms += RTT_INPUT_POLL_INTERVAL_STEP;
+        itvl_ms = min(itvl_ms, RTT_INPUT_POLL_INTERVAL_MAX);
+    } else {
+        while (key >= 0 && avail > 0) {
+            recv_buf[recv_off] = (u8_t) key;
+            recv_off++;
+            avail = recv_buf_len - recv_off;
+            key = rtt_pipe_get_char((unsigned int) rtt_index_down);
+        }
+
+        /*
+         * Call application callback with received data. Application
+         * may provide new buffer or alter data offset.
+         */
+        recv_buf = app_cb(recv_buf, &recv_off);
+
+        itvl_ms = RTT_INPUT_POLL_INTERVAL_MIN;
+    }
+
+    os_cputime_timer_relative(&rtt_timer, itvl_ms * 1000);
+}
+
+int
+bttester_pipe_send(const u8_t *data, int len)
+{
+    SEGGER_RTT_Write((unsigned int) rtt_index_up, data, (unsigned int) len);
+    return 0;
+}
+
+void
+bttester_pipe_register(u8_t *buf, size_t len, bttester_pipe_recv_cb cb)
+{
+    recv_buf = buf;
+    recv_buf_len = len;
+    app_cb = cb;
+}
+
+int
+bttester_pipe_init(void)
+{
+    rtt_index_up = SEGGER_RTT_AllocUpBuffer(MYNEWT_VAL(BTTESTER_RTT_BUFFER_NAME),
+                                            rtt_buf_up, sizeof(rtt_buf_up),
+                                            SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL);
+
+    if (rtt_index_up < 0) {
+        return -1;
+    }
+
+    rtt_index_down = SEGGER_RTT_AllocDownBuffer(MYNEWT_VAL(BTTESTER_RTT_BUFFER_NAME),
+                                                rtt_buf_down, sizeof(rtt_buf_down),
+                                                SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL);
+
+    if (rtt_index_down < 0) {
+        return -1;
+    }
+
+    console_printf("Using up-buffer #%d\n", rtt_index_up);
+    console_printf("Using down-buffer #%d\n", rtt_index_down);
+
+    os_cputime_timer_init(&rtt_timer, rtt_pipe_poll_func, NULL);
+    os_cputime_timer_relative(&rtt_timer, 200000);
+    return 0;
+}
+#endif /* MYNEWT_VAL(BTTESTER_PIPE_RTT) */

--- a/apps/bttester/src/uart_pipe.c
+++ b/apps/bttester/src/uart_pipe.c
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "syscfg/syscfg.h"
+
+#if MYNEWT_VAL(BTTESTER_PIPE_UART)
+
+#include "os/mynewt.h"
+#include "uart/uart.h"
+
+#include "bttester_pipe.h"
+
+static u8_t *recv_buf;
+static size_t recv_buf_len;
+static bttester_pipe_recv_cb app_cb;
+static size_t recv_off;
+
+struct uart_pipe_ring {
+    uint8_t head;
+    uint8_t tail;
+    uint16_t size;
+    uint8_t *buf;
+};
+
+static struct uart_dev *uart_dev;
+static struct uart_pipe_ring cr_tx;
+static uint8_t cr_tx_buf[2048];
+typedef void (*console_write_char)(struct uart_dev*, uint8_t);
+static console_write_char write_char_cb;
+
+static struct uart_pipe_ring cr_rx;
+static uint8_t cr_rx_buf[2048];
+static volatile bool uart_console_rx_stalled;
+
+struct os_event rx_ev;
+
+static inline int
+inc_and_wrap(int i, int max)
+{
+    return (i + 1) & (max - 1);
+}
+
+static void
+uart_pipe_ring_add_char(struct uart_pipe_ring *cr, char ch)
+{
+    cr->buf[cr->head] = ch;
+    cr->head = inc_and_wrap(cr->head, cr->size);
+}
+
+static uint8_t
+uart_pipe_ring_pull_char(struct uart_pipe_ring *cr)
+{
+    uint8_t ch;
+
+    ch = cr->buf[cr->tail];
+    cr->tail = inc_and_wrap(cr->tail, cr->size);
+    return ch;
+}
+
+static bool
+uart_pipe_ring_is_full(const struct uart_pipe_ring *cr)
+{
+    return inc_and_wrap(cr->head, cr->size) == cr->tail;
+}
+
+static bool
+uart_pipe_ring_is_empty(const struct uart_pipe_ring *cr)
+{
+    return cr->head == cr->tail;
+}
+
+static void
+uart_pipe_queue_char(struct uart_dev *uart_dev, uint8_t ch)
+{
+    int sr;
+
+    if ((uart_dev->ud_dev.od_flags & OS_DEV_F_STATUS_OPEN) == 0) {
+        return;
+    }
+
+    OS_ENTER_CRITICAL(sr);
+    while (uart_pipe_ring_is_full(&cr_tx)) {
+        /* TX needs to drain */
+        uart_start_tx(uart_dev);
+        OS_EXIT_CRITICAL(sr);
+        if (os_started()) {
+            os_time_delay(1);
+        }
+        OS_ENTER_CRITICAL(sr);
+    }
+    uart_pipe_ring_add_char(&cr_tx, ch);
+    OS_EXIT_CRITICAL(sr);
+}
+
+/*
+ * Interrupts disabled when console_tx_char/console_rx_char are called.
+ * Characters sent only in blocking mode.
+ */
+static int
+uart_console_tx_char(void *arg)
+{
+    if (uart_pipe_ring_is_empty(&cr_tx)) {
+        return -1;
+    }
+    return uart_pipe_ring_pull_char(&cr_tx);
+}
+
+/*
+ * Interrupts disabled when console_tx_char/console_rx_char are called.
+ */
+static int
+uart_console_rx_char(void *arg, uint8_t byte)
+{
+    if (uart_pipe_ring_is_full(&cr_rx)) {
+        uart_console_rx_stalled = true;
+        return -1;
+    }
+
+    uart_pipe_ring_add_char(&cr_rx, byte);
+
+    if (!rx_ev.ev_queued) {
+        os_eventq_put(os_eventq_dflt_get(), &rx_ev);
+    }
+
+    return 0;
+}
+
+static int
+uart_pipe_handle_char(int key)
+{
+    recv_buf[recv_off] = (u8_t) key;
+    recv_off++;
+
+    return 0;
+}
+
+static void
+uart_console_rx_char_event(struct os_event *ev)
+{
+    static int b = -1;
+    int sr;
+    int ret;
+
+    /* We may have unhandled character - try it first */
+    if (b >= 0) {
+        ret = uart_pipe_handle_char(b);
+        if (ret < 0) {
+            return;
+        }
+    }
+
+    while (!uart_pipe_ring_is_empty(&cr_rx)) {
+        OS_ENTER_CRITICAL(sr);
+        b = uart_pipe_ring_pull_char(&cr_rx);
+        OS_EXIT_CRITICAL(sr);
+
+        /* If UART RX was stalled due to a full receive buffer, restart RX now
+         * that we have removed a byte from the buffer.
+         */
+        if (uart_console_rx_stalled) {
+            uart_console_rx_stalled = false;
+            uart_start_rx(uart_dev);
+        }
+
+        ret = uart_pipe_handle_char(b);
+        if (ret < 0) {
+            return;
+        }
+    }
+
+    /*
+     * Call application callback with received data. Application
+     * may provide new buffer or alter data offset.
+     */
+    recv_buf = app_cb(recv_buf, &recv_off);
+
+    b = -1;
+}
+
+int
+bttester_pipe_send(const u8_t *data, int len)
+{
+    int i;
+
+    /* Assure that there is a write cb installed; this enables to debug
+     * code that is faulting before the console was initialized.
+     */
+    if (!write_char_cb) {
+        return -1;
+    }
+
+    for (i = 0; i < len; ++i) {
+        write_char_cb(uart_dev, data[i]);
+    }
+
+    uart_start_tx(uart_dev);
+
+    return 0;
+}
+
+int
+bttester_pipe_init(void)
+{
+    struct uart_conf uc = {
+            .uc_speed = MYNEWT_VAL(CONSOLE_UART_BAUD),
+            .uc_databits = 8,
+            .uc_stopbits = 1,
+            .uc_parity = UART_PARITY_NONE,
+            .uc_flow_ctl = MYNEWT_VAL(CONSOLE_UART_FLOW_CONTROL),
+            .uc_tx_char = uart_console_tx_char,
+            .uc_rx_char = uart_console_rx_char,
+    };
+
+    cr_tx.size = 2048;
+    cr_tx.buf = cr_tx_buf;
+    write_char_cb = uart_pipe_queue_char;
+
+    cr_rx.size = 2048;
+    cr_rx.buf = cr_rx_buf;
+
+    rx_ev.ev_cb = uart_console_rx_char_event;
+
+    if (!uart_dev) {
+        uart_dev = (struct uart_dev *)os_dev_open(MYNEWT_VAL(CONSOLE_UART_DEV),
+                                                  OS_TIMEOUT_NEVER, &uc);
+        if (!uart_dev) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+void
+bttester_pipe_register(u8_t *buf, size_t len, bttester_pipe_recv_cb cb)
+{
+	recv_buf = buf;
+	recv_buf_len = len;
+	app_cb = cb;
+}
+#endif /* MYNEWT_VAL(BTTESTER_PIPE_UART) */

--- a/apps/bttester/syscfg.yml
+++ b/apps/bttester/syscfg.yml
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: apps/blemesh
+
+syscfg.defs:
+    BTTESTER_PIPE_UART:
+        description: 'Set communication pipe to UART'
+        value: 0
+
+    BTTESTER_PIPE_RTT:
+        description: 'Set communication pipe to RTT'
+        value: 1
+
+    BTTESTER_RTT_BUFFER_NAME:
+        description: Bttester rtt pipe buffer name
+        value: '"bttester"'
+
+    BTTESTER_RTT_BUFFER_SIZE_UP:
+        description: Bttester upstream buffer size
+        value: 512
+
+    BTTESTER_RTT_BUFFER_SIZE_DOWN:
+        description: Bttester downstream buffer size
+        value: 512
+
+    BTTESTER_PRIVACY_MODE:
+        description: Use Resolvable Private Address
+        value: 0
+
+    BTTESTER_BTP_DATA_SIZE_MAX:
+        description: Maximum BTP payload
+        value: MYNEWT_VAL_BTTESTER_RTT_BUFFER_SIZE_UP
+
+    BTTESTER_CONN_PARAM_UPDATE:
+        description: Trigger conn param update after connection establish
+        value: 0
+
+    BTTESTER_DEBUG:
+        description: Enable debug logging
+        value: 0
+
+syscfg.vals:
+    OS_MAIN_STACK_SIZE: 12444
+    SHELL_TASK: 1
+    SHELL_NEWTMGR: 0
+    LOG_LEVEL: 1
+    MSYS_1_BLOCK_COUNT: 48
+    BLE_PUBLIC_DEV_ADDR: "((uint8_t[6]){0x66, 0x55, 0x44, 0x33, 0x22, 0x11})"
+
+    BLE_MONITOR_RTT: 1
+    CONSOLE_RTT: 0
+    CONSOLE_UART: 1
+    RTT_NUM_BUFFERS_UP: 1
+    RTT_NUM_BUFFERS_DOWN: 1
+
+    BLE_L2CAP_COC_MAX_NUM: 2
+    BLE_RPA_TIMEOUT: 10
+    BLE_SM_BONDING: 1
+    BLE_SM_MITM: 1
+    BLE_SM_SC: 1
+    BLE_SM_OUR_KEY_DIST: 7
+    BLE_SM_THEIR_KEY_DIST: 7
+
+    BLE_MESH: 1
+    BLE_MESH_SHELL: 0
+    BLE_MESH_PROV: 1
+    BLE_MESH_RELAY: 1
+    BLE_MESH_PB_ADV: 1
+    BLE_MESH_PB_GATT: 1
+    BLE_MESH_LOW_POWER: 1
+    BLE_MESH_LPN_AUTO: 0
+    BLE_MESH_GATT_PROXY: 1
+    BLE_MESH_LABEL_COUNT: 2
+    BLE_MESH_SUBNET_COUNT: 2
+    BLE_MESH_MODEL_GROUP_COUNT: 2
+    BLE_MESH_APP_KEY_COUNT: 4
+    BLE_MESH_IV_UPDATE_TEST: 1
+    BLE_MESH_TESTING: 1
+    BLE_MESH_FRIEND: 1
+    BLE_MESH_CFG_CLI: 1
+
+    BLE_MESH_ADV_BUF_COUNT: 20
+    BLE_MESH_TX_SEG_MAX: 6
+
+    BLE_MESH_DEBUG: 0
+    BLE_MESH_DEBUG_NET: 0
+    BLE_MESH_DEBUG_TRANS: 0
+    BLE_MESH_DEBUG_BEACON: 0
+    BLE_MESH_DEBUG_CRYPTO: 0
+    BLE_MESH_DEBUG_PROV: 0
+    BLE_MESH_DEBUG_ACCESS: 0
+    BLE_MESH_DEBUG_MODEL: 0
+    BLE_MESH_DEBUG_ADV: 0
+    BLE_MESH_DEBUG_LOW_POWER: 0
+    BLE_MESH_DEBUG_FRIEND: 0
+    BLE_MESH_DEBUG_PROXY: 0
+
+syscfg.vals.BTTESTER_PIPE_UART:
+    CONSOLE_UART: 0
+    CONSOLE_RTT: 1
+


### PR DESCRIPTION
Tester application uses binary protocol to control Mynewt Nimble stack
and is aimed at automated testing. It uses Bluetooth Testing Protocol (BTP)
to drive Bluetooth stack. BTP commands and events are received and buffered for
further processing.

Supported Profiles:

 GAP, GATT, SM, L2CAP, MESH