### PR TITLE
nimble/host: Replace chr_def_handle with chr_val_handle

### DIFF
--- a/apps/blecent/src/peer.c
+++ b/apps/blecent/src/peer.c
@@ -55,7 +55,7 @@ peer_disc_chrs(struct peer *peer);
 
 static int
 peer_dsc_disced(uint16_t conn_handle, const struct ble_gatt_error *error,
-                uint16_t chr_def_handle, const struct ble_gatt_dsc *dsc,
+                uint16_t chr_val_handle, const struct ble_gatt_dsc *dsc,
                 void *arg);
 
 static struct peer *

--- a/apps/bttester/src/gatt.c
+++ b/apps/bttester/src/gatt.c
@@ -1252,7 +1252,7 @@ fail:
 
 static int disc_all_desc_cb(uint16_t conn_handle,
 			    const struct ble_gatt_error *error,
-			    uint16_t chr_def_handle,
+			    uint16_t chr_val_handle,
 			    const struct ble_gatt_dsc *gatt_dsc,
 			    void *arg)
 {

--- a/nimble/host/include/host/ble_gatt.h
+++ b/nimble/host/include/host/ble_gatt.h
@@ -143,7 +143,7 @@ typedef int ble_gatt_chr_fn(uint16_t conn_handle,
 
 typedef int ble_gatt_dsc_fn(uint16_t conn_handle,
                             const struct ble_gatt_error *error,
-                            uint16_t chr_def_handle,
+                            uint16_t chr_val_handle,
                             const struct ble_gatt_dsc *dsc,
                             void *arg);
 
@@ -790,9 +790,9 @@ int ble_gatts_count_cfg(const struct ble_gatt_svc_def *defs);
  * Send notification (or indication) to any connected devices that have
  * subscribed for notification (or indication) for specified characteristic.
  *
- * @param chr_def_handle        Characteristic definition handle
+ * @param chr_val_handle        Characteristic value handle
  */
-void ble_gatts_chr_updated(uint16_t chr_def_handle);
+void ble_gatts_chr_updated(uint16_t chr_val_handle);
 
 /**
  * Retrieves the attribute handle associated with a local GATT service.

--- a/nimble/host/test/src/ble_gatt_conn_test.c
+++ b/nimble/host/test/src/ble_gatt_conn_test.c
@@ -202,7 +202,7 @@ ble_gatt_conn_test_disc_chr_uuid_cb(uint16_t conn_handle,
 static int
 ble_gatt_conn_test_disc_all_dscs_cb(uint16_t conn_handle,
                                     const struct ble_gatt_error *error,
-                                    uint16_t chr_def_handle,
+                                    uint16_t chr_val_handle,
                                     const struct ble_gatt_dsc *dsc,
                                     void *arg)
 {


### PR DESCRIPTION
At some places for APIs ble_gatt_dsc_fn() and ble_gatts_chr_updated(), chr_val_handle was used and at other places chr_def_handle was used. Changed it uniformly with the right one to avoid confusion