### PR TITLE
nimble/sm: Fix bonding when key distribution is one-sided

### DIFF
--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -1590,11 +1590,12 @@ ble_sm_pair_cfg(struct ble_sm_proc *proc)
         proc->flags |= BLE_SM_PROC_F_BONDING;
     }
 
-    /* In legacy mode, bonding requires the exchange of keys.  If no key
-     * exchange was specified, pretend bonding is not enabled.
+    /* In legacy mode, bonding requires the exchange of keys
+     * at least from one side.  If no key exchange was specified,
+     * pretend bonding is not enabled.
      */
     if (!(proc->flags & BLE_SM_PROC_F_SC) &&
-        (init_key_dist == 0 || resp_key_dist == 0)) {
+        (init_key_dist == 0 && resp_key_dist == 0)) {
 
         proc->flags &= ~BLE_SM_PROC_F_BONDING;
     }


### PR DESCRIPTION
When using Legacy pairing, Nimble is a slave/responder and
the initiator set key distribution to 0 then our LTK would
not be stored and it wouldn't be possible to restore encryption later.

In legacy mode, bonding requires the exchange of keys at least
from one side.  If no key exchange was specified, pretend bonding
is not enabled.

This fixes SM/SLA/KDU/BV-07-C.