### PR TITLE
host: Free txq on connection free, not atomic del

### DIFF
--- a/nimble/host/src/ble_hs_atomic.c
+++ b/nimble/host/src/ble_hs_atomic.c
@@ -23,17 +23,10 @@ int
 ble_hs_atomic_conn_delete(uint16_t conn_handle)
 {
     struct ble_hs_conn *conn;
-    struct os_mbuf_pkthdr *omp;
 
     ble_hs_lock();
     conn = ble_hs_conn_find(conn_handle);
     if (conn != NULL) {
-
-        while ((omp = STAILQ_FIRST(&conn->bhc_tx_q)) != NULL) {
-            STAILQ_REMOVE_HEAD(&conn->bhc_tx_q, omp_next);
-            os_mbuf_free_chain(OS_MBUF_PKTHDR_TO_MBUF(omp));
-        }
-
         ble_hs_conn_remove(conn);
         ble_hs_conn_free(conn);
 

--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -207,6 +207,7 @@ ble_hs_conn_free(struct ble_hs_conn *conn)
 #endif
 
     struct ble_l2cap_chan *chan;
+    struct os_mbuf_pkthdr *omp;
     int rc;
 
     if (conn == NULL) {
@@ -217,6 +218,11 @@ ble_hs_conn_free(struct ble_hs_conn *conn)
 
     while ((chan = SLIST_FIRST(&conn->bhc_channels)) != NULL) {
         ble_hs_conn_delete_chan(conn, chan);
+    }
+
+    while ((omp = STAILQ_FIRST(&conn->bhc_tx_q)) != NULL) {
+        STAILQ_REMOVE_HEAD(&conn->bhc_tx_q, omp_next);
+        os_mbuf_free_chain(OS_MBUF_PKTHDR_TO_MBUF(omp));
     }
 
 #if MYNEWT_VAL(BLE_HS_DEBUG)


### PR DESCRIPTION
This PR just moves a bit of code from one function to another. Previously, a connection's transmit queue was freed in `ble_hs_atomic_conn_delete()`.  This operation is more logically placed in the more "leaf" function `ble_hs_conn_free()`.