### PR TITLE
nimble/host: Fix HCI fragmentation buffer size

### DIFF
--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -41,6 +41,7 @@ static uint8_t ble_hs_hci_version;
 
 #define BLE_HS_HCI_FRAG_DATABUF_SIZE    \
     (BLE_ACL_MAX_PKT_SIZE +             \
+     BLE_HCI_DATA_HDR_SZ +              \
      sizeof (struct os_mbuf_pkthdr) +   \
      sizeof (struct os_mbuf))
 


### PR DESCRIPTION
This patch fixes a regression introduced in:
4a894678 nimble/hci: Modifying ACL Buf size based on BLE 5.1 Standard

and is related to:
2bd8de56 nimble/host: Register a 1-elem mbuf pool for ACL

After adding a dedicated mbuf pool for HCI fragmentation
and changing the ACL buffer size, the fragmentation data buffer
size was too small to hold full ACL buffer including HCI header.