### PR TITLE
Fix copying CI targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,7 @@ before_script:
   - gcc --version
   - if [ "${TEST}" != "TEST_ALL" ]; then arm-none-eabi-gcc --version; fi
   - cp -R $HOME/ci/mynewt-nimble-project.yml project.yml
+  - mkdir -p targets
   - cp -R $HOME/ci/mynewt-nimble-targets targets
   - $HOME/ci/prepare_test.sh $VM_AMOUNT
   - mkdir -p repos && pushd repos/


### PR DESCRIPTION
CI currently expects target tree inside targets directory and uses a hardcoded path. The targets directory might not exist on some of the repos tested, so create it first here. CI will be updated to use the repo slug to determine which repo's targets it should build.