### PR TITLE
mesh/adv.c: fix advertising duration

### DIFF
--- a/nimble/host/mesh/src/adv.c
+++ b/nimble/host/mesh/src/adv.c
@@ -105,9 +105,14 @@ static inline void adv_send(struct os_mbuf *buf)
 
 	adv_int = max(adv_int_min,
 		      BT_MESH_TRANSMIT_INT(BT_MESH_ADV(buf)->xmit));
+#if MYNEWT_VAL(BLE_CONTROLLER)
+	duration = ((BT_MESH_TRANSMIT_COUNT(BT_MESH_ADV(buf)->xmit) + 1) *
+				(adv_int + 10));
+#else
 	duration = (MESH_SCAN_WINDOW_MS +
 		    ((BT_MESH_TRANSMIT_COUNT(BT_MESH_ADV(buf)->xmit) + 1) *
 		     (adv_int + 10)));
+#endif
 
 	BT_DBG("type %u om_len %u: %s", BT_MESH_ADV(buf)->type,
 	       buf->om_len, bt_hex(buf->om_data, buf->om_len));


### PR DESCRIPTION
The default configuration for link layer (re)transmission in the `Configuration Server Model` for the `Network Transmit State` and the `Relay Retransmit State` is **3 transmissions** with an interval of **20ms**. But after doing some closer analysis, I discovered that the implementation actually does 5-6 transmissions.

Looking at `nimble/host/mesh/src/adv.c` line 108ff, it seems to me, that the calculation of the duration value is flawed -> adding in `MESH_SCAN_WINDOW_MS` should not be needed, right?!

With this fix, I see exactly the 3 transmissions (advertising events) that one would expect from the Configuration Server's Transmission State.

Does this make sense or did I miss something here?