### PR TITLE
drivers/nrf51: make it RIOT compatible

### DIFF
--- a/nimble/drivers/nrf51/src/ble_hw.c
+++ b/nimble/drivers/nrf51/src/ble_hw.c
@@ -27,7 +27,13 @@
 #include "nimble/nimble_opt.h"
 #include "nrfx.h"
 #include "controller/ble_hw.h"
+#if MYNEWT
 #include "mcu/cmsis_nvic.h"
+#else
+#include "core_cm0.h"
+#include <nimble/nimble_npl_os.h>
+#endif
+#include "os/os_trace_api.h"
 
 /* Total number of resolving list elements */
 #define BLE_HW_RESOLV_LIST_SIZE     (16)
@@ -309,7 +315,11 @@ ble_hw_rng_init(ble_rng_isr_cb_t cb, int bias)
     /* If we were passed a function pointer we need to enable the interrupt */
     if (cb != NULL) {
         NVIC_SetPriority(RNG_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+#if MYNEWT
         NVIC_SetVector(RNG_IRQn, (uint32_t)ble_rng_isr);
+#else
+        ble_npl_hw_set_isr(RNG_IRQn, ble_rng_isr);
+#endif
         NVIC_EnableIRQ(RNG_IRQn);
         g_ble_rng_isr_cb = cb;
     }

--- a/nimble/drivers/nrf51/src/ble_hw.c
+++ b/nimble/drivers/nrf51/src/ble_hw.c
@@ -66,14 +66,19 @@ uint8_t g_nrf_num_irks;
 int
 ble_hw_get_public_addr(ble_addr_t *addr)
 {
+    uint32_t addr_high;
+    uint32_t addr_low;
+
     /* Does FICR have a public address */
     if ((NRF_FICR->DEVICEADDRTYPE & 1) != 0) {
         return -1;
     }
 
     /* Copy into device address. We can do this because we know platform */
-    memcpy(addr->val, &NRF_FICR->DEVICEADDR[0], 4);
-    memcpy(&addr->val[4], &NRF_FICR->DEVICEADDR[1], 2);
+    addr_low = NRF_FICR->DEVICEADDR[0];
+    addr_high = NRF_FICR->DEVICEADDR[1];
+    memcpy(addr->val, &addr_low, 4);
+    memcpy(&addr->val[4], &addr_high, 2);
     addr->type = BLE_ADDR_PUBLIC;
 
     return 0;

--- a/nimble/drivers/nrf51/src/ble_phy.c
+++ b/nimble/drivers/nrf51/src/ble_phy.c
@@ -23,7 +23,6 @@
 #include "syscfg/syscfg.h"
 #include "os/os.h"
 #include "ble/xcvr.h"
-#include "mcu/cmsis_nvic.h"
 #include "nimble/ble.h"
 #include "nimble/nimble_opt.h"
 #include "controller/ble_phy.h"
@@ -33,6 +32,9 @@
 
 #if MYNEWT
 #include "mcu/nrf51_clock.h"
+#include "mcu/cmsis_nvic.h"
+#else
+#include "core_cm0.h"
 #endif
 
 /* XXX: 4) Make sure RF is higher priority interrupt than schedule */
@@ -907,7 +909,11 @@ ble_phy_init(void)
 
     /* Set isr in vector table and enable interrupt */
     NVIC_SetPriority(RADIO_IRQn, 0);
+#if MYNEWT
     NVIC_SetVector(RADIO_IRQn, (uint32_t)ble_phy_isr);
+#else
+    ble_npl_hw_set_isr(RADIO_IRQn, ble_phy_isr);
+#endif
     NVIC_EnableIRQ(RADIO_IRQn);
 
     /* Register phy statistics */


### PR DESCRIPTION
This PR is adapting the nrf51 driver part to make it RIOT compatible:
- apply the same preprocessor macro conditionals use with nrf52 driver
- fix an issue with a discarded volatile qualifier