### PR TITLE
nimble/l2cap: Generalize L2CAP COC Dynamic Channel Allocation.

### DIFF
--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -196,7 +196,7 @@ ble_hs_conn_delete_chan(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan)
     }
 
     SLIST_REMOVE(&conn->bhc_channels, chan, ble_l2cap_chan, next);
-    ble_l2cap_chan_free(chan);
+    ble_l2cap_chan_free(conn, chan);
 }
 
 void

--- a/nimble/host/src/ble_hs_conn_priv.h
+++ b/nimble/host/src/ble_hs_conn_priv.h
@@ -33,10 +33,21 @@ struct hci_create_conn;
 struct ble_l2cap_chan;
 
 typedef uint8_t ble_hs_conn_flags_t;
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+typedef uint8_t ble_hs_conn_cid_mask_t;
+#endif
 
 #define BLE_HS_CONN_F_MASTER        0x01
 #define BLE_HS_CONN_F_TERMINATING   0x02
 #define BLE_HS_CONN_F_TX_FRAG       0x04 /* Cur ACL packet partially txed. */
+
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+#define BLE_HS_CONN_TOTAL_CID_PER_MASK_ELEMENT \
+                                   (8 * sizeof(ble_hs_conn_cid_mask_t))
+#define BLE_HS_CONN_CID_MASK_LEN   ((MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) \
+                                   + BLE_HS_CONN_TOTAL_CID_PER_MASK_ELEMENT) \
+                                   / BLE_HS_CONN_TOTAL_CID_PER_MASK_ELEMENT)
+#endif
 
 struct ble_hs_conn {
     SLIST_ENTRY(ble_hs_conn) bhc_next;
@@ -58,6 +69,12 @@ struct ble_hs_conn {
 
     ble_hs_conn_flags_t bhc_flags;
 
+#if MYNEWT_VAL(BLE_L2CAP_COC_MAX_NUM) != 0
+    /**
+     * CID Mask used for allocation of CID for l2cap Channels.
+     */
+    ble_hs_conn_cid_mask_t bhc_cid_mask[BLE_HS_CONN_CID_MASK_LEN];
+#endif
     struct ble_l2cap_chan_list bhc_channels;
     struct ble_l2cap_chan *bhc_rx_chan; /* Channel rxing current packet. */
     ble_npl_time_t bhc_rx_timeout;

--- a/nimble/host/src/ble_l2cap_coc_priv.h
+++ b/nimble/host/src/ble_l2cap_coc_priv.h
@@ -57,14 +57,15 @@ struct ble_l2cap_coc_srv {
 int ble_l2cap_coc_init(void);
 int ble_l2cap_coc_create_server(uint16_t psm, uint16_t mtu,
                                 ble_l2cap_event_fn *cb, void *cb_arg);
-int ble_l2cap_coc_create_srv_chan(uint16_t conn_handle, uint16_t psm,
+int ble_l2cap_coc_create_srv_chan(struct ble_hs_conn *conn, uint16_t psm,
                                   struct ble_l2cap_chan **chan);
-struct ble_l2cap_chan * ble_l2cap_coc_chan_alloc(uint16_t conn_handle,
+struct ble_l2cap_chan * ble_l2cap_coc_chan_alloc(struct ble_hs_conn *,
                                                  uint16_t psm, uint16_t mtu,
                                                  struct os_mbuf *sdu_rx,
                                                  ble_l2cap_event_fn *cb,
                                                  void *cb_arg);
-void ble_l2cap_coc_cleanup_chan(struct ble_l2cap_chan *chan);
+void ble_l2cap_coc_cleanup_chan(struct ble_hs_conn *conn,
+                                struct ble_l2cap_chan *chan);
 void ble_l2cap_coc_le_credits_update(uint16_t conn_handle, uint16_t dcid,
                                     uint16_t credits);
 int ble_l2cap_coc_recv_ready(struct ble_l2cap_chan *chan,
@@ -74,7 +75,7 @@ int ble_l2cap_coc_send(struct ble_l2cap_chan *chan, struct os_mbuf *sdu_tx);
 #define ble_l2cap_coc_init()                                    0
 #define ble_l2cap_coc_create_server(psm, mtu, cb, cb_arg)       BLE_HS_ENOTSUP
 #define ble_l2cap_coc_recv_ready(chan, sdu_rx)                  BLE_HS_ENOTSUP
-#define ble_l2cap_coc_cleanup_chan(chan)
+#define ble_l2cap_coc_cleanup_chan(conn, chan)
 #define ble_l2cap_coc_send(chan, sdu_tx)                        BLE_HS_ENOTSUP
 #endif
 

--- a/nimble/host/src/ble_l2cap_priv.h
+++ b/nimble/host/src/ble_l2cap_priv.h
@@ -102,7 +102,8 @@ struct os_mbuf *ble_l2cap_prepend_hdr(struct os_mbuf *om, uint16_t cid,
                                       uint16_t len);
 
 struct ble_l2cap_chan *ble_l2cap_chan_alloc(uint16_t conn_handle);
-void ble_l2cap_chan_free(struct ble_l2cap_chan *chan);
+void ble_l2cap_chan_free(struct ble_hs_conn *conn,
+                         struct ble_l2cap_chan *chan);
 
 bool ble_l2cap_is_mtu_req_sent(const struct ble_l2cap_chan *chan);
 

--- a/nimble/host/src/ble_l2cap_sig.c
+++ b/nimble/host/src/ble_l2cap_sig.c
@@ -606,6 +606,7 @@ ble_l2cap_event_coc_accept(struct ble_l2cap_chan *chan, uint16_t peer_sdu_size)
 static void
 ble_l2cap_sig_coc_connect_cb(struct ble_l2cap_sig_proc *proc, int status)
 {
+	struct ble_hs_conn *conn;
     struct ble_l2cap_chan *chan;
 
     if (!proc) {
@@ -625,7 +626,11 @@ ble_l2cap_sig_coc_connect_cb(struct ble_l2cap_sig_proc *proc, int status)
          * event with error status. To avoid additional disconnected event lets
          * clear callbacks since we don't needed it anymore.*/
         chan->cb = NULL;
-        ble_l2cap_chan_free(chan);
+        ble_hs_lock();
+        conn = ble_hs_conn_find(chan->conn_handle);
+        assert(conn != NULL);
+        ble_l2cap_chan_free(conn, chan);
+        ble_hs_unlock();
     }
 }
 
@@ -677,7 +682,7 @@ ble_l2cap_sig_coc_req_rx(uint16_t conn_handle, struct ble_l2cap_sig_hdr *hdr,
         goto failed;
     }
 
-    rc = ble_l2cap_coc_create_srv_chan(conn_handle, le16toh(req->psm), &chan);
+    rc = ble_l2cap_coc_create_srv_chan(conn, le16toh(req->psm), &chan);
     if (rc != 0) {
         uint16_t coc_err = ble_l2cap_sig_ble_hs_err2coc_err(rc);
         rsp->result = htole16(coc_err);
@@ -815,7 +820,7 @@ ble_l2cap_sig_coc_connect(uint16_t conn_handle, uint16_t psm, uint16_t mtu,
         return BLE_HS_ENOTCONN;
     }
 
-    chan = ble_l2cap_coc_chan_alloc(conn_handle, psm, mtu, sdu_rx, cb, cb_arg);
+    chan = ble_l2cap_coc_chan_alloc(conn, psm, mtu, sdu_rx, cb, cb_arg);
     if (!chan) {
         ble_hs_unlock();
         return BLE_HS_ENOMEM;
@@ -823,7 +828,7 @@ ble_l2cap_sig_coc_connect(uint16_t conn_handle, uint16_t psm, uint16_t mtu,
 
     proc = ble_l2cap_sig_proc_alloc();
     if (!proc) {
-        ble_l2cap_chan_free(chan);
+        ble_l2cap_chan_free(conn, chan);
         ble_hs_unlock();
         return BLE_HS_ENOMEM;
     }
@@ -836,7 +841,7 @@ ble_l2cap_sig_coc_connect(uint16_t conn_handle, uint16_t psm, uint16_t mtu,
     req = ble_l2cap_sig_cmd_get(BLE_L2CAP_SIG_OP_CREDIT_CONNECT_REQ, proc->id,
                                 sizeof(*req), &txom);
     if (!req) {
-        ble_l2cap_chan_free(chan);
+        ble_l2cap_chan_free(conn, chan);
         ble_hs_unlock();
         return BLE_HS_ENOMEM;
     }
@@ -851,7 +856,7 @@ ble_l2cap_sig_coc_connect(uint16_t conn_handle, uint16_t psm, uint16_t mtu,
 
     rc = ble_l2cap_sig_tx(proc->conn_handle, txom);
     if (rc != 0) {
-        ble_l2cap_chan_free(chan);
+        ble_l2cap_chan_free(conn, chan);
     }
 
     ble_l2cap_sig_process_status(proc, rc);
@@ -943,8 +948,6 @@ done:
     conn = ble_hs_conn_find(chan->conn_handle);
     if (conn) {
         ble_hs_conn_delete_chan(conn, chan);
-    } else {
-        ble_l2cap_chan_free(chan);
     }
     ble_hs_unlock();
 }

--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -83,11 +83,6 @@ syscfg.defs:
         value: 128
 
     # L2CAP settings.
-    BLE_L2CAP_MAX_CHANS:
-        description: >
-            The number of L2CAP channels to allocate.  The default value allows
-            for the signal, ATT, and SM channels for each connection.
-        value: '3*MYNEWT_VAL_BLE_MAX_CONNECTIONS'
     BLE_L2CAP_SIG_MAX_PROCS:
         description: >
             The maximum number of concurrent L2CAP signal procedures.
@@ -110,6 +105,11 @@ syscfg.defs:
             Defines maximum number of LE Connection Oriented Channels channels.
             When set to (0), LE COC is not compiled in.
         value: 0
+    BLE_L2CAP_MAX_CHANS:
+        description: >
+            The number of L2CAP channels to allocate.  The default value allows
+            for the signal, ATT, and SM channels for each connection.
+        value: '(3+MYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM)*MYNEWT_VAL_BLE_MAX_CONNECTIONS'
     BLE_L2CAP_COC_MPS:
         description: >
             Defines the MPS of L2CAP COC module. This is actually NimBLE's internal

--- a/nimble/host/test/src/ble_l2cap_test.c
+++ b/nimble/host/test/src/ble_l2cap_test.c
@@ -790,7 +790,7 @@ ble_l2cap_test_coc_connect(struct test_data *t)
     req.mps = htole16(MYNEWT_VAL(BLE_L2CAP_COC_MPS));
     req.mtu = htole16(t->mtu);
     req.psm = htole16(t->psm);
-    req.scid = htole16(current_cid++);
+    req.scid = htole16(current_cid);
 
     /* Ensure an update request got sent. */
     id = ble_hs_test_util_verify_tx_l2cap_sig(
@@ -831,7 +831,7 @@ ble_l2cap_test_coc_connect_by_peer(struct test_data *t)
     req.mps = htole16(MYNEWT_VAL(BLE_L2CAP_COC_MPS) + 16);
     req.mtu = htole16(t->mtu);
     req.psm = htole16(t->psm);
-    req.scid = htole16(0x0040);
+    req.scid = htole16(current_cid);
 
     /* Receive remote request*/
     rc = ble_hs_test_util_inject_rx_l2cap_sig(2,
@@ -853,7 +853,7 @@ ble_l2cap_test_coc_connect_by_peer(struct test_data *t)
         rsp.credits = htole16(
                             ble_l2cap_calculate_credits(t->mtu,
                                                         MYNEWT_VAL(BLE_L2CAP_COC_MPS)));
-        rsp.dcid = current_cid++;
+        rsp.dcid = htole16(current_cid);
         rsp.mps = htole16(MYNEWT_VAL(BLE_L2CAP_COC_MPS));
         rsp.mtu = htole16(t->mtu);
     }
@@ -1177,11 +1177,6 @@ TEST_CASE_SELF(ble_l2cap_test_case_sig_coc_incoming_conn_rejected_by_app)
     ble_l2cap_test_coc_connect_by_peer(&t);
 
     TEST_ASSERT(t.expected_num_of_ev == t.event_iter);
-
-    /* In this test case, L2CAP channel is created and once application rejects
-     * connection, channel is destroyed. In such case CID for channel has been
-     * used and we need to increase current_cid. */
-    current_cid++;
 
     ble_hs_test_util_assert_mbufs_freed(NULL);
 }


### PR DESCRIPTION
This PR has the following modifications to generalize L2CAP COC Dynamic Channel Allocation:-
- Modifying COC Channel Allocation to be per connection, instead of using the whole 64 channels to support all connections.
- Freeing the COC Allocated channel when there is a disconnection on the l2cap COC channel.
- Modifying COC Channel Allocation to reuse the already freed channels.