### PR TITLE
host: Wake up stalled conns when a conn is dropped

### DIFF
--- a/nimble/host/src/ble_hs_hci_evt.c
+++ b/nimble/host/src/ble_hs_hci_evt.c
@@ -166,6 +166,12 @@ ble_hs_hci_evt_disconn_complete(uint8_t event_code, uint8_t *data, int len)
 
     ble_gap_rx_disconn_complete(&evt);
 
+    /* The connection termination may have freed up some capacity in the
+     * controller for additional ACL data packets.  Wake up any stalled
+     * connections.
+     */
+    ble_hs_wakeup_tx();
+
     return 0;
 }
 


### PR DESCRIPTION
When a connection is dropped, it may free up some ACL packet capacity in the controller.  When this happens, we need to wake up all stalled connections.

We want to wake up connections every time the ACL data buffer capcity increases (whenever `ble_hs_hci_add_avail_pkts()` is called).