### PR TITLE
nimble: Replace BLE_DEVICE with BLE_CONTROLLER

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -1382,7 +1382,7 @@ cmd_set_addr(void)
     }
 
     switch (addr_type) {
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
     case BLE_ADDR_PUBLIC:
         /* We shouldn't be writing to the controller's address (g_dev_addr).
          * There is no standard way to set the local public address, so this is

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -17,15 +17,10 @@
 #
 
 syscfg.defs:
-    BLE_DEVICE:
+    BLE_CONTROLLER:
         description: >
-            Used by package management system to include BLE hardware
-            drivers.
-        value: 1
-
-    BLE_LP_CLOCK:
-        description: >
-            Used by BSP packages to configure LP clock for controller.
+            Indicates that NimBLE controller is present. The default value for
+            this setting shall not be overriden.
         value: 1
 
     BLE_HW_WHITELIST_ENABLE:
@@ -302,6 +297,16 @@ syscfg.defs:
         description: >
             Sysinit stage for the NimBLE controller.
         value: 250
+
+# defunct settings (to be removed eventually)
+    BLE_DEVICE:
+        description: Superseded by BLE_CONTROLLER
+        value: 1
+        defunct: 1
+    BLE_LP_CLOCK:
+        description: Superseded by BLE_CONTROLLER
+        value: 1
+        defunct: 1
 
 syscfg.vals.BLE_LL_CFG_FEAT_LL_EXT_ADV:
     BLE_LL_CFG_FEAT_LE_CSA2: 1

--- a/nimble/host/src/ble_hs_hci_cmd.c
+++ b/nimble/host/src/ble_hs_hci_cmd.c
@@ -175,7 +175,7 @@ ble_hs_hci_cmd_body_le_set_adv_params(const struct hci_adv_params *adv,
 /* When build with nimBLE controller we know it is BT5 compliant so no need
  * to limit non-connectable advertising interval
  */
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
     itvl = BLE_HCI_ADV_ITVL_MIN;
 #else
     /* Make sure interval is valid for advertising type. */

--- a/nimble/host/src/ble_hs_startup.c
+++ b/nimble/host/src/ble_hs_startup.c
@@ -23,7 +23,7 @@
 #include "host/ble_hs_hci.h"
 #include "ble_hs_priv.h"
 
-#if !MYNEWT_VAL(BLE_DEVICE)
+#if !MYNEWT_VAL(BLE_CONTROLLER)
 static int
 ble_hs_startup_read_sup_f_tx(void)
 {
@@ -351,7 +351,7 @@ ble_hs_startup_go(void)
     /* XXX: Read local supported commands. */
 
     /* we need to check this only if using external controller */
-#if !MYNEWT_VAL(BLE_DEVICE)
+#if !MYNEWT_VAL(BLE_CONTROLLER)
     if (ble_hs_hci_get_hci_version() < BLE_HCI_VER_BCS_4_0) {
         BLE_HS_LOG(ERROR, "Required controller version is 4.0 (6)\n");
         return BLE_HS_ECONTROLLER;

--- a/nimble/host/util/src/addr.c
+++ b/nimble/host/util/src/addr.c
@@ -20,7 +20,7 @@
 #include "host/ble_hs.h"
 #include "host/util/util.h"
 
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
 #include "controller/ble_hw.h"
 #endif
 
@@ -31,7 +31,7 @@ ble_hs_util_load_rand_addr(ble_addr_t *addr)
      * is in the controller package.  A host-only device ought to be able to
      * automically restore a random address.
      */
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
     int rc;
 
     rc = ble_hw_get_static_addr(addr);

--- a/nimble/transport/socket/src/ble_hci_socket.c
+++ b/nimble/transport/socket/src/ble_hci_socket.c
@@ -344,7 +344,7 @@ ble_hci_sock_rx_msg(void)
 
     while (bhss->rx_off > 0) {
         switch (bhss->rx_data[0]) {
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
         case BLE_HCI_UART_H4_CMD:
             if (bhss->rx_off < BLE_HCI_CMD_HDR_LEN) {
                 return -1;

--- a/nimble/transport/uart/src/ble_hci_uart.c
+++ b/nimble/transport/uart/src/ble_hci_uart.c
@@ -53,7 +53,7 @@
  */
 
 /* XXX: for now, define this here */
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
 extern void ble_ll_data_buffer_overflow(void);
 extern void ble_ll_hw_error(uint8_t err);
 
@@ -193,7 +193,7 @@ ble_hci_trans_acl_buf_alloc(void)
     struct os_mbuf *m;
     uint8_t usrhdr_len;
 
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
     usrhdr_len = sizeof(struct ble_mbuf_hdr);
 #elif MYNEWT_VAL(BLE_HS_FLOW_CTRL)
     usrhdr_len = BLE_MBUF_HS_HDR_LEN;
@@ -387,7 +387,7 @@ ble_hci_uart_tx_char(void *arg)
     return rc;
 }
 
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
 /**
  * HCI uart sync lost.
  *
@@ -420,7 +420,7 @@ ble_hci_uart_rx_pkt_type(uint8_t data)
 
     switch (ble_hci_uart_state.rx_type) {
     /* Host should never receive a command! */
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
     case BLE_HCI_UART_H4_CMD:
         ble_hci_uart_state.rx_cmd.len = 0;
         ble_hci_uart_state.rx_cmd.cur = 0;
@@ -460,7 +460,7 @@ ble_hci_uart_rx_pkt_type(uint8_t data)
         break;
 
     default:
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
         /*
          * If we receive an unknown HCI packet type this is considered a loss
          * of sync.
@@ -479,7 +479,7 @@ ble_hci_uart_rx_pkt_type(uint8_t data)
     return 0;
 }
 
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
 /**
  * HCI uart sync loss.
  *
@@ -710,7 +710,7 @@ ble_hci_uart_rx_acl(uint8_t data)
          */
         if (pktlen > MYNEWT_VAL(BLE_ACL_BUF_SIZE)) {
             os_mbuf_free_chain(ble_hci_uart_state.rx_acl.buf);
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
             ble_hci_uart_sync_lost();
 #else
         /*
@@ -756,7 +756,7 @@ ble_hci_uart_rx_skip_acl(uint8_t data)
 
     if (rxd_bytes == ble_hci_uart_state.rx_acl.len) {
 /* XXX: I dont like this but for now this denotes controller only */
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
         ble_ll_data_buffer_overflow();
 #endif
         ble_hci_uart_state.rx_type = BLE_HCI_UART_H4_NONE;
@@ -769,7 +769,7 @@ ble_hci_uart_rx_char(void *arg, uint8_t data)
     switch (ble_hci_uart_state.rx_type) {
     case BLE_HCI_UART_H4_NONE:
         return ble_hci_uart_rx_pkt_type(data);
-#if MYNEWT_VAL(BLE_DEVICE)
+#if MYNEWT_VAL(BLE_CONTROLLER)
     case BLE_HCI_UART_H4_CMD:
         ble_hci_uart_rx_cmd(data);
         return 0;

--- a/porting/examples/linux/include/syscfg/syscfg.h
+++ b/porting/examples/linux/include/syscfg/syscfg.h
@@ -272,8 +272,8 @@
 #endif
 
 /*** net/nimble/controller */
-#ifndef MYNEWT_VAL_BLE_DEVICE
-#define MYNEWT_VAL_BLE_DEVICE (0)
+#ifndef MYNEWT_VAL_BLE_CONTROLLER
+#define MYNEWT_VAL_BLE_CONTROLLER (0)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_PUBLIC_DEV_ADDR

--- a/porting/examples/linux_blemesh/include/syscfg/syscfg.h
+++ b/porting/examples/linux_blemesh/include/syscfg/syscfg.h
@@ -272,8 +272,8 @@
 #endif
 
 /*** net/nimble/controller */
-#ifndef MYNEWT_VAL_BLE_DEVICE
-#define MYNEWT_VAL_BLE_DEVICE (0)
+#ifndef MYNEWT_VAL_BLE_CONTROLLER
+#define MYNEWT_VAL_BLE_CONTROLLER (0)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_PUBLIC_DEV_ADDR

--- a/porting/npl/riot/include/syscfg/syscfg.h
+++ b/porting/npl/riot/include/syscfg/syscfg.h
@@ -435,8 +435,8 @@
 #endif
 
 /*** nimble/controller */
-#ifndef MYNEWT_VAL_BLE_DEVICE
-#define MYNEWT_VAL_BLE_DEVICE (1)
+#ifndef MYNEWT_VAL_BLE_CONTROLLER
+#define MYNEWT_VAL_BLE_CONTROLLER (1)
 #endif
 
 /* Overridden by nimble/controller (defined by nimble/controller) */


### PR DESCRIPTION
BLE_CONTROLLER is a better name for its purpose.