### PR TITLE
nimble/hw: Apply #102 #106 and #107 erratas also for nRF52840

### DIFF
--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -245,7 +245,6 @@ struct nrf_ccm_data
 struct nrf_ccm_data g_nrf_ccm_data;
 #endif
 
-#ifdef NRF52
 static void
 ble_phy_apply_errata_102_106_107(void)
 {
@@ -256,7 +255,6 @@ ble_phy_apply_errata_102_106_107(void)
     *(volatile uint32_t *)0x40001774 = ((*(volatile uint32_t *)0x40001774) &
                          0xfffffffe) | 0x01000000;
 }
-#endif
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
 
@@ -1842,9 +1840,7 @@ ble_phy_set_access_addr(uint32_t access_addr)
 
     g_ble_phy_data.phy_access_address = access_addr;
 
-#ifdef NRF52
     ble_phy_apply_errata_102_106_107();
-#endif
 
     return 0;
 }


### PR DESCRIPTION
Although Nordic's infocenter claims this is fixed in final build of
nRF52840, LL/ENC/MAS/BI-01-C was failing without enabling those.