### PR TITLE
ble_hs: `ble_hs_id_set_rnd` should check if all bits are 0s or 1s

### DIFF
--- a/nimble/host/src/ble_hs_id.c
+++ b/nimble/host/src/ble_hs_id.c
@@ -58,11 +58,14 @@ ble_hs_id_set_rnd(const uint8_t *rnd_addr)
 {
     uint8_t addr_type_byte;
     int rc;
+    uint8_t all_zeros[BLE_DEV_ADDR_LEN] = {0}, all_ones[BLE_DEV_ADDR_LEN] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
     ble_hs_lock();
 
+    /* Make sure all bits are neither one nor zero */
     addr_type_byte = rnd_addr[5] & 0xc0;
-    if (addr_type_byte != 0x00 && addr_type_byte != 0xc0) {
+    if ((addr_type_byte != 0x00 && addr_type_byte != 0xc0) ||
+        !memcmp(rnd_addr, all_zeros, BLE_DEV_ADDR_LEN) || !memcmp(rnd_addr, all_ones, BLE_DEV_ADDR_LEN)) {
         rc = BLE_HS_EINVAL;
         goto done;
     }
@@ -283,3 +286,13 @@ ble_hs_id_reset(void)
     memset(ble_hs_id_pub, 0, sizeof ble_hs_id_pub);
     memset(ble_hs_id_rnd, 0, sizeof ble_hs_id_pub);
 }
+
+/**
+ * Clears random address. This function is necessary when the host wants to
+ * clear random address.
+ */
+ void
+ ble_hs_id_rnd_reset(void)
+ {
+    memset(ble_hs_id_rnd, 0, sizeof ble_hs_id_rnd);
+ }

--- a/nimble/host/src/ble_hs_id_priv.h
+++ b/nimble/host/src/ble_hs_id_priv.h
@@ -31,6 +31,7 @@ int ble_hs_id_addr(uint8_t id_addr_type, const uint8_t **out_id_addr,
                    int *out_is_nrpa);
 int ble_hs_id_use_addr(uint8_t addr_type);
 void ble_hs_id_reset(void);
+void ble_hs_id_rnd_reset(void);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/test/src/ble_hs_test_util.c
+++ b/nimble/host/test/src/ble_hs_test_util.c
@@ -2044,7 +2044,8 @@ ble_hs_test_util_init(void)
     TEST_ASSERT_FATAL(rc == 0);
 
     ble_hs_test_util_hci_out_clear();
+    ble_hs_test_util_hci_acks_clear();
 
     /* Clear random address. */
-    ble_hs_test_util_set_static_rnd_addr((uint8_t[6]){ 0, 0, 0, 0, 0, 0 });
+    ble_hs_id_rnd_reset();
 }

--- a/nimble/host/test/src/ble_hs_test_util_hci.c
+++ b/nimble/host/test/src/ble_hs_test_util_hci.c
@@ -107,6 +107,12 @@ ble_hs_test_util_hci_out_clear(void)
     ble_hs_test_util_hci_out_queue_sz = 0;
 }
 
+void
+ble_hs_test_util_hci_acks_clear(void)
+{
+    ble_hs_test_util_hci_num_acks = 0;
+}
+
 /*****************************************************************************
  * $build                                                                    *
  *****************************************************************************/

--- a/nimble/host/test/src/ble_hs_test_util_hci.h
+++ b/nimble/host/test/src/ble_hs_test_util_hci.h
@@ -46,6 +46,7 @@ void *ble_hs_test_util_hci_out_first(void);
 void *ble_hs_test_util_hci_out_last(void);
 void ble_hs_test_util_hci_out_enqueue(void *cmd);
 void ble_hs_test_util_hci_out_clear(void);
+void ble_hs_test_util_hci_acks_clear(void);
 
 /* $build */
 void ble_hs_test_util_hci_build_cmd_complete(uint8_t *dst, int len,


### PR DESCRIPTION
`ble_hs_id_set_rnd` should make sure that all bits are not 0s or 1s.
Useful for host only implementation.