### PR TITLE
Remove implicit enum conversions for clang

### DIFF
--- a/porting/npl/mynewt/include/nimble/nimble_npl_os.h
+++ b/porting/npl/mynewt/include/nimble/nimble_npl_os.h
@@ -152,37 +152,37 @@ ble_npl_event_set_arg(struct ble_npl_event *ev, void *arg)
 static inline ble_npl_error_t
 ble_npl_mutex_init(struct ble_npl_mutex *mu)
 {
-    return os_mutex_init(&mu->mu);
+    return (ble_npl_error_t)os_mutex_init(&mu->mu);
 }
 
 static inline ble_npl_error_t
 ble_npl_mutex_pend(struct ble_npl_mutex *mu, ble_npl_time_t timeout)
 {
-    return os_mutex_pend(&mu->mu, timeout);
+    return (ble_npl_error_t)os_mutex_pend(&mu->mu, timeout);
 }
 
 static inline ble_npl_error_t
 ble_npl_mutex_release(struct ble_npl_mutex *mu)
 {
-    return os_mutex_release(&mu->mu);
+    return (ble_npl_error_t)os_mutex_release(&mu->mu);
 }
 
 static inline ble_npl_error_t
 ble_npl_sem_init(struct ble_npl_sem *sem, uint16_t tokens)
 {
-    return os_sem_init(&sem->sem, tokens);
+    return (ble_npl_error_t)os_sem_init(&sem->sem, tokens);
 }
 
 static inline ble_npl_error_t
 ble_npl_sem_pend(struct ble_npl_sem *sem, ble_npl_time_t timeout)
 {
-    return os_sem_pend(&sem->sem, timeout);
+    return (ble_npl_error_t)os_sem_pend(&sem->sem, timeout);
 }
 
 static inline ble_npl_error_t
 ble_npl_sem_release(struct ble_npl_sem *sem)
 {
-    return os_sem_release(&sem->sem);
+    return (ble_npl_error_t)os_sem_release(&sem->sem);
 }
 
 static inline uint16_t
@@ -201,7 +201,7 @@ ble_npl_callout_init(struct ble_npl_callout *co, struct ble_npl_eventq *evq,
 static inline ble_npl_error_t
 ble_npl_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks)
 {
-    return os_callout_reset(&co->co, ticks);
+    return (ble_npl_error_t)os_callout_reset(&co->co, ticks);
 }
 
 static inline void
@@ -245,7 +245,7 @@ ble_npl_time_get(void)
 static inline ble_npl_error_t
 ble_npl_time_ms_to_ticks(uint32_t ms, ble_npl_time_t *out_ticks)
 {
-    return os_time_ms_to_ticks(ms, out_ticks);
+    return (ble_npl_error_t)os_time_ms_to_ticks(ms, out_ticks);
 }
 
 static inline ble_npl_error_t


### PR DESCRIPTION
gcc allows implicit conversion between enum type (even when `-Wall` is specified).  clang does not allow such conversions with `-Wall`.  It reports warnings like this one:

```error: implicit conversion from enumeration type 'os_error_t' (aka 'enum os_error') to different enumeration type 'ble_npl_error_t' (aka 'enum ble_npl_error')```

This commit makes these conversions explicit via casts.  This allows the unit test code to be built with clang using Mynewt's default build flags.