### PR TITLE
nimble/ll: Remove DTM event from queue before erasing context

### DIFF
--- a/nimble/controller/src/ble_ll_dtm.c
+++ b/nimble/controller/src/ble_ll_dtm.c
@@ -427,6 +427,7 @@ ble_ll_dtm_ctx_free(struct dtm_ctx * ctx)
     OS_EXIT_CRITICAL(sr);
 
     ble_ll_sched_rmv_elem(&ctx->sch);
+    ble_npl_eventq_remove(&g_ble_ll_data.ll_evq, &g_ble_ll_dtm_ctx.evt);
 
     ble_phy_disable();
     ble_phy_disable_dtm();


### PR DESCRIPTION
If event is already queued, we should remove it from queue before
erasing context as otherwise callback and link will be removed which
leads to a crash when event is run,