### PR TITLE
linux: fix for btvirt controller emulator.

### DIFF
--- a/nimble/host/src/ble_hs_startup.c
+++ b/nimble/host/src/ble_hs_startup.c
@@ -301,6 +301,8 @@ ble_hs_startup_set_evmask_tx(void)
         return rc;
     }
 
+    /* Do not send this to btvirt virtual external controller. */
+#if MYNEWT_VAL(BLE_CONTROLLER)
     if (version >= BLE_HCI_VER_BCS_4_1) {
         /**
          * Enable the following events:
@@ -314,6 +316,9 @@ ble_hs_startup_set_evmask_tx(void)
             return rc;
         }
     }
+#else
+    (void)version;
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Resolve lock-up issue when using simulated hci interfaces from bluez (btvirt).