### PR TITLE
Additional Fix For Handling conn_handle=0

### DIFF
--- a/nimble/host/mesh/src/prov.c
+++ b/nimble/host/mesh/src/prov.c
@@ -1013,7 +1013,7 @@ done:
 static inline bool is_pb_gatt(void)
 {
 #if MYNEWT_VAL(BLE_MESH_PB_GATT)
-	return !!link.conn_handle;
+	return (link.conn_handle != BLE_HS_CONN_HANDLE_NONE);
 #else
 	return false;
 #endif
@@ -1132,7 +1132,7 @@ static const struct {
 static void close_link(u8_t err, u8_t reason)
 {
 #if (MYNEWT_VAL(BLE_MESH_PB_GATT))
-	if (link.conn_handle) {
+	if (link.conn_handle != BLE_HS_CONN_HANDLE_NONE) {
 		bt_mesh_pb_gatt_close(link.conn_handle);
 		return;
 	}

--- a/nimble/host/mesh/src/proxy.c
+++ b/nimble/host/mesh/src/proxy.c
@@ -808,8 +808,9 @@ void bt_mesh_proxy_gatt_disconnect(void)
 	for (i = 0; i < ARRAY_SIZE(clients); i++) {
 		struct bt_mesh_proxy_client *client = &clients[i];
 
-		if (client->conn_handle && (client->filter_type == WHITELIST ||
-					    client->filter_type == BLACKLIST)) {
+		if ((client->conn_handle != BLE_HS_CONN_HANDLE_NONE) &&
+		    (client->filter_type == WHITELIST ||
+		     client->filter_type == BLACKLIST)) {
 			client->filter_type = NONE;
 			rc = ble_gap_terminate(client->conn_handle,
 			                       BLE_ERR_REM_USER_CONN_TERM);


### PR DESCRIPTION
A conn_handle of 0 should be handled as a valid connection handle while BLE_HS_CONN_HANDLE_NONE should be the proper assignment for the cases where the connection is no longer valid. This fix includes some spotted areas where a check for a valid connection handle is not properly handled.