### PR TITLE
Mynewt: Use logcfg for host logging

### DIFF
--- a/apps/blemesh/src/main.c
+++ b/apps/blemesh/src/main.c
@@ -405,7 +405,7 @@ static const struct bt_mesh_prov prov = {
 static void
 blemesh_on_reset(int reason)
 {
-    BLE_HS_LOG(ERROR, "Resetting state; reason=%d\n", reason);
+    BLE_HS_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static void

--- a/apps/blemesh_light/src/main.c
+++ b/apps/blemesh_light/src/main.c
@@ -66,7 +66,7 @@ static struct bt_test_cb bt_test_cb = {
 static void
 blemesh_on_reset(int reason)
 {
-    BLE_HS_LOG(ERROR, "Resetting state; reason=%d\n", reason);
+    BLE_HS_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static struct bt_mesh_gen_onoff_srv_cb gen_onoff_srv_cb = {

--- a/apps/blemesh_models_example_1/src/main.c
+++ b/apps/blemesh_models_example_1/src/main.c
@@ -625,7 +625,7 @@ void init_button(int button)
 static void
 blemesh_on_reset(int reason)
 {
-    BLE_HS_LOG(ERROR, "Resetting state; reason=%d\n", reason);
+    BLE_HS_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static void

--- a/apps/blemesh_models_example_2/src/ble_mesh.c
+++ b/apps/blemesh_models_example_2/src/ble_mesh.c
@@ -78,7 +78,7 @@ static const struct bt_mesh_prov prov = {
 
 void blemesh_on_reset(int reason)
 {
-	BLE_HS_LOG(ERROR, "Resetting state; reason=%d\n", reason);
+	BLE_HS_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 void blemesh_on_sync(void)

--- a/apps/blemesh_shell/src/main.c
+++ b/apps/blemesh_shell/src/main.c
@@ -77,7 +77,7 @@ static struct bt_test_cb bt_test_cb = {
 static void
 blemesh_on_reset(int reason)
 {
-    BLE_HS_LOG(ERROR, "Resetting state; reason=%d\n", reason);
+    BLE_HS_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 static void

--- a/nimble/host/include/host/ble_hs_log.h
+++ b/nimble/host/include/host/ble_hs_log.h
@@ -22,18 +22,48 @@
 
 #include "modlog/modlog.h"
 
+#if MYNEWT
+#include "os/mynewt.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct os_mbuf;
 
-#define BLE_HS_LOG(lvl, ...) \
-    MODLOG_ ## lvl(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+/* For Mynewt builds, the newt tool generates the `BLE_HS_LOG_[...] macros
+ * based on the host's configured log level.  For non Mynewt-builds, these
+ * macros are defined here.
+ */
+
+#ifndef BLE_HS_LOG_DEBUG
+#define BLE_HS_LOG_DEBUG(fmt, ...)      \
+    MODLOG_DEBUG(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+#endif
+
+#ifndef BLE_HS_LOG_INFO
+#define BLE_HS_LOG_INFO(fmt, ...)       \
+    MODLOG_INFO(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+#endif
+
+#ifndef BLE_HS_LOG_WARN
+#define BLE_HS_LOG_WARN(fmt, ...)       \
+    MODLOG_WARN(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+#endif
+
+#ifndef BLE_HS_LOG_ERROR
+#define BLE_HS_LOG_ERROR(fmt, ...)      \
+    MODLOG_ERROR(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+#endif
+
+#ifndef BLE_HS_LOG_CRITICAL
+#define BLE_HS_LOG_CRITICAL(fmt, ...)   \
+    MODLOG_CRITICAL(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+#endif
 
 #define BLE_HS_LOG_ADDR(lvl, addr)                      \
-    MODLOG_ ## lvl(LOG_MODULE_NIMBLE_HOST,              \
-                   "%02x:%02x:%02x:%02x:%02x:%02x",     \
+    BLE_HS_LOG_ ## lvl("%02x:%02x:%02x:%02x:%02x:%02x", \
                    (addr)[5], (addr)[4], (addr)[3],     \
                    (addr)[2], (addr)[1], (addr)[0])
 

--- a/nimble/host/mesh/include/mesh/glue.h
+++ b/nimble/host/mesh/include/mesh/glue.h
@@ -170,11 +170,11 @@ extern "C" {
 
 #define BT_DBG(fmt, ...)    \
     if (BT_DBG_ENABLED) { \
-        BLE_HS_LOG(DEBUG, "%s: " fmt "\n", __func__, ## __VA_ARGS__); \
+        BLE_HS_LOG_DEBUG("%s: " fmt "\n", __func__, ## __VA_ARGS__); \
     }
-#define BT_INFO(fmt, ...)   BLE_HS_LOG(INFO, "%s: " fmt "\n", __func__, ## __VA_ARGS__);
-#define BT_WARN(fmt, ...)   BLE_HS_LOG(WARN, "%s: " fmt "\n", __func__, ## __VA_ARGS__);
-#define BT_ERR(fmt, ...)    BLE_HS_LOG(ERROR, "%s: " fmt "\n", __func__, ## __VA_ARGS__);
+#define BT_INFO(fmt, ...)   BLE_HS_LOG_INFO("%s: " fmt "\n", __func__, ## __VA_ARGS__);
+#define BT_WARN(fmt, ...)   BLE_HS_LOG_WARN("%s: " fmt "\n", __func__, ## __VA_ARGS__);
+#define BT_ERR(fmt, ...)    BLE_HS_LOG_ERROR("%s: " fmt "\n", __func__, ## __VA_ARGS__);
 #define BT_GATT_ERR(_att_err)   (-(_att_err))
 
 typedef ble_addr_t bt_addr_le_t;

--- a/nimble/host/src/ble_att_clt.c
+++ b/nimble/host/src/ble_att_clt.c
@@ -754,14 +754,14 @@ ble_att_clt_tx_write_cmd(uint16_t conn_handle, uint16_t handle,
     int rc;
     int i;
 
-    BLE_HS_LOG(DEBUG, "ble_att_clt_tx_write_cmd(): ");
+    BLE_HS_LOG_DEBUG("ble_att_clt_tx_write_cmd(): ");
     for (i = 0; i < OS_MBUF_PKTLEN(txom); i++) {
         if (i != 0) {
-            BLE_HS_LOG(DEBUG, ":");
+            BLE_HS_LOG_DEBUG(":");
         }
         rc = os_mbuf_copydata(txom, i, 1, &b);
         assert(rc == 0);
-        BLE_HS_LOG(DEBUG, "0x%02x", b);
+        BLE_HS_LOG_DEBUG("0x%02x", b);
     }
 
 

--- a/nimble/host/src/ble_att_cmd.c
+++ b/nimble/host/src/ble_att_cmd.c
@@ -139,8 +139,8 @@ ble_att_error_rsp_write(void *payload, int len,
 void
 ble_att_error_rsp_log(const struct ble_att_error_rsp *cmd)
 {
-    BLE_HS_LOG(DEBUG, "req_op=%d handle=0x%04x error_code=%d",
-               cmd->baep_req_op, cmd->baep_handle, cmd->baep_error_code);
+    BLE_HS_LOG_DEBUG("req_op=%d handle=0x%04x error_code=%d",
+                     cmd->baep_req_op, cmd->baep_handle, cmd->baep_error_code);
 }
 
 void
@@ -193,7 +193,7 @@ ble_att_mtu_rsp_write(void *payload, int len,
 void
 ble_att_mtu_cmd_log(const struct ble_att_mtu_cmd *cmd)
 {
-    BLE_HS_LOG(DEBUG, "mtu=%d", cmd->bamc_mtu);
+    BLE_HS_LOG_DEBUG("mtu=%d", cmd->bamc_mtu);
 }
 
 void
@@ -225,8 +225,8 @@ ble_att_find_info_req_write(void *payload, int len,
 void
 ble_att_find_info_req_log(const struct ble_att_find_info_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "start_handle=0x%04x end_handle=0x%04x",
-               cmd->bafq_start_handle, cmd->bafq_end_handle);
+    BLE_HS_LOG_DEBUG("start_handle=0x%04x end_handle=0x%04x",
+                     cmd->bafq_start_handle, cmd->bafq_end_handle);
 }
 
 void
@@ -256,7 +256,7 @@ ble_att_find_info_rsp_write(void *payload, int len,
 void
 ble_att_find_info_rsp_log(const struct ble_att_find_info_rsp *cmd)
 {
-    BLE_HS_LOG(DEBUG, "format=%d", cmd->bafp_format);
+    BLE_HS_LOG_DEBUG("format=%d", cmd->bafp_format);
 }
 
 void
@@ -290,9 +290,9 @@ ble_att_find_type_value_req_write(
 void
 ble_att_find_type_value_req_log(const struct ble_att_find_type_value_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "start_handle=0x%04x end_handle=0x%04x attr_type=%d",
-               cmd->bavq_start_handle, cmd->bavq_end_handle,
-               cmd->bavq_attr_type);
+    BLE_HS_LOG_DEBUG("start_handle=0x%04x end_handle=0x%04x attr_type=%d",
+                     cmd->bavq_start_handle, cmd->bavq_end_handle,
+                     cmd->bavq_attr_type);
 }
 
 void
@@ -324,8 +324,8 @@ ble_att_read_type_req_write(void *payload, int len,
 void
 ble_att_read_type_req_log(const struct ble_att_read_type_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "start_handle=0x%04x end_handle=0x%04x",
-               cmd->batq_start_handle, cmd->batq_end_handle);
+    BLE_HS_LOG_DEBUG("start_handle=0x%04x end_handle=0x%04x",
+                     cmd->batq_start_handle, cmd->batq_end_handle);
 }
 
 void
@@ -355,7 +355,7 @@ ble_att_read_type_rsp_write(void *payload, int len,
 void
 ble_att_read_type_rsp_log(const struct ble_att_read_type_rsp *cmd)
 {
-    BLE_HS_LOG(DEBUG, "length=%d", cmd->batp_length);
+    BLE_HS_LOG_DEBUG("length=%d", cmd->batp_length);
 }
 
 void
@@ -385,7 +385,7 @@ ble_att_read_req_write(void *payload, int len,
 void
 ble_att_read_req_log(const struct ble_att_read_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "handle=0x%04x", cmd->barq_handle);
+    BLE_HS_LOG_DEBUG("handle=0x%04x", cmd->barq_handle);
 }
 
 void
@@ -417,8 +417,8 @@ ble_att_read_blob_req_write(void *payload, int len,
 void
 ble_att_read_blob_req_log(const struct ble_att_read_blob_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "handle=0x%04x offset=%d", cmd->babq_handle,
-               cmd->babq_offset);
+    BLE_HS_LOG_DEBUG("handle=0x%04x offset=%d", cmd->babq_handle,
+                     cmd->babq_offset);
 }
 
 void
@@ -478,8 +478,8 @@ ble_att_read_group_type_req_write(
 void
 ble_att_read_group_type_req_log(const struct ble_att_read_group_type_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "start_handle=0x%04x end_handle=0x%04x",
-               cmd->bagq_start_handle, cmd->bagq_end_handle);
+    BLE_HS_LOG_DEBUG("start_handle=0x%04x end_handle=0x%04x",
+                     cmd->bagq_start_handle, cmd->bagq_end_handle);
 }
 
 void
@@ -509,7 +509,7 @@ ble_att_read_group_type_rsp_write(
 void
 ble_att_read_group_type_rsp_log(const struct ble_att_read_group_type_rsp *cmd)
 {
-    BLE_HS_LOG(DEBUG, "length=%d", cmd->bagp_length);
+    BLE_HS_LOG_DEBUG("length=%d", cmd->bagp_length);
 }
 
 void
@@ -560,13 +560,13 @@ ble_att_write_cmd_write(void *payload, int len,
 void
 ble_att_write_cmd_log(const struct ble_att_write_cmd *cmd)
 {
-    BLE_HS_LOG(DEBUG, "handle=0x%04x", cmd->handle);
+    BLE_HS_LOG_DEBUG("handle=0x%04x", cmd->handle);
 }
 
 void
 ble_att_write_req_log(const struct ble_att_write_req *req)
 {
-    BLE_HS_LOG(DEBUG, "handle=0x%04x", req->bawq_handle);
+    BLE_HS_LOG_DEBUG("handle=0x%04x", req->bawq_handle);
 }
 
 void
@@ -624,8 +624,8 @@ ble_att_prep_write_rsp_write(void *payload, int len,
 void
 ble_att_prep_write_cmd_log(const struct ble_att_prep_write_cmd *cmd)
 {
-    BLE_HS_LOG(DEBUG, "handle=0x%04x offset=%d", cmd->bapc_handle,
-               cmd->bapc_offset);
+    BLE_HS_LOG_DEBUG("handle=0x%04x offset=%d", cmd->bapc_handle,
+                     cmd->bapc_offset);
 }
 
 void
@@ -655,7 +655,7 @@ ble_att_exec_write_req_write(void *payload, int len,
 void
 ble_att_exec_write_req_log(const struct ble_att_exec_write_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "flags=0x%02x", cmd->baeq_flags);
+    BLE_HS_LOG_DEBUG("flags=0x%02x", cmd->baeq_flags);
 }
 
 void
@@ -699,7 +699,7 @@ ble_att_notify_req_write(void *payload, int len,
 void
 ble_att_notify_req_log(const struct ble_att_notify_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "handle=0x%04x", cmd->banq_handle);
+    BLE_HS_LOG_DEBUG("handle=0x%04x", cmd->banq_handle);
 }
 
 void
@@ -729,7 +729,7 @@ ble_att_indicate_req_write(void *payload, int len,
 void
 ble_att_indicate_req_log(const struct ble_att_indicate_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "handle=0x%04x", cmd->baiq_handle);
+    BLE_HS_LOG_DEBUG("handle=0x%04x", cmd->baiq_handle);
 }
 
 void

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -282,9 +282,9 @@ static void
 ble_gap_log_duration(int32_t duration_ms)
 {
     if (duration_ms == BLE_HS_FOREVER) {
-        BLE_HS_LOG(INFO, "duration=forever");
+        BLE_HS_LOG_INFO("duration=forever");
     } else {
-        BLE_HS_LOG(INFO, "duration=%dms", duration_ms);
+        BLE_HS_LOG_INFO("duration=%dms", duration_ms);
     }
 }
 #endif
@@ -295,16 +295,17 @@ ble_gap_log_conn(uint8_t own_addr_type, const ble_addr_t *peer_addr,
                  const struct ble_gap_conn_params *params)
 {
     if (peer_addr != NULL) {
-        BLE_HS_LOG(INFO, "peer_addr_type=%d peer_addr=", peer_addr->type);
+        BLE_HS_LOG_INFO("peer_addr_type=%d peer_addr=", peer_addr->type);
         BLE_HS_LOG_ADDR(INFO, peer_addr->val);
     }
 
-    BLE_HS_LOG(INFO, " scan_itvl=%d scan_window=%d itvl_min=%d itvl_max=%d "
-                     "latency=%d supervision_timeout=%d min_ce_len=%d "
-                     "max_ce_len=%d own_addr_type=%d",
-               params->scan_itvl, params->scan_window, params->itvl_min,
-               params->itvl_max, params->latency, params->supervision_timeout,
-               params->min_ce_len, params->max_ce_len, own_addr_type);
+    BLE_HS_LOG_INFO(" scan_itvl=%d scan_window=%d itvl_min=%d itvl_max=%d "
+                    "latency=%d supervision_timeout=%d min_ce_len=%d "
+                    "max_ce_len=%d own_addr_type=%d",
+                    params->scan_itvl, params->scan_window, params->itvl_min,
+                    params->itvl_max, params->latency,
+                    params->supervision_timeout, params->min_ce_len,
+                    params->max_ce_len, own_addr_type);
 }
 #endif
 
@@ -313,10 +314,11 @@ static void
 ble_gap_log_disc(uint8_t own_addr_type, int32_t duration_ms,
                  const struct ble_gap_disc_params *disc_params)
 {
-    BLE_HS_LOG(INFO, "own_addr_type=%d filter_policy=%d passive=%d limited=%d "
-                     "filter_duplicates=%d ",
-               own_addr_type, disc_params->filter_policy, disc_params->passive,
-               disc_params->limited, disc_params->filter_duplicates);
+    BLE_HS_LOG_INFO("own_addr_type=%d filter_policy=%d passive=%d limited=%d "
+                    "filter_duplicates=%d ",
+                    own_addr_type, disc_params->filter_policy,
+                    disc_params->passive, disc_params->limited,
+                    disc_params->filter_duplicates);
     ble_gap_log_duration(duration_ms);
 }
 #endif
@@ -325,12 +327,12 @@ static void
 ble_gap_log_update(uint16_t conn_handle,
                    const struct ble_gap_upd_params *params)
 {
-    BLE_HS_LOG(INFO, "connection parameter update; "
-                     "conn_handle=%d itvl_min=%d itvl_max=%d latency=%d "
-                     "supervision_timeout=%d min_ce_len=%d max_ce_len=%d",
-               conn_handle, params->itvl_min, params->itvl_max,
-               params->latency, params->supervision_timeout,
-               params->min_ce_len, params->max_ce_len);
+    BLE_HS_LOG_INFO("connection parameter update; "
+                    "conn_handle=%d itvl_min=%d itvl_max=%d latency=%d "
+                    "supervision_timeout=%d min_ce_len=%d max_ce_len=%d",
+                    conn_handle, params->itvl_min, params->itvl_max,
+                    params->latency, params->supervision_timeout,
+                    params->min_ce_len, params->max_ce_len);
 }
 
 static void
@@ -338,12 +340,12 @@ ble_gap_log_wl(const ble_addr_t *addr, uint8_t white_list_count)
 {
     int i;
 
-    BLE_HS_LOG(INFO, "count=%d ", white_list_count);
+    BLE_HS_LOG_INFO("count=%d ", white_list_count);
 
     for (i = 0; i < white_list_count; i++, addr++) {
-        BLE_HS_LOG(INFO, "entry-%d={addr_type=%d addr=", i, addr->type);
+        BLE_HS_LOG_INFO("entry-%d={addr_type=%d addr=", i, addr->type);
         BLE_HS_LOG_ADDR(INFO, addr->val);
-        BLE_HS_LOG(INFO, "} ");
+        BLE_HS_LOG_INFO("} ");
     }
 }
 
@@ -352,19 +354,19 @@ static void
 ble_gap_log_adv(uint8_t own_addr_type, const ble_addr_t *direct_addr,
                 const struct ble_gap_adv_params *adv_params)
 {
-    BLE_HS_LOG(INFO, "disc_mode=%d", adv_params->disc_mode);
+    BLE_HS_LOG_INFO("disc_mode=%d", adv_params->disc_mode);
     if (direct_addr) {
-        BLE_HS_LOG(INFO, " direct_addr_type=%d direct_addr=",
-                   direct_addr->type);
+        BLE_HS_LOG_INFO(" direct_addr_type=%d direct_addr=",
+                        direct_addr->type);
         BLE_HS_LOG_ADDR(INFO, direct_addr->val);
     }
-    BLE_HS_LOG(INFO, " adv_channel_map=%d own_addr_type=%d "
-                     "adv_filter_policy=%d adv_itvl_min=%d adv_itvl_max=%d",
-               adv_params->channel_map,
-               own_addr_type,
-               adv_params->filter_policy,
-               adv_params->itvl_min,
-               adv_params->itvl_max);
+    BLE_HS_LOG_INFO(" adv_channel_map=%d own_addr_type=%d "
+                    "adv_filter_policy=%d adv_itvl_min=%d adv_itvl_max=%d",
+                    adv_params->channel_map,
+                    own_addr_type,
+                    adv_params->filter_policy,
+                    adv_params->itvl_min,
+                    adv_params->itvl_max);
 }
 #endif
 
@@ -1502,8 +1504,8 @@ ble_gap_rx_conn_complete(struct hci_le_conn_complete *evt, uint8_t instance)
             break;
         default:
             /* this should never happen, unless controller is broken */
-            BLE_HS_LOG(INFO, "controller reported invalid error code in conn"
-                             "complete event: %u", evt->status);
+            BLE_HS_LOG_INFO("controller reported invalid error code in conn"
+                            "complete event: %u", evt->status);
             assert(0);
             break;
         }
@@ -1903,9 +1905,9 @@ ble_gap_wl_set(const ble_addr_t *addrs, uint8_t white_list_count)
         goto done;
     }
 
-    BLE_HS_LOG(INFO, "GAP procedure initiated: set whitelist; ");
+    BLE_HS_LOG_INFO("GAP procedure initiated: set whitelist; ");
     ble_gap_log_wl(addrs, white_list_count);
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 
     rc = ble_gap_wl_tx_clear();
     if (rc != 0) {
@@ -1968,7 +1970,7 @@ ble_gap_adv_stop_no_lock(void)
 
     active = ble_gap_adv_active();
 
-    BLE_HS_LOG(INFO, "GAP procedure initiated: stop advertising.\n");
+    BLE_HS_LOG_INFO("GAP procedure initiated: stop advertising.\n");
 
     rc = ble_gap_adv_enable_tx(0);
     if (rc != 0) {
@@ -2234,9 +2236,9 @@ ble_gap_adv_start(uint8_t own_addr_type, const ble_addr_t *direct_addr,
         goto done;
     }
 
-    BLE_HS_LOG(INFO, "GAP procedure initiated: advertise; ");
+    BLE_HS_LOG_INFO("GAP procedure initiated: advertise; ");
     ble_gap_log_adv(own_addr_type, direct_addr, adv_params);
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 
     ble_gap_slave[0].cb = cb;
     ble_gap_slave[0].cb_arg = cb_arg;
@@ -4108,9 +4110,9 @@ ble_gap_disc(uint8_t own_addr_type, int32_t duration_ms,
     ble_gap_master.cb = cb;
     ble_gap_master.cb_arg = cb_arg;
 
-    BLE_HS_LOG(INFO, "GAP procedure initiated: discovery; ");
+    BLE_HS_LOG_INFO("GAP procedure initiated: discovery; ");
     ble_gap_log_disc(own_addr_type, duration_ms, &params);
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 
     rc = ble_gap_disc_tx_params(own_addr_type, &params);
     if (rc != 0) {
@@ -4539,9 +4541,9 @@ ble_gap_connect(uint8_t own_addr_type, const ble_addr_t *peer_addr,
         goto done;
     }
 
-    BLE_HS_LOG(INFO, "GAP procedure initiated: connect; ");
+    BLE_HS_LOG_INFO("GAP procedure initiated: connect; ");
     ble_gap_log_conn(own_addr_type, peer_addr, conn_params);
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 
     ble_gap_master.cb = cb;
     ble_gap_master.cb_arg = cb_arg;
@@ -4606,9 +4608,9 @@ ble_gap_terminate(uint16_t conn_handle, uint8_t hci_reason)
         goto done;
     }
 
-    BLE_HS_LOG(INFO, "GAP procedure initiated: terminate connection; "
-                     "conn_handle=%d hci_reason=%d\n",
-               conn_handle, hci_reason);
+    BLE_HS_LOG_INFO("GAP procedure initiated: terminate connection; "
+                    "conn_handle=%d hci_reason=%d\n",
+                    conn_handle, hci_reason);
 
     ble_hs_hci_cmd_build_disconnect(conn_handle, hci_reason,
                                     buf, sizeof buf);
@@ -4666,7 +4668,7 @@ ble_gap_conn_cancel_no_lock(void)
         goto done;
     }
 
-    BLE_HS_LOG(INFO, "GAP procedure initiated: cancel connection\n");
+    BLE_HS_LOG_INFO("GAP procedure initiated: cancel connection\n");
 
     rc = ble_gap_conn_cancel_tx();
     if (rc != 0) {
@@ -5009,9 +5011,9 @@ ble_gap_update_params(uint16_t conn_handle,
     entry->exp_os_ticks = ble_npl_time_get() +
                           ble_npl_time_ms_to_ticks32(BLE_GAP_UPDATE_TIMEOUT_MS);
 
-    BLE_HS_LOG(INFO, "GAP procedure initiated: ");
+    BLE_HS_LOG_INFO("GAP procedure initiated: ");
     ble_gap_log_update(conn_handle, params);
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 
     /*
      * If LL update procedure is not supported on this connection and we are
@@ -5222,8 +5224,8 @@ ble_gap_passkey_event(uint16_t conn_handle,
 
     struct ble_gap_event event;
 
-    BLE_HS_LOG(DEBUG, "send passkey action request %d\n",
-               passkey_params->action);
+    BLE_HS_LOG_DEBUG("send passkey action request %d\n",
+                     passkey_params->action);
 
     memset(&event, 0, sizeof event);
     event.type = BLE_GAP_EVENT_PASSKEY_ACTION;
@@ -5267,7 +5269,7 @@ ble_gap_identity_event(uint16_t conn_handle)
 
     struct ble_gap_event event;
 
-    BLE_HS_LOG(DEBUG, "send identity changed");
+    BLE_HS_LOG_DEBUG("send identity changed");
 
     memset(&event, 0, sizeof event);
     event.type = BLE_GAP_EVENT_IDENTITY_RESOLVED;

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -487,7 +487,7 @@ ble_gattc_dbg_assert_proc_not_inserted(struct ble_gattc_proc *proc)
 static void
 ble_gattc_log_proc_init(char *name)
 {
-    BLE_HS_LOG(INFO, "GATT procedure initiated: %s", name);
+    BLE_HS_LOG_INFO("GATT procedure initiated: %s", name);
 }
 
 static void
@@ -497,7 +497,7 @@ ble_gattc_log_uuid(const ble_uuid_t *uuid)
 
     ble_uuid_to_str(uuid, buf);
 
-    BLE_HS_LOG(INFO, "%s", buf);
+    BLE_HS_LOG_INFO("%s", buf);
 }
 
 static void
@@ -505,52 +505,52 @@ ble_gattc_log_disc_svc_uuid(struct ble_gattc_proc *proc)
 {
     ble_gattc_log_proc_init("discover service by uuid; uuid=");
     ble_gattc_log_uuid(&proc->disc_svc_uuid.service_uuid.u);
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 }
 
 static void
 ble_gattc_log_find_inc_svcs(struct ble_gattc_proc *proc)
 {
     ble_gattc_log_proc_init("find included services; ");
-    BLE_HS_LOG(INFO, "start_handle=%d end_handle=%d\n",
-               proc->find_inc_svcs.prev_handle + 1,
-               proc->find_inc_svcs.end_handle);
+    BLE_HS_LOG_INFO("start_handle=%d end_handle=%d\n",
+                    proc->find_inc_svcs.prev_handle + 1,
+                    proc->find_inc_svcs.end_handle);
 }
 
 static void
 ble_gattc_log_disc_all_chrs(struct ble_gattc_proc *proc)
 {
     ble_gattc_log_proc_init("discover all characteristics; ");
-    BLE_HS_LOG(INFO, "start_handle=%d end_handle=%d\n",
-               proc->disc_all_chrs.prev_handle + 1,
-               proc->disc_all_chrs.end_handle);
+    BLE_HS_LOG_INFO("start_handle=%d end_handle=%d\n",
+                    proc->disc_all_chrs.prev_handle + 1,
+                    proc->disc_all_chrs.end_handle);
 }
 
 static void
 ble_gattc_log_disc_chr_uuid(struct ble_gattc_proc *proc)
 {
     ble_gattc_log_proc_init("discover characteristics by uuid; ");
-    BLE_HS_LOG(INFO, "start_handle=%d end_handle=%d uuid=",
-               proc->disc_chr_uuid.prev_handle + 1,
-               proc->disc_chr_uuid.end_handle);
+    BLE_HS_LOG_INFO("start_handle=%d end_handle=%d uuid=",
+                    proc->disc_chr_uuid.prev_handle + 1,
+                    proc->disc_chr_uuid.end_handle);
     ble_gattc_log_uuid(&proc->disc_chr_uuid.chr_uuid.u);
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 }
 
 static void
 ble_gattc_log_disc_all_dscs(struct ble_gattc_proc *proc)
 {
     ble_gattc_log_proc_init("discover all descriptors; ");
-    BLE_HS_LOG(INFO, "chr_val_handle=%d end_handle=%d\n",
-               proc->disc_all_dscs.chr_val_handle,
-               proc->disc_all_dscs.end_handle);
+    BLE_HS_LOG_INFO("chr_val_handle=%d end_handle=%d\n",
+                    proc->disc_all_dscs.chr_val_handle,
+                    proc->disc_all_dscs.end_handle);
 }
 
 static void
 ble_gattc_log_read(uint16_t att_handle)
 {
     ble_gattc_log_proc_init("read; ");
-    BLE_HS_LOG(INFO, "att_handle=%d\n", att_handle);
+    BLE_HS_LOG_INFO("att_handle=%d\n", att_handle);
 }
 
 static void
@@ -558,17 +558,17 @@ ble_gattc_log_read_uuid(uint16_t start_handle, uint16_t end_handle,
                         const ble_uuid_t *uuid)
 {
     ble_gattc_log_proc_init("read by uuid; ");
-    BLE_HS_LOG(INFO, "start_handle=%d end_handle=%d uuid=",
-               start_handle, end_handle);
+    BLE_HS_LOG_INFO("start_handle=%d end_handle=%d uuid=",
+                    start_handle, end_handle);
     ble_gattc_log_uuid(uuid);
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 }
 
 static void
 ble_gattc_log_read_long(struct ble_gattc_proc *proc)
 {
     ble_gattc_log_proc_init("read long; ");
-    BLE_HS_LOG(INFO, "att_handle=%d\n", proc->read_long.handle);
+    BLE_HS_LOG_INFO("att_handle=%d\n", proc->read_long.handle);
 }
 
 static void
@@ -577,11 +577,11 @@ ble_gattc_log_read_mult(const uint16_t *handles, uint8_t num_handles)
     int i;
 
     ble_gattc_log_proc_init("read multiple; ");
-    BLE_HS_LOG(INFO, "att_handles=");
+    BLE_HS_LOG_INFO("att_handles=");
     for (i = 0; i < num_handles; i++) {
-        BLE_HS_LOG(INFO, "%s%d", i != 0 ? "," : "", handles[i]);
+        BLE_HS_LOG_INFO("%s%d", i != 0 ? "," : "", handles[i]);
     }
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 }
 
 static void
@@ -596,16 +596,16 @@ ble_gattc_log_write(uint16_t att_handle, uint16_t len, int expecting_rsp)
     }
 
     ble_gattc_log_proc_init(name);
-    BLE_HS_LOG(INFO, "att_handle=%d len=%d\n", att_handle, len);
+    BLE_HS_LOG_INFO("att_handle=%d len=%d\n", att_handle, len);
 }
 
 static void
 ble_gattc_log_write_long(struct ble_gattc_proc *proc)
 {
     ble_gattc_log_proc_init("write long; ");
-    BLE_HS_LOG(INFO, "att_handle=%d len=%d\n",
-               proc->write_long.attr.handle,
-               OS_MBUF_PKTLEN(proc->write_long.attr.om));
+    BLE_HS_LOG_INFO("att_handle=%d len=%d\n",
+                    proc->write_long.attr.handle,
+                    OS_MBUF_PKTLEN(proc->write_long.attr.om));
 }
 
 static void
@@ -614,26 +614,26 @@ ble_gattc_log_write_reliable(struct ble_gattc_proc *proc)
     int i;
 
     ble_gattc_log_proc_init("write reliable; ");
-    BLE_HS_LOG(INFO, "att_handles=");
+    BLE_HS_LOG_INFO("att_handles=");
     for (i = 0; i < proc->write_reliable.num_attrs; i++) {
-        BLE_HS_LOG(INFO, "%s%d", i != 0 ? "," : "",
-                   proc->write_reliable.attrs[i].handle);
+        BLE_HS_LOG_INFO("%s%d", i != 0 ? "," : "",
+                        proc->write_reliable.attrs[i].handle);
     }
-    BLE_HS_LOG(INFO, "\n");
+    BLE_HS_LOG_INFO("\n");
 }
 
 static void
 ble_gattc_log_notify(uint16_t att_handle)
 {
     ble_gattc_log_proc_init("notify; ");
-    BLE_HS_LOG(INFO, "att_handle=%d\n", att_handle);
+    BLE_HS_LOG_INFO("att_handle=%d\n", att_handle);
 }
 
 static void
 ble_gattc_log_indicate(uint16_t att_handle)
 {
     ble_gattc_log_proc_init("indicate; ");
-    BLE_HS_LOG(INFO, "att_handle=%d\n", att_handle);
+    BLE_HS_LOG_INFO("att_handle=%d\n", att_handle);
 }
 
 /*****************************************************************************

--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -344,8 +344,8 @@ ble_hs_sync(void)
     if (rc == 0) {
         rc = ble_hs_misc_restore_irks();
         if (rc != 0) {
-            BLE_HS_LOG(INFO, "Failed to restore IRKs from store; status=%d\n",
-                       rc);
+            BLE_HS_LOG_INFO("Failed to restore IRKs from store; status=%d\n",
+                            rc);
         }
 
         if (ble_hs_cfg.sync_cb != NULL) {

--- a/nimble/host/src/ble_hs_dbg.c
+++ b/nimble/host/src/ble_hs_dbg.c
@@ -43,39 +43,39 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
     case BLE_HCI_LE_SUBEV_CONN_COMPLETE:
         status = evdata[0];
         if (status == BLE_ERR_SUCCESS) {
-            BLE_HS_LOG(DEBUG, "LE connection complete. handle=%u role=%u "
-                              "paddrtype=%u addr=%x.%x.%x.%x.%x.%x ",
-                       get_le16(evdata + 1), evdata[3], evdata[4],
-                       evdata[10], evdata[9], evdata[8], evdata[7],
-                       evdata[6], evdata[5]);
+            BLE_HS_LOG_DEBUG("LE connection complete. handle=%u role=%u "
+                             "paddrtype=%u addr=%x.%x.%x.%x.%x.%x ",
+                             get_le16(evdata + 1), evdata[3], evdata[4],
+                             evdata[10], evdata[9], evdata[8], evdata[7],
+                             evdata[6], evdata[5]);
 
             evdata += 11;
             if (subev == BLE_HCI_LE_SUBEV_ENH_CONN_COMPLETE) {
-                BLE_HS_LOG(DEBUG, "local_rpa=%x.%x.%x.%x.%x.%x "
-                                   "peer_rpa=%x.%x.%x.%x.%x.%x ",
-                           evdata[5], evdata[4], evdata[3], evdata[2],
-                           evdata[1], evdata[0],
-                           evdata[11], evdata[10], evdata[9], evdata[8],
-                           evdata[7], evdata[6]);
+                BLE_HS_LOG_DEBUG("local_rpa=%x.%x.%x.%x.%x.%x "
+                                 "peer_rpa=%x.%x.%x.%x.%x.%x ",
+                                 evdata[5], evdata[4], evdata[3], evdata[2],
+                                 evdata[1], evdata[0],
+                                 evdata[11], evdata[10], evdata[9], evdata[8],
+                                 evdata[7], evdata[6]);
 
                 evdata += 12;
             }
-            BLE_HS_LOG(DEBUG, "itvl=%u latency=%u spvn_tmo=%u mca=%u\n",
-                       get_le16(evdata), get_le16(evdata + 2),
-                       get_le16(evdata + 4), evdata[6]);
+            BLE_HS_LOG_DEBUG("itvl=%u latency=%u spvn_tmo=%u mca=%u\n",
+                             get_le16(evdata), get_le16(evdata + 2),
+                             get_le16(evdata + 4), evdata[6]);
         } else {
-            BLE_HS_LOG(DEBUG, "LE connection complete. FAIL (status=%u)\n",
-                       status);
+            BLE_HS_LOG_DEBUG("LE connection complete. FAIL (status=%u)\n",
+                             status);
         }
         break;
     case BLE_HCI_LE_SUBEV_ADV_RPT:
         advlen = evdata[9];
         rssi = evdata[10 + advlen];
-        BLE_HS_LOG(DEBUG, "LE advertising report. len=%u num=%u evtype=%u "
-                          "addrtype=%u addr=%x.%x.%x.%x.%x.%x advlen=%u "
-                          "rssi=%d\n", len, evdata[0], evdata[1], evdata[2],
-                   evdata[8], evdata[7], evdata[6], evdata[5],
-                   evdata[4], evdata[3], advlen, rssi);
+        BLE_HS_LOG_DEBUG("LE advertising report. len=%u num=%u evtype=%u "
+                         "addrtype=%u addr=%x.%x.%x.%x.%x.%x advlen=%u "
+                         "rssi=%d\n", len, evdata[0], evdata[1], evdata[2],
+                         evdata[8], evdata[7], evdata[6], evdata[5],
+                         evdata[4], evdata[3], advlen, rssi);
         if (advlen) {
             dptr = &evdata[10];
             while (advlen > 0) {
@@ -91,62 +91,62 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
                     ++dptr;
                 }
                 advlen -= imax;
-                BLE_HS_LOG(DEBUG, "%s\n", adv_data_buf);
+                BLE_HS_LOG_DEBUG("%s\n", adv_data_buf);
             }
         }
         break;
     case BLE_HCI_LE_SUBEV_CONN_UPD_COMPLETE:
         status = evdata[0];
         if (status == BLE_ERR_SUCCESS) {
-            BLE_HS_LOG(DEBUG, "LE Connection Update Complete. handle=%u "
-                              "itvl=%u latency=%u timeout=%u\n",
-                       get_le16(evdata + 1), get_le16(evdata + 3),
-                       get_le16(evdata + 5), get_le16(evdata + 7));
+            BLE_HS_LOG_DEBUG("LE Connection Update Complete. handle=%u "
+                             "itvl=%u latency=%u timeout=%u\n",
+                             get_le16(evdata + 1), get_le16(evdata + 3),
+                             get_le16(evdata + 5), get_le16(evdata + 7));
         } else {
-            BLE_HS_LOG(DEBUG, "LE Connection Update Complete. FAIL "
-                              "(status=%u)\n", status);
+            BLE_HS_LOG_DEBUG("LE Connection Update Complete. FAIL "
+                             "(status=%u)\n", status);
         }
         break;
 
     case BLE_HCI_LE_SUBEV_DATA_LEN_CHG:
-        BLE_HS_LOG(DEBUG, "LE Data Length Change. handle=%u max_tx_bytes=%u "
-                          "max_tx_time=%u max_rx_bytes=%u max_rx_time=%u\n",
-                   get_le16(evdata), get_le16(evdata + 2),
-                   get_le16(evdata + 4), get_le16(evdata + 6),
-                   get_le16(evdata + 8));
+        BLE_HS_LOG_DEBUG("LE Data Length Change. handle=%u max_tx_bytes=%u "
+                         "max_tx_time=%u max_rx_bytes=%u max_rx_time=%u\n",
+                         get_le16(evdata), get_le16(evdata + 2),
+                         get_le16(evdata + 4), get_le16(evdata + 6),
+                         get_le16(evdata + 8));
         break;
     case BLE_HCI_LE_SUBEV_REM_CONN_PARM_REQ:
-        BLE_HS_LOG(DEBUG, "LE Remote Connection Parameter Request. handle=%u "
-                          "min_itvl=%u max_itvl=%u latency=%u timeout=%u\n",
-                   get_le16(evdata), get_le16(evdata + 2),
-                   get_le16(evdata + 4), get_le16(evdata + 6),
-                   get_le16(evdata + 8));
+        BLE_HS_LOG_DEBUG("LE Remote Connection Parameter Request. handle=%u "
+                         "min_itvl=%u max_itvl=%u latency=%u timeout=%u\n",
+                         get_le16(evdata), get_le16(evdata + 2),
+                         get_le16(evdata + 4), get_le16(evdata + 6),
+                         get_le16(evdata + 8));
         break;
 
     case BLE_HCI_LE_SUBEV_RD_REM_USED_FEAT:
         status = evdata[0];
         if (status == BLE_ERR_SUCCESS) {
-            BLE_HS_LOG(DEBUG, "LE Remote Used Features. handle=%u feat=",
-                       get_le16(evdata + 1));
+            BLE_HS_LOG_DEBUG("LE Remote Used Features. handle=%u feat=",
+                             get_le16(evdata + 1));
             for (i = 0; i < BLE_HCI_RD_LOC_SUPP_FEAT_RSPLEN; ++i) {
-                BLE_HS_LOG(DEBUG, "%02x ", evdata[3 + i]);
+                BLE_HS_LOG_DEBUG("%02x ", evdata[3 + i]);
             }
-            BLE_HS_LOG(DEBUG, "\n");
+            BLE_HS_LOG_DEBUG("\n");
         } else {
-            BLE_HS_LOG(DEBUG, "LE Remote Used Features. FAIL (status=%u)\n",
-                       status);
+            BLE_HS_LOG_DEBUG("LE Remote Used Features. FAIL (status=%u)\n",
+                             status);
         }
         break;
 
     case BLE_HCI_LE_SUBEV_LT_KEY_REQ:
-            BLE_HS_LOG(DEBUG, "LE LTK Req. handle=%u rand=%lx%lx encdiv=%u\n",
-                       get_le16(evdata), get_le32(evdata + 6),
-                       get_le32(evdata + 2), get_le16(evdata + 10));
+            BLE_HS_LOG_DEBUG("LE LTK Req. handle=%u rand=%lx%lx encdiv=%u\n",
+                             get_le16(evdata), get_le32(evdata + 6),
+                             get_le32(evdata + 2), get_le16(evdata + 10));
         break;
 
     case BLE_HCI_LE_SUBEV_PHY_UPDATE_COMPLETE:
-            BLE_HS_LOG(DEBUG, "PHY update. handle=%u tx=%u rx=%u\n",
-                       get_le16(evdata + 1), evdata[3], evdata[4]);
+            BLE_HS_LOG_DEBUG("PHY update. handle=%u tx=%u rx=%u\n",
+                             get_le16(evdata + 1), evdata[3], evdata[4]);
         break;
 
     case BLE_HCI_LE_SUBEV_DIRECT_ADV_RPT:
@@ -156,16 +156,16 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
 
         if (len < sizeof(*data) ||
                 len < sizeof(*data) + data->num_reports * sizeof(*params)) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Directed Advertising Report "
-                       "len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Directed Advertising Report "
+                             "len=%u\n", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Directed Advertising Report len=%u "
-                   "num=0x%02x ", len, data->num_reports);
+        BLE_HS_LOG_DEBUG("LE Directed Advertising Report len=%u "
+                         "num=0x%02x ", len, data->num_reports);
 
         for (i = 0; i < data->num_reports; i++) {
-            BLE_HS_LOG(DEBUG, "[%d]={evttype=0x%02x}\n", i, params->evt_type);
+            BLE_HS_LOG_DEBUG("[%d]={evttype=0x%02x}\n", i, params->evt_type);
             params += 1;
         }
         break;
@@ -176,13 +176,13 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
         struct hci_le_subev_rd_loc_p256_pubkey *data = (void *) evdata;
 
         if (len != sizeof(*data)) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Read Local P-256 Public Key "
-                       "Complete Event len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Read Local P-256 Public Key "
+                             "Complete Event len=%u\n", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Read Local P-256 Public Key Complete "
-                   "len=%u status=0x%02x\n", len, data->status);
+        BLE_HS_LOG_DEBUG("LE Read Local P-256 Public Key Complete "
+                         "len=%u status=0x%02x\n", len, data->status);
         break;
     }
 
@@ -191,13 +191,13 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
         struct hci_le_subev_gen_dhkey_complete *data = (void *) evdata;
 
         if (len != sizeof(*data)) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Generate DHKey Complete "
-                       "len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Generate DHKey Complete "
+                             "len=%u\n", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Generate DHKey Complete Event len=%u "
-                   "status=0x%02x\n", len, data->status);
+        BLE_HS_LOG_DEBUG("LE Generate DHKey Complete Event len=%u "
+                         "status=0x%02x\n", len, data->status);
         break;
     }
 
@@ -208,18 +208,18 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
         struct hci_ext_adv_report_param *params;
 
         if (len < sizeof(*data) + sizeof(*params)) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Extended Advertising Report "
-                       "len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Extended Advertising Report "
+                             "len=%u\n", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Extended Advertising Report len=%u num=0x%02x ",
-                   len, data->num_reports);
+        BLE_HS_LOG_DEBUG("LE Extended Advertising Report len=%u num=0x%02x ",
+                         len, data->num_reports);
 
         for (i = 0, dptr = &evdata[1]; i < data->num_reports;  i++) {
             params = (void *) dptr;
-            BLE_HS_LOG(DEBUG, "[%d]={evttype=0x%04x advlen=%u}\n",
-                       i, le16toh(params->evt_type), params->adv_data_len);
+            BLE_HS_LOG_DEBUG("[%d]={evttype=0x%04x advlen=%u}\n",
+                             i, le16toh(params->evt_type), params->adv_data_len);
             dptr += sizeof(*params) + params->adv_data_len;
         }
         break;
@@ -230,14 +230,14 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
         struct hci_le_subev_periodic_adv_sync_estab *data = (void *) evdata;
 
         if (len != sizeof(*data)) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Periodic Advertising Sync "
-                       "Established len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Periodic Advertising Sync "
+                             "Established len=%u\n", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Periodic Advertising Sync Established "
-                   "len=%u status=0x%02x handle=0x%04x", len, data->status,
-                   le16toh(data->sync_handle));
+        BLE_HS_LOG_DEBUG("LE Periodic Advertising Sync Established "
+                         "len=%u status=0x%02x handle=0x%04x", len,
+                         data->status, le16toh(data->sync_handle));
         break;
     }
 
@@ -246,15 +246,16 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
         struct hci_le_subev_periodic_adv_rpt *data = (void *) evdata;
 
         if (len < sizeof(*data) || len != sizeof(*data) + data->data_length) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Periodic Advertising Report "
-                    "len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Periodic Advertising Report "
+                             "len=%u\n", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Periodic Advertising Report "
-                   "len=%u handle=0x%04x data_status=0x%02x data_len=0x%02x",
-                   len, le16toh(data->sync_handle), data->data_status,
-                   data->data_length);
+        BLE_HS_LOG_DEBUG("LE Periodic Advertising Report "
+                         "len=%u handle=0x%04x data_status=0x%02x "
+                         "data_len=0x%02x",
+                         len, le16toh(data->sync_handle), data->data_status,
+                         data->data_length);
         break;
     }
 
@@ -263,24 +264,25 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
         struct hci_le_subev_periodic_adv_sync_lost *data = (void *) evdata;
 
         if (len != sizeof(*data)) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Periodic Advertising Sync Lost "
-                       "len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Periodic Advertising Sync Lost "
+                             "len=%u\n", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Periodic Advertising Sync Lost "
-                   "len=%u handle=0x%04x", len, le16toh(data->sync_handle));
+        BLE_HS_LOG_DEBUG("LE Periodic Advertising Sync Lost "
+                         "len=%u handle=0x%04x", len,
+                         le16toh(data->sync_handle));
         break;
     }
 #endif
 
     case BLE_HCI_LE_SUBEV_SCAN_TIMEOUT:
         if (len) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Scan Timeout len=%u", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Scan Timeout len=%u", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Scan Timeout Event len=%u", len);
+        BLE_HS_LOG_DEBUG("LE Scan Timeout Event len=%u", len);
         break;
 
     case BLE_HCI_LE_SUBEV_ADV_SET_TERMINATED:
@@ -288,16 +290,17 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
         struct hci_le_subev_adv_set_terminated *data = (void *) evdata;
 
         if (len != sizeof(*data)) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Advertising Set Terminated "
-                       "len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Advertising Set Terminated "
+                             "len=%u\n", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Advertising Set Terminated len=%u "
-                   "status=0x%02x adv_handle=0x%02x conn_handle=0x%04x "
-                   "num_compl_ext_adv_ev=0x%02x", len, data->status,
-                   data->adv_handle, le16toh(data->conn_handle),
-                   data->num_compl_ext_adv_ev);
+        BLE_HS_LOG_DEBUG("LE Advertising Set Terminated len=%u "
+                         "status=0x%02x adv_handle=0x%02x conn_handle=0x%04x "
+                         "num_compl_ext_adv_ev=0x%02x",
+                         len, data->status, data->adv_handle,
+                         le16toh(data->conn_handle),
+                         data->num_compl_ext_adv_ev);
         break;
     }
 
@@ -306,13 +309,13 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
         struct hci_le_subev_scan_req_rcvd *data = (void *) evdata;
 
         if (len != sizeof(*data)) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Scan Request Received "
-                       "len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Scan Request Received len=%u\n",
+                             len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Scan Request Received len=%u "
-                   "adv_handle=0x%02x", len, data->adv_handle);
+        BLE_HS_LOG_DEBUG("LE Scan Request Received len=%u "
+                         "adv_handle=0x%02x", len, data->adv_handle);
         break;
     }
 #endif /* MYNEWT_VAL(BLE_EXT_ADV) */
@@ -322,19 +325,19 @@ ble_hs_dbg_le_event_disp(uint8_t subev, uint8_t len, uint8_t *evdata)
         struct hci_le_subev_chan_sel_alg *data = (void *) evdata;
 
         if (len != sizeof(*data)) {
-            BLE_HS_LOG(DEBUG, "Corrupted LE Channel Selection Algorithm "
-                       "len=%u\n", len);
+            BLE_HS_LOG_DEBUG("Corrupted LE Channel Selection Algorithm "
+                             "len=%u\n", len);
             break;
         }
 
-        BLE_HS_LOG(DEBUG, "LE Channel Selection Algorithm len=%u "
-                   "conn_handle=0x%04x chan_sel_alg=0x%02x\n", len,
-                   le16toh(data->conn_handle), data->chan_sel_alg);
+        BLE_HS_LOG_DEBUG("LE Channel Selection Algorithm len=%u "
+                         "conn_handle=0x%04x chan_sel_alg=0x%02x\n", len,
+                         le16toh(data->conn_handle), data->chan_sel_alg);
         break;
     }
 
     default:
-        BLE_HS_LOG(DEBUG, "LE Meta SubEvent op=0x%02x\n", subev);
+        BLE_HS_LOG_DEBUG("LE Meta SubEvent op=0x%02x\n", subev);
         break;
     }
 }
@@ -361,8 +364,8 @@ ble_hs_dbg_disconn_comp_disp(uint8_t *evdata, uint8_t len)
     } else {
         reason = evdata[3];
     }
-    BLE_HS_LOG(DEBUG, "Disconnection Complete: status=%u handle=%u "
-                      "reason=%u\n", status, handle, reason);
+    BLE_HS_LOG_DEBUG("Disconnection Complete: status=%u handle=%u "
+                     "reason=%u\n", status, handle, reason);
 }
 
 /**
@@ -387,8 +390,8 @@ ble_hs_dbg_encrypt_chg_disp(uint8_t *evdata, uint8_t len)
     } else {
         enabled = evdata[3];
     }
-    BLE_HS_LOG(DEBUG, "Encrypt change: status=%u handle=%u state=%u\n",
-               status, handle, enabled);
+    BLE_HS_LOG_DEBUG("Encrypt change: status=%u handle=%u state=%u\n",
+                     status, handle, enabled);
 }
 
 /**
@@ -406,8 +409,8 @@ ble_hs_dbg_encrypt_refresh_disp(uint8_t *evdata, uint8_t len)
     status = evdata[0];
     handle = get_le16(evdata + 1);
 
-    BLE_HS_LOG(DEBUG, "Encrypt key refresh: status=%u handle=%u\n",
-               status, handle);
+    BLE_HS_LOG_DEBUG("Encrypt key refresh: status=%u handle=%u\n",
+                     status, handle);
 }
 
 /**
@@ -419,10 +422,10 @@ ble_hs_dbg_encrypt_refresh_disp(uint8_t *evdata, uint8_t len)
 static void
 ble_hs_dbg_rd_rem_ver_disp(uint8_t *evdata, uint8_t len)
 {
-    BLE_HS_LOG(DEBUG, "Remote Version Info: status=%u handle=%u vers_nr=%u "
-                      "compid=%u subver=%u\n",
-               evdata[0], get_le16(evdata + 1), evdata[3],
-               get_le16(evdata + 4), get_le16(evdata + 6));
+    BLE_HS_LOG_DEBUG("Remote Version Info: status=%u handle=%u vers_nr=%u "
+                     "compid=%u subver=%u\n",
+                     evdata[0], get_le16(evdata + 1), evdata[3],
+                     get_le16(evdata + 4), get_le16(evdata + 6));
 }
 
 /**
@@ -441,21 +444,21 @@ ble_hs_dbg_num_comp_pkts_disp(uint8_t *evdata, uint8_t len)
 
     handles = evdata[0];
     if (len != ((handles * 4) + 1)) {
-        BLE_HS_LOG(DEBUG, "ERR: Number of Completed Packets bad length: "
-                          "num_handles=%u len=%u\n", handles, len);
+        BLE_HS_LOG_DEBUG("ERR: Number of Completed Packets bad length: "
+                         "num_handles=%u len=%u\n", handles, len);
         return;
 
     }
 
-    BLE_HS_LOG(DEBUG, "Number of Completed Packets: num_handles=%u\n",
-               handles);
+    BLE_HS_LOG_DEBUG("Number of Completed Packets: num_handles=%u\n",
+                     handles);
     if (handles) {
         handle_ptr = evdata + 1;
         while (handles) {
             handle = get_le16(handle_ptr);
             pkts = get_le16(handle_ptr + 2);
             handle_ptr += 4;
-            BLE_HS_LOG(DEBUG, "handle:%u pkts:%u\n", handle, pkts);
+            BLE_HS_LOG_DEBUG("handle:%u pkts:%u\n", handle, pkts);
             --handles;
         }
     }
@@ -473,13 +476,13 @@ ble_hs_dbg_auth_pyld_tmo_disp(uint8_t *evdata, uint8_t len)
     uint16_t handle;
 
     if (len != sizeof(uint16_t)) {
-        BLE_HS_LOG(DEBUG, "ERR: AuthPyldTmoEvent bad length %u\n", len);
+        BLE_HS_LOG_DEBUG("ERR: AuthPyldTmoEvent bad length %u\n", len);
         return;
 
     }
 
     handle = get_le16(evdata);
-    BLE_HS_LOG(DEBUG, "AuthPyldTmo: handle=%u\n", handle);
+    BLE_HS_LOG_DEBUG("AuthPyldTmo: handle=%u\n", handle);
 }
 
 
@@ -495,29 +498,29 @@ ble_hs_dbg_cmd_comp_info_params(uint8_t status, uint8_t ocf, uint8_t *evdata)
 
     switch (ocf) {
     case BLE_HCI_OCF_IP_RD_LOCAL_VER:
-        BLE_HS_LOG(DEBUG, "hci_ver=%u hci_rev=%u lmp_ver=%u mfrg=%u "
-                          "lmp_subver=%u",
-                   evdata[0], get_le16(evdata + 1), evdata[3],
-                   get_le16(evdata + 4), get_le16(evdata + 6));
+        BLE_HS_LOG_DEBUG("hci_ver=%u hci_rev=%u lmp_ver=%u mfrg=%u "
+                         "lmp_subver=%u",
+                         evdata[0], get_le16(evdata + 1), evdata[3],
+                         get_le16(evdata + 4), get_le16(evdata + 6));
         break;
     case BLE_HCI_OCF_IP_RD_LOC_SUPP_CMD:
-        BLE_HS_LOG(DEBUG, "supp_cmds=");
+        BLE_HS_LOG_DEBUG("supp_cmds=");
         dptr = evdata;
         for (i = 0; i < 8; ++i) {
-            BLE_HS_LOG(DEBUG, "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:",
-                       dptr[0], dptr[1], dptr[2], dptr[3],
-                       dptr[4], dptr[5], dptr[6], dptr[7]);
+            BLE_HS_LOG_DEBUG("%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:",
+                             dptr[0], dptr[1], dptr[2], dptr[3],
+                             dptr[4], dptr[5], dptr[6], dptr[7]);
             dptr += 8;
         }
         break;
     case BLE_HCI_OCF_IP_RD_LOC_SUPP_FEAT:
-        BLE_HS_LOG(DEBUG, "supp_feat=0x%lx%08lx",
-                   get_le32(evdata + 4), get_le32(evdata));
+        BLE_HS_LOG_DEBUG("supp_feat=0x%lx%08lx",
+                         get_le32(evdata + 4), get_le32(evdata));
         break;
     case BLE_HCI_OCF_IP_RD_BD_ADDR:
-        BLE_HS_LOG(DEBUG, "bd_addr=%x:%x:%x:%x:%x:%x",
-                   evdata[5], evdata[4], evdata[3],
-                   evdata[2], evdata[1], evdata[0]);
+        BLE_HS_LOG_DEBUG("bd_addr=%x:%x:%x:%x:%x:%x",
+                         evdata[5], evdata[4], evdata[3],
+                         evdata[2], evdata[1], evdata[0]);
         break;
     default:
         break;
@@ -534,8 +537,8 @@ ble_hs_dbg_cmd_complete_disp(uint8_t *evdata, uint8_t len)
     uint16_t opcode;
 
     if (len < 3) {
-        BLE_HS_LOG(DEBUG, "Invalid command complete: len=%d "
-                          "(expected >= 3)", len);
+        BLE_HS_LOG_DEBUG("Invalid command complete: len=%d "
+                         "(expected >= 3)", len);
         goto done;
     }
 
@@ -544,15 +547,15 @@ ble_hs_dbg_cmd_complete_disp(uint8_t *evdata, uint8_t len)
     ogf = BLE_HCI_OGF(opcode);
     ocf = BLE_HCI_OCF(opcode);
 
-    BLE_HS_LOG(DEBUG, "Command complete: cmd_pkts=%u ogf=0x%x ocf=0x%x",
-               cmd_pkts, ogf, ocf);
+    BLE_HS_LOG_DEBUG("Command complete: cmd_pkts=%u ogf=0x%x ocf=0x%x",
+                     cmd_pkts, ogf, ocf);
 
     if (len == 3) {
         goto done;
     }
 
     status = evdata[3];
-    BLE_HS_LOG(DEBUG, " status=%u ", status);
+    BLE_HS_LOG_DEBUG(" status=%u ", status);
 
     /* Move past header and status */
     evdata += 4;
@@ -565,8 +568,8 @@ ble_hs_dbg_cmd_complete_disp(uint8_t *evdata, uint8_t len)
     case BLE_HCI_OGF_STATUS_PARAMS:
         switch (ocf) {
         case BLE_HCI_OCF_RD_RSSI:
-            BLE_HS_LOG(DEBUG, "handle=%u rssi=%d", get_le16(evdata),
-                       (int8_t)evdata[2]);
+            BLE_HS_LOG_DEBUG("handle=%u rssi=%d", get_le16(evdata),
+                             (int8_t)evdata[2]);
             break;
         default:
             break;
@@ -575,41 +578,41 @@ ble_hs_dbg_cmd_complete_disp(uint8_t *evdata, uint8_t len)
     case BLE_HCI_OGF_LE:
         switch (ocf) {
         case BLE_HCI_OCF_LE_RD_CHAN_MAP:
-            BLE_HS_LOG(DEBUG, "handle=%u chanmap=%x.%x.%x.%x.%x",
-                       get_le16(evdata), evdata[2], evdata[3], evdata[4],
-                       evdata[5], evdata[6]);
+            BLE_HS_LOG_DEBUG("handle=%u chanmap=%x.%x.%x.%x.%x",
+                             get_le16(evdata), evdata[2], evdata[3], evdata[4],
+                             evdata[5], evdata[6]);
             break;
         case BLE_HCI_OCF_LE_RD_MAX_DATA_LEN:
-            BLE_HS_LOG(DEBUG, "txoct=%u txtime=%u rxoct=%u rxtime=%u",
-                       get_le16(evdata), get_le16(evdata + 2),
-                       get_le16(evdata + 4), get_le16(evdata + 6));
+            BLE_HS_LOG_DEBUG("txoct=%u txtime=%u rxoct=%u rxtime=%u",
+                             get_le16(evdata), get_le16(evdata + 2),
+                             get_le16(evdata + 4), get_le16(evdata + 6));
             break;
         case BLE_HCI_OCF_LE_RD_SUPP_STATES:
-            BLE_HS_LOG(DEBUG, "states=0x%lx%08lx", get_le32(evdata + 4),
-                       get_le32(evdata));
+            BLE_HS_LOG_DEBUG("states=0x%lx%08lx", get_le32(evdata + 4),
+                             get_le32(evdata));
             break;
         case BLE_HCI_OCF_LE_ENCRYPT:
-            BLE_HS_LOG(DEBUG, "encdata=0x%02x%02x%02x%02x%02x%02x%02x%02x",
-                       evdata[15], evdata[14], evdata[13], evdata[12],
-                       evdata[11], evdata[10], evdata[9], evdata[8]);
-            BLE_HS_LOG(DEBUG, "%02x%02x%02x%02x%02x%02x%02x%02x",
-                       evdata[7], evdata[6], evdata[5], evdata[4],
-                       evdata[3], evdata[2], evdata[1], evdata[0]);
+            BLE_HS_LOG_DEBUG("encdata=0x%02x%02x%02x%02x%02x%02x%02x%02x",
+                             evdata[15], evdata[14], evdata[13], evdata[12],
+                             evdata[11], evdata[10], evdata[9], evdata[8]);
+            BLE_HS_LOG_DEBUG("%02x%02x%02x%02x%02x%02x%02x%02x",
+                             evdata[7], evdata[6], evdata[5], evdata[4],
+                             evdata[3], evdata[2], evdata[1], evdata[0]);
 
             break;
         case BLE_HCI_OCF_LE_RAND:
-            BLE_HS_LOG(DEBUG, "rand=0x%02x%02x%02x%02x%02x%02x%02x%02x",
-                       evdata[0], evdata[1], evdata[2], evdata[3],
-                       evdata[4], evdata[5], evdata[6], evdata[7]);
+            BLE_HS_LOG_DEBUG("rand=0x%02x%02x%02x%02x%02x%02x%02x%02x",
+                             evdata[0], evdata[1], evdata[2], evdata[3],
+                             evdata[4], evdata[5], evdata[6], evdata[7]);
             break;
         case BLE_HCI_OCF_LE_RD_SUGG_DEF_DATA_LEN:
-            BLE_HS_LOG(DEBUG, "txoct=%u txtime=%u", get_le16(evdata),
-                       get_le16(evdata + 2));
+            BLE_HS_LOG_DEBUG("txoct=%u txtime=%u", get_le16(evdata),
+                             get_le16(evdata + 2));
             break;
         case BLE_HCI_OCF_LE_LT_KEY_REQ_REPLY:
         case BLE_HCI_OCF_LE_LT_KEY_REQ_NEG_REPLY:
         case BLE_HCI_OCF_LE_SET_DATA_LEN:
-            BLE_HS_LOG(DEBUG, "handle=%u", get_le16(evdata));
+            BLE_HS_LOG_DEBUG("handle=%u", get_le16(evdata));
             break;
         default:
             break;
@@ -620,7 +623,7 @@ ble_hs_dbg_cmd_complete_disp(uint8_t *evdata, uint8_t len)
     }
 
 done:
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 }
 
 static void
@@ -634,8 +637,8 @@ ble_hs_dbg_cmd_status_disp(uint8_t *evdata, uint8_t len)
     ogf = BLE_HCI_OGF(opcode);
     ocf = BLE_HCI_OCF(opcode);
 
-    BLE_HS_LOG(DEBUG, "Command Status: status=%u cmd_pkts=%u ocf=0x%x "
-                      "ogf=0x%x\n", evdata[0], evdata[1], ocf, ogf);
+    BLE_HS_LOG_DEBUG("Command Status: status=%u cmd_pkts=%u ocf=0x%x "
+                     "ogf=0x%x\n", evdata[0], evdata[1], ocf, ogf);
 }
 
 void
@@ -683,7 +686,7 @@ ble_hs_dbg_event_disp(uint8_t *evbuf)
         ble_hs_dbg_auth_pyld_tmo_disp(evdata, len);
         break;
     default:
-        BLE_HS_LOG(DEBUG, "Unknown event 0x%x len=%u\n", evcode, len);
+        BLE_HS_LOG_DEBUG("Unknown event 0x%x len=%u\n", evcode, len);
         break;
     }
 }

--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -488,8 +488,8 @@ ble_hs_hci_acl_hdr_prepend(struct os_mbuf *om, uint16_t handle,
     memcpy(om->om_data, &hci_hdr, sizeof hci_hdr);
 
 #if !BLE_MONITOR
-    BLE_HS_LOG(DEBUG, "host tx hci data; handle=%d length=%d\n", handle,
-               get_le16(&hci_hdr.hdh_len));
+    BLE_HS_LOG_DEBUG("host tx hci data; handle=%d length=%d\n", handle,
+                     get_le16(&hci_hdr.hdh_len));
 #endif
 
     return om;
@@ -534,9 +534,9 @@ ble_hs_hci_acl_tx_now(struct ble_hs_conn *conn, struct os_mbuf **om)
         }
 
 #if !BLE_MONITOR
-        BLE_HS_LOG(DEBUG, "ble_hs_hci_acl_tx(): ");
+        BLE_HS_LOG_DEBUG("ble_hs_hci_acl_tx(): ");
         ble_hs_log_mbuf(frag);
-        BLE_HS_LOG(DEBUG, "\n");
+        BLE_HS_LOG_DEBUG("\n");
 #endif
 
         rc = ble_hs_tx_data(frag);

--- a/nimble/host/src/ble_hs_hci_cmd.c
+++ b/nimble/host/src/ble_hs_hci_cmd.c
@@ -81,10 +81,10 @@ ble_hs_hci_cmd_send(uint16_t opcode, uint8_t len, const void *cmddata)
     }
 
 #if !BLE_MONITOR
-    BLE_HS_LOG(DEBUG, "ble_hs_hci_cmd_send: ogf=0x%02x ocf=0x%04x len=%d\n",
-               BLE_HCI_OGF(opcode), BLE_HCI_OCF(opcode), len);
+    BLE_HS_LOG_DEBUG("ble_hs_hci_cmd_send: ogf=0x%02x ocf=0x%04x len=%d\n",
+                     BLE_HCI_OGF(opcode), BLE_HCI_OCF(opcode), len);
     ble_hs_log_flat_buf(buf, len + BLE_HCI_CMD_HDR_LEN);
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 #endif
 
     rc = ble_hs_hci_cmd_transport(buf);
@@ -92,7 +92,7 @@ ble_hs_hci_cmd_send(uint16_t opcode, uint8_t len, const void *cmddata)
     if (rc == 0) {
         STATS_INC(ble_hs_stats, hci_cmd);
     } else {
-        BLE_HS_LOG(DEBUG, "ble_hs_hci_cmd_send failure; rc=%d\n", rc);
+        BLE_HS_LOG_DEBUG("ble_hs_hci_cmd_send failure; rc=%d\n", rc);
     }
 
     return rc;

--- a/nimble/host/src/ble_hs_hci_evt.c
+++ b/nimble/host/src/ble_hs_hci_evt.c
@@ -898,13 +898,13 @@ ble_hs_hci_evt_acl_process(struct os_mbuf *om)
 
 #if (BLETEST_THROUGHPUT_TEST == 0)
 #if !BLE_MONITOR
-    BLE_HS_LOG(DEBUG, "ble_hs_hci_evt_acl_process(): conn_handle=%u pb=%x "
-                      "len=%u data=",
-               BLE_HCI_DATA_HANDLE(hci_hdr.hdh_handle_pb_bc),
-               BLE_HCI_DATA_PB(hci_hdr.hdh_handle_pb_bc),
-               hci_hdr.hdh_len);
+    BLE_HS_LOG_DEBUG("ble_hs_hci_evt_acl_process(): conn_handle=%u pb=%x "
+                     "len=%u data=",
+                     BLE_HCI_DATA_HANDLE(hci_hdr.hdh_handle_pb_bc),
+                     BLE_HCI_DATA_PB(hci_hdr.hdh_handle_pb_bc),
+                     hci_hdr.hdh_len);
     ble_hs_log_mbuf(om);
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 #endif
 #endif
 

--- a/nimble/host/src/ble_hs_hci_util.c
+++ b/nimble/host/src/ble_hs_hci_util.c
@@ -50,7 +50,7 @@ ble_hs_hci_util_read_adv_tx_pwr(int8_t *out_tx_pwr)
     if (params_len != 1                     ||
         *out_tx_pwr < BLE_HCI_ADV_CHAN_TXPWR_MIN ||
         *out_tx_pwr > BLE_HCI_ADV_CHAN_TXPWR_MAX) {
-        BLE_HS_LOG(WARN, "advertiser txpwr out of range\n");
+        BLE_HS_LOG_WARN("advertiser txpwr out of range\n");
     }
 
     return 0;

--- a/nimble/host/src/ble_hs_log.c
+++ b/nimble/host/src/ble_hs_log.c
@@ -30,7 +30,7 @@ ble_hs_log_mbuf(const struct os_mbuf *om)
 
     for (i = 0; i < OS_MBUF_PKTLEN(om); i++) {
         os_mbuf_copydata(om, i, 1, &u8);
-        BLE_HS_LOG(DEBUG, "0x%02x ", u8);
+        BLE_HS_LOG_DEBUG("0x%02x ", u8);
     }
 }
 
@@ -42,6 +42,6 @@ ble_hs_log_flat_buf(const void *data, int len)
 
     u8ptr = data;
     for (i = 0; i < len; i++) {
-        BLE_HS_LOG(DEBUG, "0x%02x ", u8ptr[i]);
+        BLE_HS_LOG_DEBUG("0x%02x ", u8ptr[i]);
     }
 }

--- a/nimble/host/src/ble_hs_misc.c
+++ b/nimble/host/src/ble_hs_misc.c
@@ -108,7 +108,7 @@ ble_hs_misc_restore_one_irk(int obj_type, union ble_store_value *val,
         rc = ble_hs_pvcy_add_entry(sec->peer_addr.val, sec->peer_addr.type,
                                    sec->irk);
         if (rc != 0) {
-            BLE_HS_LOG(ERROR, "failed to configure restored IRK\n");
+            BLE_HS_LOG_ERROR("failed to configure restored IRK\n");
         }
     }
 

--- a/nimble/host/src/ble_hs_priv.h
+++ b/nimble/host/src/ble_hs_priv.h
@@ -147,17 +147,19 @@ int ble_mqueue_put(struct ble_mqueue *mq, struct ble_npl_eventq *evq, struct os_
 #define BLE_HS_LOG_CMD(is_tx, cmd_type, cmd_name, conn_handle,                \
                        log_cb, cmd) do                                        \
 {                                                                             \
-    BLE_HS_LOG(DEBUG, "%sed %s command: %s; conn=%d ",                        \
-               (is_tx) ? "tx" : "rx", (cmd_type), (cmd_name), (conn_handle)); \
+    BLE_HS_LOG_DEBUG("%sed %s command: %s; conn=%d ",                         \
+                     (is_tx) ? "tx" : "rx", (cmd_type), (cmd_name),           \
+                     (conn_handle));                                          \
     (log_cb)(cmd);                                                            \
-    BLE_HS_LOG(DEBUG, "\n");                                                  \
+    BLE_HS_LOG_DEBUG("\n");                                                   \
 } while (0)
 
 #define BLE_HS_LOG_EMPTY_CMD(is_tx, cmd_type, cmd_name, conn_handle) do       \
 {                                                                             \
-    BLE_HS_LOG(DEBUG, "%sed %s command: %s; conn=%d ",                        \
-               (is_tx) ? "tx" : "rx", (cmd_type), (cmd_name), (conn_handle)); \
-    BLE_HS_LOG(DEBUG, "\n");                                                  \
+    BLE_HS_LOG_DEBUG("%sed %s command: %s; conn=%d ",                         \
+                     (is_tx) ? "tx" : "rx", (cmd_type), (cmd_name),           \
+                     (conn_handle));                                          \
+    BLE_HS_LOG_DEBUG("\n");                                                   \
 } while (0)
 
 #else

--- a/nimble/host/src/ble_hs_shutdown.c
+++ b/nimble/host/src/ble_hs_shutdown.c
@@ -61,7 +61,7 @@ ble_hs_shutdown(int reason)
         return SYSDOWN_COMPLETE;
 
     default:
-        BLE_HS_LOG(ERROR, "ble_hs_shutdown: failed to stop host; rc=%d\n", rc);
+        BLE_HS_LOG_ERROR("ble_hs_shutdown: failed to stop host; rc=%d\n", rc);
         return SYSDOWN_COMPLETE;
     }
 }

--- a/nimble/host/src/ble_hs_startup.c
+++ b/nimble/host/src/ble_hs_startup.c
@@ -47,7 +47,7 @@ ble_hs_startup_read_sup_f_tx(void)
      * LE Supported (Controller) byte 4, bit 6
      */
     if (!(ack_params[4] & 0x60)) {
-        BLE_HS_LOG(ERROR, "Controller doesn't support LE\n");
+        BLE_HS_LOG_ERROR("Controller doesn't support LE\n");
         return BLE_HS_ECONTROLLER;
     }
 
@@ -356,7 +356,7 @@ ble_hs_startup_go(void)
     /* we need to check this only if using external controller */
 #if !MYNEWT_VAL(BLE_CONTROLLER)
     if (ble_hs_hci_get_hci_version() < BLE_HCI_VER_BCS_4_0) {
-        BLE_HS_LOG(ERROR, "Required controller version is 4.0 (6)\n");
+        BLE_HS_LOG_ERROR("Required controller version is 4.0 (6)\n");
         return BLE_HS_ECONTROLLER;
     }
 

--- a/nimble/host/src/ble_hs_stop.c
+++ b/nimble/host/src/ble_hs_stop.c
@@ -84,8 +84,8 @@ ble_hs_stop_terminate_all_periodic_sync(void)
         sync_handle = psync->sync_handle;
         rc = ble_gap_periodic_adv_terminate_sync(sync_handle);
         if (rc != 0 && rc != BLE_HS_ENOTCONN) {
-            BLE_HS_LOG(ERROR, "failed to terminate periodic sync=0x%04x, rc=%d\n",
-                       sync_handle, rc);
+            BLE_HS_LOG_ERROR("failed to terminate periodic sync=0x%04x, rc=%d\n",
+                             sync_handle, rc);
             return rc;
         }
     }
@@ -119,7 +119,7 @@ ble_hs_stop_terminate_next_conn(void)
          * handler deal with the result.
          */
     } else {
-        BLE_HS_LOG(ERROR,
+        BLE_HS_LOG_ERROR(
             "ble_hs_stop: failed to terminate connection; rc=%d\n", rc);
         ble_hs_stop_done(rc);
     }

--- a/nimble/host/src/ble_l2cap.c
+++ b/nimble/host/src/ble_l2cap.c
@@ -329,8 +329,8 @@ ble_l2cap_rx(struct ble_hs_conn *conn,
              * CID response.
              */
             if (l2cap_hdr.cid != BLE_L2CAP_CID_BLACK_HOLE) {
-                BLE_HS_LOG(DEBUG, "rx on unknown L2CAP channel: %d\n",
-                           l2cap_hdr.cid);
+                BLE_HS_LOG_DEBUG("rx on unknown L2CAP channel: %d\n",
+                                 l2cap_hdr.cid);
                 *out_reject_cid = l2cap_hdr.cid;
             }
             goto err;

--- a/nimble/host/src/ble_l2cap_sig.c
+++ b/nimble/host/src/ble_l2cap_sig.c
@@ -743,7 +743,7 @@ ble_l2cap_sig_coc_rsp_rx(uint16_t conn_handle, struct ble_l2cap_sig_hdr *hdr,
     int rc;
 
 #if !BLE_MONITOR
-    BLE_HS_LOG(DEBUG, "L2CAP LE COC connection response received\n");
+    BLE_HS_LOG_DEBUG("L2CAP LE COC connection response received\n");
 #endif
 
     proc = ble_l2cap_sig_proc_extract(conn_handle,
@@ -1115,9 +1115,9 @@ ble_l2cap_sig_rx(struct ble_l2cap_chan *chan)
     STATS_INC(ble_l2cap_stats, sig_rx);
 
 #if !BLE_MONITOR
-    BLE_HS_LOG(DEBUG, "L2CAP - rxed signalling msg: ");
+    BLE_HS_LOG_DEBUG("L2CAP - rxed signalling msg: ");
     ble_hs_log_mbuf(*om);
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 #endif
 
     rc = ble_hs_mbuf_pullup_base(om, BLE_L2CAP_SIG_HDR_SZ);

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -871,7 +871,7 @@ ble_sm_chk_repeat_pairing(uint16_t conn_handle,
         rc = ble_gap_repeat_pairing_event(&rp);
     } while (rc == BLE_GAP_REPEAT_PAIRING_RETRY);
 
-    BLE_HS_LOG(DEBUG, "silently ignoring pair request from bonded peer");
+    BLE_HS_LOG_DEBUG("silently ignoring pair request from bonded peer");
 
     return BLE_HS_EALREADY;
 }
@@ -2164,7 +2164,7 @@ err:
 static void
 ble_sm_key_rxed(struct ble_sm_proc *proc, struct ble_sm_result *res)
 {
-    BLE_HS_LOG(DEBUG, "rx_key_flags=0x%02x\n", proc->rx_key_flags);
+    BLE_HS_LOG_DEBUG("rx_key_flags=0x%02x\n", proc->rx_key_flags);
 
     if (proc->rx_key_flags == 0) {
         /* The peer is done sending keys.  If we are the initiator, we need to

--- a/nimble/host/src/ble_sm_alg.c
+++ b/nimble/host/src/ble_sm_alg.c
@@ -101,15 +101,15 @@ ble_sm_alg_s1(uint8_t *k, uint8_t *r1, uint8_t *r2, uint8_t *out)
         return rc;
     }
 
-    BLE_HS_LOG(DEBUG, "ble_sm_alg_s1()\n    k=");
+    BLE_HS_LOG_DEBUG("ble_sm_alg_s1()\n    k=");
     ble_hs_log_flat_buf(k, 16);
-    BLE_HS_LOG(DEBUG, "\n    r1=");
+    BLE_HS_LOG_DEBUG("\n    r1=");
     ble_hs_log_flat_buf(r1, 16);
-    BLE_HS_LOG(DEBUG, "\n    r2=");
+    BLE_HS_LOG_DEBUG("\n    r2=");
     ble_hs_log_flat_buf(r2, 16);
-    BLE_HS_LOG(DEBUG, "\n    out=");
+    BLE_HS_LOG_DEBUG("\n    out=");
     ble_hs_log_flat_buf(out, 16);
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 
     return 0;
 }
@@ -124,18 +124,18 @@ ble_sm_alg_c1(uint8_t *k, uint8_t *r,
     uint8_t p1[16], p2[16];
     int rc;
 
-    BLE_HS_LOG(DEBUG, "ble_sm_alg_c1()\n    k=");
+    BLE_HS_LOG_DEBUG("ble_sm_alg_c1()\n    k=");
     ble_hs_log_flat_buf(k, 16);
-    BLE_HS_LOG(DEBUG, "\n    r=");
+    BLE_HS_LOG_DEBUG("\n    r=");
     ble_hs_log_flat_buf(r, 16);
-    BLE_HS_LOG(DEBUG, "\n    iat=%d rat=%d", iat, rat);
-    BLE_HS_LOG(DEBUG, "\n    ia=");
+    BLE_HS_LOG_DEBUG("\n    iat=%d rat=%d", iat, rat);
+    BLE_HS_LOG_DEBUG("\n    ia=");
     ble_hs_log_flat_buf(ia, 6);
-    BLE_HS_LOG(DEBUG, "\n    ra=");
+    BLE_HS_LOG_DEBUG("\n    ra=");
     ble_hs_log_flat_buf(ra, 6);
-    BLE_HS_LOG(DEBUG, "\n    preq=");
+    BLE_HS_LOG_DEBUG("\n    preq=");
     ble_hs_log_flat_buf(preq, 7);
-    BLE_HS_LOG(DEBUG, "\n    pres=");
+    BLE_HS_LOG_DEBUG("\n    pres=");
     ble_hs_log_flat_buf(pres, 7);
 
     /* pres, preq, rat and iat are concatenated to generate p1 */
@@ -144,7 +144,7 @@ ble_sm_alg_c1(uint8_t *k, uint8_t *r,
     memcpy(p1 + 2, preq, 7);
     memcpy(p1 + 9, pres, 7);
 
-    BLE_HS_LOG(DEBUG, "\n    p1=");
+    BLE_HS_LOG_DEBUG("\n    p1=");
     ble_hs_log_flat_buf(p1, sizeof p1);
 
     /* c1 = e(k, e(k, r XOR p1) XOR p2) */
@@ -163,7 +163,7 @@ ble_sm_alg_c1(uint8_t *k, uint8_t *r,
     memcpy(p2 + 6, ia, 6);
     memset(p2 + 12, 0, 4);
 
-    BLE_HS_LOG(DEBUG, "\n    p2=");
+    BLE_HS_LOG_DEBUG("\n    p2=");
     ble_hs_log_flat_buf(p2, sizeof p2);
 
     ble_sm_alg_xor_128(out_enc_data, p2, out_enc_data);
@@ -174,13 +174,13 @@ ble_sm_alg_c1(uint8_t *k, uint8_t *r,
         goto done;
     }
 
-    BLE_HS_LOG(DEBUG, "\n    out_enc_data=");
+    BLE_HS_LOG_DEBUG("\n    out_enc_data=");
     ble_hs_log_flat_buf(out_enc_data, 16);
 
     rc = 0;
 
 done:
-    BLE_HS_LOG(DEBUG, "\n    rc=%d\n", rc);
+    BLE_HS_LOG_DEBUG("\n    rc=%d\n", rc);
     return rc;
 }
 
@@ -189,9 +189,9 @@ done:
 static void
 ble_sm_alg_log_buf(const char *name, const uint8_t *buf, int len)
 {
-    BLE_HS_LOG(DEBUG, "    %s=", name);
+    BLE_HS_LOG_DEBUG("    %s=", name);
     ble_hs_log_flat_buf(buf, len);
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 }
 
 /**
@@ -232,13 +232,13 @@ ble_sm_alg_f4(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t z,
     uint8_t m[65];
     int rc;
 
-    BLE_HS_LOG(DEBUG, "ble_sm_alg_f4()\n    u=");
+    BLE_HS_LOG_DEBUG("ble_sm_alg_f4()\n    u=");
     ble_hs_log_flat_buf(u, 32);
-    BLE_HS_LOG(DEBUG, "\n    v=");
+    BLE_HS_LOG_DEBUG("\n    v=");
     ble_hs_log_flat_buf(v, 32);
-    BLE_HS_LOG(DEBUG, "\n    x=");
+    BLE_HS_LOG_DEBUG("\n    x=");
     ble_hs_log_flat_buf(x, 16);
-    BLE_HS_LOG(DEBUG, "\n    z=0x%02x\n", z);
+    BLE_HS_LOG_DEBUG("\n    z=0x%02x\n", z);
 
     /*
      * U, V and Z are concatenated and used as input m to the function
@@ -262,9 +262,9 @@ ble_sm_alg_f4(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t z,
 
     swap_in_place(out_enc_data, 16);
 
-    BLE_HS_LOG(DEBUG, "    out_enc_data=");
+    BLE_HS_LOG_DEBUG("    out_enc_data=");
     ble_hs_log_flat_buf(out_enc_data, 16);
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 
     return 0;
 }
@@ -292,7 +292,7 @@ ble_sm_alg_f5(uint8_t *w, uint8_t *n1, uint8_t *n2, uint8_t a1t,
     uint8_t t[16];
     int rc;
 
-    BLE_HS_LOG(DEBUG, "ble_sm_alg_f5()\n");
+    BLE_HS_LOG_DEBUG("ble_sm_alg_f5()\n");
     ble_sm_alg_log_buf("w", w, 32);
     ble_sm_alg_log_buf("n1", n1, 16);
     ble_sm_alg_log_buf("n2", n2, 16);
@@ -347,7 +347,7 @@ ble_sm_alg_f6(const uint8_t *w, const uint8_t *n1, const uint8_t *n2,
     uint8_t m[65];
     int rc;
 
-    BLE_HS_LOG(DEBUG, "ble_sm_alg_f6()\n");
+    BLE_HS_LOG_DEBUG("ble_sm_alg_f6()\n");
     ble_sm_alg_log_buf("w", w, 16);
     ble_sm_alg_log_buf("n1", n1, 16);
     ble_sm_alg_log_buf("n2", n2, 16);
@@ -392,7 +392,7 @@ ble_sm_alg_g2(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t *y,
     uint8_t m[80], xs[16];
     int rc;
 
-    BLE_HS_LOG(DEBUG, "ble_sm_alg_g2()\n");
+    BLE_HS_LOG_DEBUG("ble_sm_alg_g2()\n");
     ble_sm_alg_log_buf("u", u, 32);
     ble_sm_alg_log_buf("v", v, 32);
     ble_sm_alg_log_buf("x", x, 16);
@@ -413,7 +413,7 @@ ble_sm_alg_g2(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t *y,
     ble_sm_alg_log_buf("res", xs, 16);
 
     *passkey = get_be32(xs + 12) % 1000000;
-    BLE_HS_LOG(DEBUG, "    passkey=%u\n", *passkey);
+    BLE_HS_LOG_DEBUG("    passkey=%u\n", *passkey);
 
     return 0;
 }

--- a/nimble/host/src/ble_sm_cmd.c
+++ b/nimble/host/src/ble_sm_cmd.c
@@ -66,7 +66,7 @@ ble_sm_tx(uint16_t conn_handle, struct os_mbuf *txom)
 void
 ble_sm_pair_cmd_log(struct ble_sm_pair_cmd *cmd)
 {
-    BLE_HS_LOG(DEBUG, "io_cap=%d oob_data_flag=%d authreq=0x%02x "
+    BLE_HS_LOG_DEBUG("io_cap=%d oob_data_flag=%d authreq=0x%02x "
                       "mac_enc_key_size=%d init_key_dist=%d "
                       "resp_key_dist=%d",
                cmd->io_cap, cmd->oob_data_flag, cmd->authreq,
@@ -77,27 +77,27 @@ ble_sm_pair_cmd_log(struct ble_sm_pair_cmd *cmd)
 void
 ble_sm_pair_confirm_log(struct ble_sm_pair_confirm *cmd)
 {
-    BLE_HS_LOG(DEBUG, "value=");
+    BLE_HS_LOG_DEBUG("value=");
     ble_hs_log_flat_buf(cmd->value, sizeof cmd->value);
 }
 
 void
 ble_sm_pair_random_log(struct ble_sm_pair_random *cmd)
 {
-    BLE_HS_LOG(DEBUG, "value=");
+    BLE_HS_LOG_DEBUG("value=");
     ble_hs_log_flat_buf(cmd->value, sizeof cmd->value);
 }
 
 void
 ble_sm_pair_fail_log(struct ble_sm_pair_fail *cmd)
 {
-    BLE_HS_LOG(DEBUG, "reason=%d", cmd->reason);
+    BLE_HS_LOG_DEBUG("reason=%d", cmd->reason);
 }
 
 void
 ble_sm_enc_info_log(struct ble_sm_enc_info *cmd)
 {
-    BLE_HS_LOG(DEBUG, "ltk=");
+    BLE_HS_LOG_DEBUG("ltk=");
     ble_hs_log_flat_buf(cmd->ltk, sizeof cmd->ltk);
 }
 
@@ -107,50 +107,50 @@ ble_sm_master_id_log(struct ble_sm_master_id *cmd)
     /* These get logged separately to accommodate a bug in the va_args
      * implementation related to 64-bit integers.
      */
-    BLE_HS_LOG(DEBUG, "ediv=0x%04x ", cmd->ediv);
-    BLE_HS_LOG(DEBUG, "rand=0x%016llx", cmd->rand_val);
+    BLE_HS_LOG_DEBUG("ediv=0x%04x ", cmd->ediv);
+    BLE_HS_LOG_DEBUG("rand=0x%016llx", cmd->rand_val);
 }
 
 void
 ble_sm_id_info_log(struct ble_sm_id_info *cmd)
 {
-    BLE_HS_LOG(DEBUG, "irk=");
+    BLE_HS_LOG_DEBUG("irk=");
     ble_hs_log_flat_buf(cmd->irk, sizeof cmd->irk);
 }
 
 void
 ble_sm_id_addr_info_log(struct ble_sm_id_addr_info *cmd)
 {
-    BLE_HS_LOG(DEBUG, "addr_type=%d addr=", cmd->addr_type);
+    BLE_HS_LOG_DEBUG("addr_type=%d addr=", cmd->addr_type);
     BLE_HS_LOG_ADDR(DEBUG, cmd->bd_addr);
 }
 
 void
 ble_sm_sign_info_log(struct ble_sm_sign_info *cmd)
 {
-    BLE_HS_LOG(DEBUG, "sig_key=");
+    BLE_HS_LOG_DEBUG("sig_key=");
     ble_hs_log_flat_buf(cmd->sig_key, sizeof cmd->sig_key);
 }
 
 void
 ble_sm_sec_req_log(struct ble_sm_sec_req *cmd)
 {
-    BLE_HS_LOG(DEBUG, "authreq=0x%02x", cmd->authreq);
+    BLE_HS_LOG_DEBUG("authreq=0x%02x", cmd->authreq);
 }
 
 void
 ble_sm_public_key_log(struct ble_sm_public_key *cmd)
 {
-    BLE_HS_LOG(DEBUG, "x=");
+    BLE_HS_LOG_DEBUG("x=");
     ble_hs_log_flat_buf(cmd->x, sizeof cmd->x);
-    BLE_HS_LOG(DEBUG, "y=");
+    BLE_HS_LOG_DEBUG("y=");
     ble_hs_log_flat_buf(cmd->y, sizeof cmd->y);
 }
 
 void
 ble_sm_dhkey_check_log(struct ble_sm_dhkey_check *cmd)
 {
-    BLE_HS_LOG(DEBUG, "value=");
+    BLE_HS_LOG_DEBUG("value=");
     ble_hs_log_flat_buf(cmd->value, sizeof cmd->value);
 }
 

--- a/nimble/host/src/ble_sm_sc.c
+++ b/nimble/host/src/ble_sm_sc.c
@@ -185,12 +185,12 @@ ble_sm_sc_ensure_keys_generated(void)
         ble_sm_sc_keys_generated = 1;
     }
 
-    BLE_HS_LOG(DEBUG, "our pubkey=");
+    BLE_HS_LOG_DEBUG("our pubkey=");
     ble_hs_log_flat_buf(&ble_sm_sc_pub_key, 64);
-    BLE_HS_LOG(DEBUG, "\n");
-    BLE_HS_LOG(DEBUG, "our privkey=");
+    BLE_HS_LOG_DEBUG("\n");
+    BLE_HS_LOG_DEBUG("our privkey=");
     ble_hs_log_flat_buf(&ble_sm_sc_priv_key, 32);
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 
     return 0;
 }
@@ -417,9 +417,9 @@ ble_sm_sc_random_rx(struct ble_sm_proc *proc, struct ble_sm_result *res)
     if (proc->flags & BLE_SM_PROC_F_INITIATOR ||
         ble_sm_sc_responder_verifies_random(proc)) {
 
-        BLE_HS_LOG(DEBUG, "tk=");
+        BLE_HS_LOG_DEBUG("tk=");
         ble_hs_log_flat_buf(proc->tk, 16);
-        BLE_HS_LOG(DEBUG, "\n");
+        BLE_HS_LOG_DEBUG("\n");
 
         rc = ble_sm_alg_f4(proc->pub_key_peer.x, ble_sm_sc_pub_key,
                            ble_sm_peer_pair_rand(proc), proc->ri,
@@ -710,9 +710,9 @@ ble_sm_dhkey_check_process(struct ble_sm_proc *proc,
     }
 
     ble_sm_sc_dhkey_addrs(proc, &our_addr, &peer_addr);
-    BLE_HS_LOG(DEBUG, "tk=");
+    BLE_HS_LOG_DEBUG("tk=");
     ble_hs_log_flat_buf(proc->tk, 16);
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 
     res->app_status = ble_sm_alg_f6(proc->mackey,
                                     ble_sm_peer_pair_rand(proc),

--- a/nimble/host/store/config/src/ble_store_config.c
+++ b/nimble/host/store/config/src/ble_store_config.c
@@ -48,37 +48,37 @@ static void
 ble_store_config_print_value_sec(const struct ble_store_value_sec *sec)
 {
     if (sec->ltk_present) {
-        BLE_HS_LOG(DEBUG, "ediv=%u rand=%llu authenticated=%d ltk=",
-                       sec->ediv, sec->rand_num, sec->authenticated);
+        BLE_HS_LOG_DEBUG("ediv=%u rand=%llu authenticated=%d ltk=",
+                         sec->ediv, sec->rand_num, sec->authenticated);
         ble_hs_log_flat_buf(sec->ltk, 16);
-        BLE_HS_LOG(DEBUG, " ");
+        BLE_HS_LOG_DEBUG(" ");
     }
     if (sec->irk_present) {
-        BLE_HS_LOG(DEBUG, "irk=");
+        BLE_HS_LOG_DEBUG("irk=");
         ble_hs_log_flat_buf(sec->irk, 16);
-        BLE_HS_LOG(DEBUG, " ");
+        BLE_HS_LOG_DEBUG(" ");
     }
     if (sec->csrk_present) {
-        BLE_HS_LOG(DEBUG, "csrk=");
+        BLE_HS_LOG_DEBUG("csrk=");
         ble_hs_log_flat_buf(sec->csrk, 16);
-        BLE_HS_LOG(DEBUG, " ");
+        BLE_HS_LOG_DEBUG(" ");
     }
 
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 }
 
 static void
 ble_store_config_print_key_sec(const struct ble_store_key_sec *key_sec)
 {
     if (ble_addr_cmp(&key_sec->peer_addr, BLE_ADDR_ANY)) {
-        BLE_HS_LOG(DEBUG, "peer_addr_type=%d peer_addr=",
-                       key_sec->peer_addr.type);
+        BLE_HS_LOG_DEBUG("peer_addr_type=%d peer_addr=",
+                         key_sec->peer_addr.type);
         ble_hs_log_flat_buf(key_sec->peer_addr.val, 6);
-        BLE_HS_LOG(DEBUG, " ");
+        BLE_HS_LOG_DEBUG(" ");
     }
     if (key_sec->ediv_rand_present) {
-        BLE_HS_LOG(DEBUG, "ediv=0x%02x rand=0x%llx ",
-                       key_sec->ediv, key_sec->rand_num);
+        BLE_HS_LOG_DEBUG("ediv=0x%02x rand=0x%llx ",
+                         key_sec->ediv, key_sec->rand_num);
     }
 }
 
@@ -147,7 +147,7 @@ ble_store_config_write_our_sec(const struct ble_store_value_sec *value_sec)
     int idx;
     int rc;
 
-    BLE_HS_LOG(DEBUG, "persisting our sec; ");
+    BLE_HS_LOG_DEBUG("persisting our sec; ");
     ble_store_config_print_value_sec(value_sec);
 
     ble_store_key_from_value_sec(&key_sec, value_sec);
@@ -155,8 +155,8 @@ ble_store_config_write_our_sec(const struct ble_store_value_sec *value_sec)
                                     ble_store_config_num_our_secs);
     if (idx == -1) {
         if (ble_store_config_num_our_secs >= MYNEWT_VAL(BLE_STORE_MAX_BONDS)) {
-            BLE_HS_LOG(DEBUG, "error persisting our sec; too many entries "
-                              "(%d)\n", ble_store_config_num_our_secs);
+            BLE_HS_LOG_DEBUG("error persisting our sec; too many entries "
+                             "(%d)\n", ble_store_config_num_our_secs);
             return BLE_HS_ESTORE_CAP;
         }
 
@@ -278,7 +278,7 @@ ble_store_config_write_peer_sec(const struct ble_store_value_sec *value_sec)
     int idx;
     int rc;
 
-    BLE_HS_LOG(DEBUG, "persisting peer sec; ");
+    BLE_HS_LOG_DEBUG("persisting peer sec; ");
     ble_store_config_print_value_sec(value_sec);
 
     ble_store_key_from_value_sec(&key_sec, value_sec);
@@ -286,7 +286,7 @@ ble_store_config_write_peer_sec(const struct ble_store_value_sec *value_sec)
                                  ble_store_config_num_peer_secs);
     if (idx == -1) {
         if (ble_store_config_num_peer_secs >= MYNEWT_VAL(BLE_STORE_MAX_BONDS)) {
-            BLE_HS_LOG(DEBUG, "error persisting peer sec; too many entries "
+            BLE_HS_LOG_DEBUG("error persisting peer sec; too many entries "
                              "(%d)\n", ble_store_config_num_peer_secs);
             return BLE_HS_ESTORE_CAP;
         }
@@ -396,8 +396,8 @@ ble_store_config_write_cccd(const struct ble_store_value_cccd *value_cccd)
     idx = ble_store_config_find_cccd(&key_cccd);
     if (idx == -1) {
         if (ble_store_config_num_cccds >= MYNEWT_VAL(BLE_STORE_MAX_CCCDS)) {
-            BLE_HS_LOG(DEBUG, "error persisting cccd; too many entries (%d)\n",
-                       ble_store_config_num_cccds);
+            BLE_HS_LOG_DEBUG("error persisting cccd; too many entries (%d)\n",
+                             ble_store_config_num_cccds);
             return BLE_HS_ESTORE_CAP;
         }
 
@@ -440,16 +440,16 @@ ble_store_config_read(int obj_type, const union ble_store_key *key,
          * result.  The nimble stack will use this key if this function returns
          * success.
          */
-        BLE_HS_LOG(DEBUG, "looking up peer sec; ");
+        BLE_HS_LOG_DEBUG("looking up peer sec; ");
         ble_store_config_print_key_sec(&key->sec);
-        BLE_HS_LOG(DEBUG, "\n");
+        BLE_HS_LOG_DEBUG("\n");
         rc = ble_store_config_read_peer_sec(&key->sec, &value->sec);
         return rc;
 
     case BLE_STORE_OBJ_TYPE_OUR_SEC:
-        BLE_HS_LOG(DEBUG, "looking up our sec; ");
+        BLE_HS_LOG_DEBUG("looking up our sec; ");
         ble_store_config_print_key_sec(&key->sec);
-        BLE_HS_LOG(DEBUG, "\n");
+        BLE_HS_LOG_DEBUG("\n");
         rc = ble_store_config_read_our_sec(&key->sec, &value->sec);
         return rc;
 

--- a/nimble/host/store/ram/src/ble_store_ram.c
+++ b/nimble/host/store/ram/src/ble_store_ram.c
@@ -51,37 +51,37 @@ static void
 ble_store_ram_print_value_sec(const struct ble_store_value_sec *sec)
 {
     if (sec->ltk_present) {
-        BLE_HS_LOG(DEBUG, "ediv=%u rand=%llu authenticated=%d ltk=",
-                       sec->ediv, sec->rand_num, sec->authenticated);
+        BLE_HS_LOG_DEBUG("ediv=%u rand=%llu authenticated=%d ltk=",
+                         sec->ediv, sec->rand_num, sec->authenticated);
         ble_hs_log_flat_buf(sec->ltk, 16);
-        BLE_HS_LOG(DEBUG, " ");
+        BLE_HS_LOG_DEBUG(" ");
     }
     if (sec->irk_present) {
-        BLE_HS_LOG(DEBUG, "irk=");
+        BLE_HS_LOG_DEBUG("irk=");
         ble_hs_log_flat_buf(sec->irk, 16);
-        BLE_HS_LOG(DEBUG, " ");
+        BLE_HS_LOG_DEBUG(" ");
     }
     if (sec->csrk_present) {
-        BLE_HS_LOG(DEBUG, "csrk=");
+        BLE_HS_LOG_DEBUG("csrk=");
         ble_hs_log_flat_buf(sec->csrk, 16);
-        BLE_HS_LOG(DEBUG, " ");
+        BLE_HS_LOG_DEBUG(" ");
     }
 
-    BLE_HS_LOG(DEBUG, "\n");
+    BLE_HS_LOG_DEBUG("\n");
 }
 
 static void
 ble_store_ram_print_key_sec(const struct ble_store_key_sec *key_sec)
 {
     if (ble_addr_cmp(&key_sec->peer_addr, BLE_ADDR_ANY)) {
-        BLE_HS_LOG(DEBUG, "peer_addr_type=%d peer_addr=",
-                       key_sec->peer_addr.type);
+        BLE_HS_LOG_DEBUG("peer_addr_type=%d peer_addr=",
+                         key_sec->peer_addr.type);
         ble_hs_log_flat_buf(key_sec->peer_addr.val, 6);
-        BLE_HS_LOG(DEBUG, " ");
+        BLE_HS_LOG_DEBUG(" ");
     }
     if (key_sec->ediv_rand_present) {
-        BLE_HS_LOG(DEBUG, "ediv=0x%02x rand=0x%llx ",
-                       key_sec->ediv, key_sec->rand_num);
+        BLE_HS_LOG_DEBUG("ediv=0x%02x rand=0x%llx ",
+                         key_sec->ediv, key_sec->rand_num);
     }
 }
 
@@ -148,7 +148,7 @@ ble_store_ram_write_our_sec(const struct ble_store_value_sec *value_sec)
     struct ble_store_key_sec key_sec;
     int idx;
 
-    BLE_HS_LOG(DEBUG, "persisting our sec; ");
+    BLE_HS_LOG_DEBUG("persisting our sec; ");
     ble_store_ram_print_value_sec(value_sec);
 
     ble_store_key_from_value_sec(&key_sec, value_sec);
@@ -156,8 +156,8 @@ ble_store_ram_write_our_sec(const struct ble_store_value_sec *value_sec)
                                  ble_store_ram_num_our_secs);
     if (idx == -1) {
         if (ble_store_ram_num_our_secs >= MYNEWT_VAL(BLE_STORE_MAX_BONDS)) {
-            BLE_HS_LOG(DEBUG, "error persisting our sec; too many entries "
-                              "(%d)\n", ble_store_ram_num_our_secs);
+            BLE_HS_LOG_DEBUG("error persisting our sec; too many entries "
+                             "(%d)\n", ble_store_ram_num_our_secs);
             return BLE_HS_ESTORE_CAP;
         }
 
@@ -262,7 +262,7 @@ ble_store_ram_write_peer_sec(const struct ble_store_value_sec *value_sec)
     struct ble_store_key_sec key_sec;
     int idx;
 
-    BLE_HS_LOG(DEBUG, "persisting peer sec; ");
+    BLE_HS_LOG_DEBUG("persisting peer sec; ");
     ble_store_ram_print_value_sec(value_sec);
 
     ble_store_key_from_value_sec(&key_sec, value_sec);
@@ -270,7 +270,7 @@ ble_store_ram_write_peer_sec(const struct ble_store_value_sec *value_sec)
                                  ble_store_ram_num_peer_secs);
     if (idx == -1) {
         if (ble_store_ram_num_peer_secs >= MYNEWT_VAL(BLE_STORE_MAX_BONDS)) {
-            BLE_HS_LOG(DEBUG, "error persisting peer sec; too many entries "
+            BLE_HS_LOG_DEBUG("error persisting peer sec; too many entries "
                              "(%d)\n", ble_store_ram_num_peer_secs);
             return BLE_HS_ESTORE_CAP;
         }
@@ -368,8 +368,8 @@ ble_store_ram_write_cccd(const struct ble_store_value_cccd *value_cccd)
     idx = ble_store_ram_find_cccd(&key_cccd);
     if (idx == -1) {
         if (ble_store_ram_num_cccds >= MYNEWT_VAL(BLE_STORE_MAX_CCCDS)) {
-            BLE_HS_LOG(DEBUG, "error persisting cccd; too many entries (%d)\n",
-                       ble_store_ram_num_cccds);
+            BLE_HS_LOG_DEBUG("error persisting cccd; too many entries (%d)\n",
+                             ble_store_ram_num_cccds);
             return BLE_HS_ESTORE_CAP;
         }
 
@@ -406,16 +406,16 @@ ble_store_ram_read(int obj_type, const union ble_store_key *key,
          * result.  The nimble stack will use this key if this function returns
          * success.
          */
-        BLE_HS_LOG(DEBUG, "looking up peer sec; ");
+        BLE_HS_LOG_DEBUG("looking up peer sec; ");
         ble_store_ram_print_key_sec(&key->sec);
-        BLE_HS_LOG(DEBUG, "\n");
+        BLE_HS_LOG_DEBUG("\n");
         rc = ble_store_ram_read_peer_sec(&key->sec, &value->sec);
         return rc;
 
     case BLE_STORE_OBJ_TYPE_OUR_SEC:
-        BLE_HS_LOG(DEBUG, "looking up our sec; ");
+        BLE_HS_LOG_DEBUG("looking up our sec; ");
         ble_store_ram_print_key_sec(&key->sec);
-        BLE_HS_LOG(DEBUG, "\n");
+        BLE_HS_LOG_DEBUG("\n");
         rc = ble_store_ram_read_our_sec(&key->sec, &value->sec);
         return rc;
 

--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -440,5 +440,20 @@ syscfg.defs:
             Sysinit stage for the NimBLE host.
         value: 200
 
+
+    ### Log settings.
+
+    BLE_HS_LOG_MOD:
+        description: 'Module ID for the nimble host log.'
+        value: 4
+    BLE_HS_LOG_LVL:
+        description: 'Minimum level for the nimble host log.'
+        value: 1
+
+syscfg.logs:
+    BLE_HS_LOG:
+        module: MYNEWT_VAL(BLE_HS_LOG_MOD)
+        level: MYNEWT_VAL(BLE_HS_LOG_LVL)
+
 syscfg.vals.BLE_MESH:
     BLE_SM_SC: 1

--- a/porting/examples/linux_blemesh/ble.c
+++ b/porting/examples/linux_blemesh/ble.c
@@ -398,7 +398,7 @@ static const struct bt_mesh_prov prov = {
 static void
 blemesh_on_reset(int reason)
 {
-    BLE_HS_LOG(ERROR, "Resetting state; reason=%d\n", reason);
+    BLE_HS_LOG_ERROR("Resetting state; reason=%d\n", reason);
 }
 
 void mesh_initialized(void);


### PR DESCRIPTION
### Background

A Mynewt package can define logs in its `syscfg.yml` file.  When the newt tool encounters a log definition, it generates macros for writing to the log.  The macros corresponding to log levels below the log's configured level are no-ops.  This allows log level to be configured per module, with sub-level log write getting compiled out.

### This PR

Use newt's auto-generated log macros.  For non-Mynewt builds, manually define these macros to use the modlog port.