### PR TITLE
apps/bttester: Add configurable Limited Advertising timeout

### DIFF
--- a/apps/bttester/src/gap.c
+++ b/apps/bttester/src/gap.c
@@ -287,6 +287,7 @@ static void start_advertising(const u8_t *data, u16_t len)
 {
 	const struct gap_start_advertising_cmd *cmd = (void *) data;
 	struct gap_start_advertising_rp rp;
+	int32_t duration_ms = BLE_HS_FOREVER;
 	uint8_t buf[BLE_HS_ADV_MAX_SZ];
 	uint8_t buf_len = 0;
 	u8_t adv_len, sd_len;
@@ -346,7 +347,11 @@ static void start_advertising(const u8_t *data, u16_t len)
 		}
 	}
 
-	err = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER,
+	if (adv_params.disc_mode == BLE_GAP_DISC_MODE_LTD) {
+		duration_ms = MYNEWT_VAL(BTTESTER_LTD_ADV_TIMEOUT);
+	}
+
+	err = ble_gap_adv_start(own_addr_type, NULL, duration_ms,
 				&adv_params, gap_event_cb, NULL);
 	if (err) {
 		SYS_LOG_ERR("Advertising failed: err %d", err);

--- a/apps/bttester/syscfg.yml
+++ b/apps/bttester/syscfg.yml
@@ -43,6 +43,10 @@ syscfg.defs:
         description: Use Resolvable Private Address
         value: 0
 
+    BTTESTER_LTD_ADV_TIMEOUT:
+        description: Limited advertising timeout
+        value: 30000
+
     BTTESTER_BTP_DATA_SIZE_MAX:
         description: Maximum BTP payload
         value: MYNEWT_VAL_BTTESTER_RTT_BUFFER_SIZE_UP


### PR DESCRIPTION
This is required to pass some GAP/DISC/LIMM/BV-03-C and
GAP/DISC/LIMM/BV-04-C testcases.