### PR TITLE
BLE: configurable stack size

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -215,17 +215,9 @@ static void ble_ll_event_dbuf_overflow(struct ble_npl_event *ev);
 
 #if MYNEWT
 
-/* The BLE LL task data structure */
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-/* TODO: This is for testing. Check it we really need it */
-#define BLE_LL_STACK_SIZE   (128)
-#else
-#define BLE_LL_STACK_SIZE   (90)
-#endif
-
 struct os_task g_ble_ll_task;
 
-OS_TASK_STACK_DEFINE(g_ble_ll_stack, BLE_LL_STACK_SIZE);
+OS_TASK_STACK_DEFINE(g_ble_ll_stack, MYNEWT_VAL(BLE_LL_STACK_SIZE));
 
 #endif /* MYNEWT */
 
@@ -1563,7 +1555,7 @@ ble_ll_init(void)
     /* Initialize the LL task */
     os_task_init(&g_ble_ll_task, "ble_ll", ble_ll_task, NULL,
                  MYNEWT_VAL(BLE_LL_PRIO), OS_WAIT_FOREVER, g_ble_ll_stack,
-                 BLE_LL_STACK_SIZE);
+                 MYNEWT_VAL(BLE_LL_STACK_SIZE));
 #else
 
 /*

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -308,10 +308,18 @@ syscfg.defs:
         value: 1
         defunct: 1
 
+    BLE_LL_STACK_SIZE:
+        description: >
+            BLE stack size. Can be reconfigured
+            if BLE_LL_CFG_FEAT_LL_EXT_ADV
+            (see syscfg.vals.BLE_LL_CFG_FEAT_LL_EXT_ADV below)
+        value: 90
+
 syscfg.vals.BLE_LL_CFG_FEAT_LL_EXT_ADV:
     BLE_LL_CFG_FEAT_LE_CSA2: 1
     BLE_HW_WHITELIST_ENABLE: 0
     BLE_LL_EXT_ADV_AUX_PTR_CNT: 5
+    BLE_LL_STACK_SIZE: 128
 
 # Enable vendor event on assert in standalone build to make failed assertions in
 # controller code visible when connected to external host


### PR DESCRIPTION
Changing the BLE stack size from a #define to a syscfg.
We want this to be configurable.