### PR TITLE
npl/riot: fix ble_npl_hw_is_in_critical()

### DIFF
--- a/porting/npl/riot/include/nimble/nimble_npl_os.h
+++ b/porting/npl/riot/include/nimble/nimble_npl_os.h
@@ -38,6 +38,8 @@ extern "C" {
 typedef uint32_t ble_npl_time_t;
 typedef int32_t ble_npl_stime_t;
 
+extern volatile int ble_npl_in_critical;
+
 struct ble_npl_event {
     event_callback_t e;
     void *arg;
@@ -251,19 +253,27 @@ ble_npl_time_ticks_to_ms32(ble_npl_time_t ticks)
 static inline uint32_t
 ble_npl_hw_enter_critical(void)
 {
-    return (uint32_t)irq_disable();
+    uint32_t ctx = irq_disable();
+    ++ble_npl_in_critical;
+    return ctx;
 }
 
 static inline void
 ble_npl_hw_exit_critical(uint32_t ctx)
 {
+    --ble_npl_in_critical;
     irq_restore((unsigned)ctx);
 }
 
 static inline bool
 ble_npl_hw_is_in_critical(void)
 {
-    return irq_is_in();
+    /*
+     * XXX Currently RIOT does not support an API for finding out if interrupts
+     *     are currently disabled, hence in a critical section in this context.
+     *     So for now, we use this global variable to keep this state for us.
+    -*/
+    return (ble_npl_in_critical > 0);
 }
 
 #ifdef __cplusplus

--- a/porting/npl/riot/src/npl_os_riot.c
+++ b/porting/npl/riot/src/npl_os_riot.c
@@ -23,6 +23,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+volatile int ble_npl_in_critical = 0;
+
 static void
 _callout_fire(void *arg)
 {


### PR DESCRIPTION
fixes #364 (for now)

This is a RIOT specific workaround to make `ble_npl_hw_is_in_critical()` working properly. As there is no `irq_is_enabled()` function in RIOT (yet), this is achieved by keeping the critical section state manually. The run-time overhead should be tolerable, and hopefully we can fix this once we get the missing API call into RIOT.