### PR TITLE
nimble/hw: Fix compilation of nrf51 driver

### DIFF
--- a/nimble/drivers/nrf51/src/ble_hw.c
+++ b/nimble/drivers/nrf51/src/ble_hw.c
@@ -60,14 +60,19 @@ uint8_t g_nrf_num_irks;
 int
 ble_hw_get_public_addr(ble_addr_t *addr)
 {
+    uint32_t addr_high;
+    uint32_t addr_low;
+
     /* Does FICR have a public address */
     if ((NRF_FICR->DEVICEADDRTYPE & 1) != 0) {
         return -1;
     }
 
     /* Copy into device address. We can do this because we know platform */
-    memcpy(addr->val, &NRF_FICR->DEVICEADDR[0], 4);
-    memcpy(&addr->val[4], &NRF_FICR->DEVICEADDR[1], 2);
+    addr_low = NRF_FICR->DEVICEADDR[0];
+    addr_high = NRF_FICR->DEVICEADDR[1];
+    memcpy(addr->val, &addr_low, 4);
+    memcpy(&addr->val[4], &addr_high, 2);
     addr->type = BLE_ADDR_PUBLIC;
 
     return 0;


### PR DESCRIPTION
Compiling repos/apache-mynewt-nimble/nimble/drivers/nrf51/src/ble_hw.c
Error: repos/apache-mynewt-nimble/nimble/drivers/nrf51/src/ble_hw.c: In function 'ble_hw_get_public_addr':
repos/apache-mynewt-nimble/nimble/drivers/nrf51/src/ble_hw.c:69:23: error: passing argument 2 of 'memcpy'
     discards 'volatile' qualifier from pointer target type [-Werror=discarded-qualifiers]
     memcpy(addr->val, &NRF_FICR->DEVICEADDR[0], 4);
                       ^
In file included from repos/apache-mynewt-nimble/nimble/drivers/nrf51/src/ble_hw.c:22:0:
repos/apache-mynewt-core/libc/baselibc/include/string.h:19:16: note: expected 'const void *' but argument is
     of type 'const volatile uint32_t * {aka const volatile long unsigned int *}'
 __extern void *memcpy(void *, const void *, size_t);
                ^~~~~~
repos/apache-mynewt-nimble/nimble/drivers/nrf51/src/ble_hw.c:70:27: error: passing argument 2 of 'memcpy'
     discards 'volatile' qualifier from pointer target type [-Werror=discarded-qualifiers]
     memcpy(&addr->val[4], &NRF_FICR->DEVICEADDR[1], 2);
                           ^
In file included from repos/apache-mynewt-nimble/nimble/drivers/nrf51/src/ble_hw.c:22:0:
repos/apache-mynewt-core/libc/baselibc/include/string.h:19:16: note: expected 'const void *' but argument is
     of type 'const volatile uint32_t * {aka const volatile long unsigned int *}'
 __extern void *memcpy(void *, const void *, size_t);
                ^~~~~~