### PR TITLE
nimble/hci: Modifying ACL Buf size based on BLE 5.1 Standard

### DIFF
--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -407,13 +407,17 @@ ble_hs_hci_rx_evt(uint8_t *hci_ev, void *arg)
 }
 
 /**
- * Calculates the largest ACL payload that the controller can accept.  This is
- * everything in an ACL data packet except for the ACL header.
+ * Calculates the largest ACL payload that the controller can accept.
  */
 static uint16_t
 ble_hs_hci_max_acl_payload_sz(void)
 {
-    return ble_hs_hci_buf_sz - BLE_HCI_DATA_HDR_SZ;
+    /* As per BLE 5.1 Standard, Vol. 2, Part E, section 7.8.2:
+     * The LE_Read_Buffer_Size command is used to read the maximum size of the
+     * data portion of HCI LE ACL Data Packets sent from the Host to the
+     * Controller.
+     */
+    return ble_hs_hci_buf_sz;
 }
 
 /**

--- a/nimble/host/test/src/ble_hs_hci_test.c
+++ b/nimble/host/test/src/ble_hs_hci_test.c
@@ -103,8 +103,8 @@ TEST_CASE_SELF(ble_hs_hci_acl_one_conn)
 
     ble_hs_test_util_init();
 
-    /* The controller has room for five 20-byte payloads (+ 4-byte header). */
-    rc = ble_hs_hci_set_buf_sz(24, 5);
+    /* The controller has room for five 20-byte payloads. */
+    rc = ble_hs_hci_set_buf_sz(20, 5);
     TEST_ASSERT_FATAL(rc == 0);
     TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 5);
 
@@ -191,8 +191,8 @@ TEST_CASE_SELF(ble_hs_hci_acl_two_conn)
 
     ble_hs_test_util_init();
 
-    /* The controller has room for five 20-byte payloads (+ 4-byte header). */
-    rc = ble_hs_hci_set_buf_sz(24, 5);
+    /* The controller has room for five 20-byte payloads*/
+    rc = ble_hs_hci_set_buf_sz(20, 5);
     TEST_ASSERT_FATAL(rc == 0);
     TEST_ASSERT_FATAL(ble_hs_hci_avail_pkts == 5);
 

--- a/nimble/host/test/src/ble_hs_test_util_hci.c
+++ b/nimble/host/test/src/ble_hs_test_util_hci.c
@@ -547,8 +547,6 @@ ble_hs_test_util_hci_rx_num_completed_pkts_event(
     for (i = 0; i < num_entries; i++) {
         put_le16(buf + off, entries[i].handle_id);
         off += 2;
-    }
-    for (i = 0; i < num_entries; i++) {
         put_le16(buf + off, entries[i].num_pkts);
         off += 2;
     }


### PR DESCRIPTION
As per BLE 5.1 Standard, Vol. 2, Part E, section 7.8.2:
The LE_Read_Buffer_Size command is used to read the maximum size of the
data portion of HCI LE ACL Data Packets sent from the Host to the Controller.
