### PR TITLE
controller: remove RIOT specific initialization hack

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1098,17 +1098,6 @@ ble_ll_task(void *arg)
 {
     struct ble_npl_event *ev;
 
-    /*
-     * XXX RIOT ties event queue to a thread which initialized it so we need to
-     * create event queue in LL task, not in general init function. This can
-     * lead to some races between host and LL so for now let us have it as a
-     * hack for RIOT where races can be avoided by proper initialization inside
-     * package.
-     */
-#ifdef RIOT_VERSION
-    ble_npl_eventq_init(&g_ble_ll_data.ll_evq);
-#endif
-
     /* Init ble phy */
     ble_phy_init();
 
@@ -1482,17 +1471,8 @@ ble_ll_init(void)
     lldata->ll_num_acl_pkts = MYNEWT_VAL(BLE_ACL_BUF_COUNT);
     lldata->ll_acl_pkt_size = MYNEWT_VAL(BLE_ACL_BUF_SIZE);
 
-    /*
-     * XXX RIOT ties event queue to a thread which initialized it so we need to
-     * create event queue in LL task, not in general init function. This can
-     * lead to some races between host and LL so for now let us have it as a
-     * hack for RIOT where races can be avoided by proper initialization inside
-     * package.
-     */
-#ifndef RIOT_VERSION
     /* Initialize eventq */
     ble_npl_eventq_init(&lldata->ll_evq);
-#endif
 
     /* Initialize the transmit (from host) and receive (from phy) queues */
     STAILQ_INIT(&lldata->ll_tx_pkt_q);

--- a/porting/npl/riot/include/nimble/nimble_npl_os.h
+++ b/porting/npl/riot/include/nimble/nimble_npl_os.h
@@ -77,7 +77,7 @@ ble_npl_get_current_task_id(void)
 static inline void
 ble_npl_eventq_init(struct ble_npl_eventq *evq)
 {
-    event_queue_init(&evq->q);
+    event_queue_init_detached(&evq->q);
 }
 
 static inline void
@@ -90,6 +90,10 @@ static inline struct ble_npl_event *
 ble_npl_eventq_get(struct ble_npl_eventq *evq, ble_npl_time_t tmo)
 {
     assert((tmo == 0) || (tmo == BLE_NPL_TIME_FOREVER));
+
+    if (evq->q.waiter == NULL) {
+        event_queue_claim(&evq->q);
+    }
 
     if (tmo == 0) {
         return (struct ble_npl_event *)event_get(&evq->q);


### PR DESCRIPTION
We finally added some additional functionality to RIOT's event queue implementation to allow for thread context independent event queue implementation. With this, there is no need anymore to treat the event queue initialization in the controller differently then for other ports.

Only caveat: the code now depends on the fact, that the first call to `ble_npl_eventq_get()` must be done from the thread's context, that is supposed to host the targeted event queue. But this should be always the case anyway, right?