### PR TITLE
ble_mesh_light/ws2812: Only compile if USE_NEOPIXEL is set to 1

### DIFF
--- a/apps/blemesh_light/src/ws2812.c
+++ b/apps/blemesh_light/src/ws2812.c
@@ -16,6 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+ 
+#include "syscfg/syscfg.h"
+
+#if (MYNEWT_VAL(USE_NEOPIXEL))
 
 #include <assert.h>
 #include <string.h>
@@ -131,3 +135,4 @@ ws2812_write(const uint32_t *rgb)
 
     return 0;
 }
+#endif


### PR DESCRIPTION
Only compile ws2812.c if USE_NEOPIXEL is set to 1. Without this builds for platforms other than NRFx fail even when USE_NEOPIXEL is set to 0 due to inclusion of NRFx header files in this source file.