### PR TITLE
apps: Fix bootutils dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,8 @@ before_script:
   - cp -R $HOME/ci/mynewt-nimble-targets targets
   - $HOME/ci/prepare_test.sh $VM_AMOUNT
   - mkdir -p repos && pushd repos/
-  - git clone https://github.com/apache/mynewt-core apache-mynewt-core
+  - git clone --depth=1 https://github.com/apache/mynewt-core apache-mynewt-core
+  - git clone --depth=1 https://github.com/JuulLabs-OSS/mcuboot mcuboot
   - popd
 
 script:

--- a/apps/blecsc/pkg.yml
+++ b/apps/blecsc/pkg.yml
@@ -25,7 +25,6 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - "@apache-mynewt-core/boot/bootutil"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"

--- a/apps/blehr/pkg.yml
+++ b/apps/blehr/pkg.yml
@@ -25,7 +25,6 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - "@apache-mynewt-core/boot/bootutil"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"

--- a/apps/bleprph/pkg.yml
+++ b/apps/bleprph/pkg.yml
@@ -24,7 +24,7 @@ pkg.keywords:
 
 pkg.deps:
     - "@apache-mynewt-core/boot/split"
-    - "@apache-mynewt-core/boot/bootutil"
+    - "@mcuboot/boot/bootutil"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/mgmt/imgmgr"
     - "@apache-mynewt-core/mgmt/newtmgr"

--- a/apps/bleprph/syscfg.yml
+++ b/apps/bleprph/syscfg.yml
@@ -45,7 +45,7 @@ syscfg.vals:
     BLE_ROLE_PERIPHERAL: 1
 
     # Configure DIS
-    BLE_SVC_DIS_FIRMWARE_REVISION_READ_PERM: 0
+    BLE_SVC_DIS_FIRMWARE_REVISION_READ_PERM: 1
 
     # Log reboot messages to a flash circular buffer.
     REBOOT_LOG_FCB: 1

--- a/apps/ext_advertiser/pkg.yml
+++ b/apps/ext_advertiser/pkg.yml
@@ -32,7 +32,6 @@ pkg.deps:
     - nimble/host/services/gatt
     - nimble/host/store/config
     - nimble/transport/ram
-    - "@apache-mynewt-core/boot/bootutil"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"


### PR DESCRIPTION
Some applications were polling bootutils even if not using it.
bleprph is using it for DIS information so depend on mcuboot instead
and enable DIS by default.