### PR TITLE
nimble/gap: Add missing ble_gap_event_listener_call() call

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -5175,6 +5175,7 @@ ble_gap_notify_rx_event(uint16_t conn_handle, uint16_t attr_handle,
     event.notify_rx.attr_handle = attr_handle;
     event.notify_rx.om = om;
     event.notify_rx.indication = is_indication;
+    ble_gap_event_listener_call(&event);
     ble_gap_call_conn_event_cb(&event, conn_handle);
 
     os_mbuf_free_chain(event.notify_rx.om);


### PR DESCRIPTION
calling gap event listener when receiving notification/indication