### PR TITLE
nimble/host: Fix handling no memory for sending ACL data fragmets

### DIFF
--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -463,8 +463,8 @@ ble_hs_hci_acl_tx_now(struct ble_hs_conn *conn, struct os_mbuf **om)
         frag = mem_split_frag(&txom, ble_hs_hci_max_acl_payload_sz(),
                               ble_hs_hci_frag_alloc, NULL);
         if (frag == NULL) {
-            rc = BLE_HS_ENOMEM;
-            goto err;
+            *om = txom;
+            return BLE_HS_EAGAIN;
         }
 
         frag = ble_hs_hci_acl_hdr_prepend(frag, conn->bhc_handle, pb);


### PR DESCRIPTION
When host has no memory for sending ACL fragment it should not free the
mbuf but instead put packet in the queue.

It is very important espacially in case when there were already some
fragments sent and packet continuation is required