### PR TITLE
nimble/host: Register a 1-elem mbuf pool for ACL; prevents possible deadlock

### DIFF
--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -440,6 +440,24 @@ ble_hs_hci_frag_alloc(uint16_t frag_size, void *arg)
     return NULL;
 }
 
+/**
+ * Retrieves the total capacity of the ACL fragment pool (always 1).
+ */
+int
+ble_hs_hci_frag_num_mbufs(void)
+{
+    return ble_hs_hci_frag_mempool.mp_num_blocks;
+}
+
+/**
+ * Retrieves the the count of free buffers in the ACL fragment pool.
+ */
+int
+ble_hs_hci_frag_num_mbufs_free(void)
+{
+    return ble_hs_hci_frag_mempool.mp_num_free;
+}
+
 static struct os_mbuf *
 ble_hs_hci_acl_hdr_prepend(struct os_mbuf *om, uint16_t handle,
                            uint8_t pb_flag)

--- a/nimble/host/src/ble_hs_hci_priv.h
+++ b/nimble/host/src/ble_hs_hci_priv.h
@@ -262,6 +262,9 @@ int ble_hs_hci_cmd_build_le_set_phy(uint16_t conn_handle, uint8_t tx_phys_mask,
                                     uint8_t rx_phys_mask, uint16_t phy_opts,
                                     uint8_t *dst, int dst_len);
 
+int ble_hs_hci_frag_num_mbufs(void);
+int ble_hs_hci_frag_num_mbufs_free(void);
+
 #if MYNEWT_VAL(BLE_EXT_ADV)
 #endif
 

--- a/nimble/host/test/src/ble_hs_test_util.c
+++ b/nimble/host/test/src/ble_hs_test_util.c
@@ -1738,6 +1738,18 @@ ble_hs_test_util_mbuf_chain_len(const struct os_mbuf *om)
     return count;
 }
 
+static int
+ble_hs_test_util_num_mbufs(void)
+{
+    return os_msys_count() + ble_hs_hci_frag_num_mbufs();
+}
+
+static int
+ble_hs_test_util_num_mbufs_free(void)
+{
+    return os_msys_num_free() + ble_hs_hci_frag_num_mbufs_free();
+}
+
 struct os_mbuf *
 ble_hs_test_util_mbuf_alloc_all_but(int count)
 {
@@ -1787,7 +1799,7 @@ ble_hs_test_util_mbuf_count(const struct ble_hs_test_util_mbuf_params *params)
 
     ble_hs_process_rx_data_queue();
 
-    count = os_msys_num_free();
+    count = ble_hs_test_util_num_mbufs_free();
 
     if (params->prev_tx) {
         count += ble_hs_test_util_mbuf_chain_len(ble_hs_test_util_prev_tx_cur);
@@ -1838,7 +1850,7 @@ ble_hs_test_util_assert_mbufs_freed(
     }
 
     count = ble_hs_test_util_mbuf_count(params);
-    TEST_ASSERT(count == os_msys_count());
+    TEST_ASSERT(count == ble_hs_test_util_num_mbufs());
 }
 
 static int

--- a/nimble/include/nimble/ble.h
+++ b/nimble/include/nimble/ble.h
@@ -35,6 +35,9 @@ extern "C" {
 /* BLE encryption block definitions */
 #define BLE_ENC_BLOCK_SIZE       (16)
 
+/* 4 byte header + 251 byte payload. */
+#define BLE_ACL_MAX_PKT_SIZE     255
+
 struct ble_encryption_block
 {
     uint8_t     key[BLE_ENC_BLOCK_SIZE];


### PR DESCRIPTION
Register a one-element mbuf pool dedicated to holding outgoing ACL data packets.  This dedicated pool prevents a deadlock caused by mbuf exhaustion.  Without this pool, all msys mbufs could be permanently allocated, preventing us from fragmenting outgoing packets and sending them (and ultimately freeing them).

When the host fragments an outgoing data packet, it first tries to allocate the fragment using the new pool.  If this fails (because the single mbuf has already been sent to the controller), the host falls back to using msys.