### PR TITLE
Bump go requirement to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ _addons: &addon_conf
       - gcc-7-multilib
 
 go:
-  - "1.10"
+  - "1.11"
 
 git:
   depth: false


### PR DESCRIPTION
The usage of RSA that allows for keys of any sizes requires go 1.11 to work.