### PR TITLE
apps/bttester: Remove ARRAY_SIZE macro

### DIFF
--- a/apps/bttester/src/glue.h
+++ b/apps/bttester/src/glue.h
@@ -36,8 +36,6 @@
 
 #define sys_le16_to_cpu le16toh
 
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
-
 struct bt_data {
     u8_t type;
     u8_t data_len;


### PR DESCRIPTION
It is already defined in Mynewt.