### PR TITLE
nimble/gap: Remove extended Adv when receive adv_set_terminate event from LL.

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -2523,12 +2523,6 @@ ble_gap_ext_adv_configure(uint8_t instance,
 
     ble_hs_lock();
 
-    /* TODO should we allow to reconfigure existing instance? */
-    if (ble_gap_slave[instance].configured) {
-        ble_hs_unlock();
-        return ENOMEM;
-    }
-
     rc = ble_gap_ext_adv_params_tx(instance, params, selected_tx_power);
     if (rc) {
         ble_hs_unlock();

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -1291,6 +1291,9 @@ ble_gap_rx_adv_set_terminated(struct hci_le_adv_set_terminated *evt)
 
     ble_gap_adv_finished(evt->adv_handle, reason, conn_handle,
                          evt->completed_events);
+
+    /* Remove ble_gap_slave instance */
+    memset(&ble_gap_slave[instance], 0, sizeof(struct ble_gap_slave_state));
 }
 #endif
 


### PR DESCRIPTION
In case we are using extended advertising, we have to remove extended adv instance (Initialize it to zero) whenever host receive adv_set_terminated event.
This will make us avoid issues like configuring the same instance to work with random address, but will not set the random address when enabling it because rnd_addr_set will be 1 in this case from the previous configuration.
Controller will send an error in this case, based on BLE5.1 standard Vol2, Part E, Sec 7.8.56 as following

"If the advertising set's Own_Address_Type parameter is set to 0x01 and the
random address for the advertising set has not been initialized, the Controller
shall return the error code Invalid HCI Command Parameters (0x12)."
