### PR TITLE
nimble/ll: Fix enh connection complete event as a master

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -271,8 +271,7 @@ struct ble_ll_conn_sm
     uint32_t last_rxd_pdu_cputime;  /* Used exclusively for supervision timer */
 
     /*
-     * Used to mark that direct advertising from the peer was using
-     * identity address as InitA
+     * Used to mark that identity address was used as InitA
      */
     uint8_t inita_identity_used;
 

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -2772,6 +2772,8 @@ ble_ll_conn_req_pdu_update(struct os_mbuf *m, uint8_t *adva, uint8_t addr_type,
 
         if (addr) {
             memcpy(dptr, addr, BLE_DEV_ADDR_LEN);
+            /* Identity address used */
+            connsm->inita_identity_used = 1;
         }
     }
 

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -164,9 +164,10 @@ ble_ll_conn_comp_event_send(struct ble_ll_conn_sm *connsm, uint8_t status,
                 memset(evdata, 0, 2 * BLE_DEV_ADDR_LEN);
                 if (connsm->conn_role == BLE_LL_CONN_ROLE_MASTER) {
                     if (connsm->inita_identity_used) {
-                        /* If it was direct advertising we were replying to and we used
-                         * identity address there (which might be just fine), we should
-                         * we should take it into account here in this event.
+                        /* We used identity address in CONNECT_IND which can be just fine if
+                         * a) it was direct advertising we replied to and remote uses its identity address
+                         * in device privacy mode or IRK is all zeros.
+                         * b) peer uses RPA and this is first time we connect to him
                          */
                         rpa = NULL;
                     } else  if (connsm->own_addr_type > BLE_HCI_ADV_OWN_ADDR_RANDOM) {


### PR DESCRIPTION
This patch fixes incorretly used identity address as a local rpa address
in the LE Enhanced Connection Complete Evt