### PR TITLE
nimble/host: Persist CCCD values that were set before bonding

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -4495,8 +4495,12 @@ ble_gap_enc_event(uint16_t conn_handle, int status, int security_restored)
     ble_gap_event_listener_call(&event);
     ble_gap_call_conn_event_cb(&event, conn_handle);
 
-    if (status == 0 && security_restored) {
-        ble_gatts_bonding_restored(conn_handle);
+    if (status == 0) {
+        if (security_restored) {
+            ble_gatts_bonding_restored(conn_handle);
+        } else {
+            ble_gatts_bonding_established(conn_handle);
+        }
     }
 }
 

--- a/nimble/host/src/ble_gatt_priv.h
+++ b/nimble/host/src/ble_gatt_priv.h
@@ -176,6 +176,7 @@ struct ble_gatt_resources {
 int ble_gatts_rx_indicate_ack(uint16_t conn_handle, uint16_t chr_val_handle);
 int ble_gatts_send_next_indicate(uint16_t conn_handle);
 void ble_gatts_tx_notifications(void);
+void ble_gatts_bonding_established(uint16_t conn_handle);
 void ble_gatts_bonding_restored(uint16_t conn_handle);
 void ble_gatts_connection_broken(uint16_t conn_handle);
 void ble_gatts_lcl_svc_foreach(ble_gatt_svc_foreach_fn cb, void *arg);


### PR DESCRIPTION
Before:

1. Nimble is a peripheral
2. A connection is established with a peer device
3. Peer device subscribes for notifications/indications on a CCCD
4. Bonding with a peer device
5. Peer device disconnects and reconnects
6. The indication setting is not restored

After:

1. Nimble is a peripheral
2. A connection is established with a peer device
3. Peer device subscribes for notifications/indications on a CCCD
4. Bonding with a peer device
5. CCCD values are persisted
6. Peer device disconnects and reconnects
7. The indication settings are restored

Fixes issue #319