### PR TITLE
nimble/l2cap: Add TX_UNSTALLED event to L2CAP CoC

### DIFF
--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -2023,6 +2023,10 @@ btshell_l2cap_event(struct ble_l2cap_event *event, void *arg)
         case BLE_L2CAP_EVENT_COC_DATA_RECEIVED:
             btshell_l2cap_coc_recv(event->receive.chan, event->receive.sdu_rx);
             return 0;
+        case BLE_L2CAP_EVENT_COC_TX_UNSTALLED:
+            console_printf("L2CAP CoC channel %p unstalled, last sdu sent with err=0x%02x\n",
+                            event->tx_unstalled.chan, event->tx_unstalled.status);
+            return 0;
         default:
             return 0;
     }

--- a/nimble/host/include/host/ble_hs.h
+++ b/nimble/host/include/host/ble_hs.h
@@ -94,6 +94,7 @@ extern "C" {
 #define BLE_HS_ESTORE_FAIL          28
 #define BLE_HS_EPREEMPTED           29
 #define BLE_HS_EDISABLED            30
+#define BLE_HS_ESTALLED             31
 
 /** Error base for ATT errors */
 #define BLE_HS_ERR_ATT_BASE         0x100

--- a/nimble/host/include/host/ble_l2cap.h
+++ b/nimble/host/include/host/ble_l2cap.h
@@ -75,6 +75,7 @@ struct ble_hs_conn;
 #define BLE_L2CAP_EVENT_COC_DISCONNECTED              1
 #define BLE_L2CAP_EVENT_COC_ACCEPT                    2
 #define BLE_L2CAP_EVENT_COC_DATA_RECEIVED             3
+#define BLE_L2CAP_EVENT_COC_TX_UNSTALLED              4
 
 typedef void ble_l2cap_sig_update_fn(uint16_t conn_handle, int status,
                                      void *arg);
@@ -173,6 +174,28 @@ struct ble_l2cap_event {
             /** The mbuf with received SDU. */
             struct os_mbuf *sdu_rx;
         } receive;
+
+        /**
+         * Represents tx_unstalled data. Valid for the following event
+         * types:
+         *     o BLE_L2CAP_EVENT_COC_TX_UNSTALLED
+         */
+        struct {
+            /** Connection handle of the relevant connection */
+            uint16_t conn_handle;
+
+            /** The L2CAP channel of the relevant L2CAP connection. */
+            struct ble_l2cap_chan *chan;
+
+            /**
+             * The status of the send attempt which was stalled due to
+             * lack of credits; This can be non zero only if there
+             * is an issue with memory allocation for following SDU fragments.
+             * In such a case last SDU has been partially sent to peer device
+             * and it is up to application to decide how to handle it.
+             */
+            int status;
+        } tx_unstalled;
     };
 };
 

--- a/nimble/host/src/ble_l2cap_coc_priv.h
+++ b/nimble/host/src/ble_l2cap_coc_priv.h
@@ -35,11 +35,14 @@ extern "C" {
 
 struct ble_l2cap_chan;
 
+#define BLE_L2CAP_COC_FLAG_STALLED              0x01
+
 struct ble_l2cap_coc_endpoint {
+    struct os_mbuf *sdu;
     uint16_t mtu;
     uint16_t credits;
     uint16_t data_offset;
-    struct os_mbuf *sdu;
+    uint8_t flags;
 };
 
 struct ble_l2cap_coc_srv {

--- a/nimble/host/test/src/ble_l2cap_test.c
+++ b/nimble/host/test/src/ble_l2cap_test.c
@@ -736,6 +736,9 @@ ble_l2cap_test_event(struct ble_l2cap_event *event, void *arg)
                                     OS_MBUF_PKTLEN(event->receive.sdu_rx));
         TEST_ASSERT(memcmp(sdu_rx->om_data, ev->data, ev->data_len) == 0);
         return 0;
+    case BLE_L2CAP_EVENT_COC_TX_UNSTALLED:
+        /* TODO Add tests for this */
+        return 0;
     default:
         return 0;
     }


### PR DESCRIPTION
    nimble/l2cap: Add TX_UNSTALLED event to L2CAP CoC
    
    With this patch if L2CAP CoC has been stalled due to lack of credits
    BLE_HS_ESTALLED code will be returned.
    
    When NimBLE gets back credits and finish sending SDU,
    BLE_L2CAP_EVENT_COC_TX_UNSTALLED will be sent to the application as the
    indication that L2CAP CoC is unstalled and ready for sending new data..