### PR TITLE
apps/bttester: Add support for Read by UUID

### DIFF
--- a/apps/bttester/src/bttester.h
+++ b/apps/bttester/src/bttester.h
@@ -513,6 +513,16 @@ struct gatt_read_rp {
 	u8_t data[0];
 } __packed;
 
+#define GATT_READ_UUID			0x12
+struct gatt_read_uuid_cmd {
+	u8_t address_type;
+	u8_t address[6];
+	u16_t start_handle;
+	u16_t end_handle;
+	u8_t uuid_length;
+	u8_t uuid[0];
+} __packed;
+
 #define GATT_READ_LONG			0x13
 struct gatt_read_long_cmd {
 	u8_t address_type;


### PR DESCRIPTION
This can be used to pass GAP/IDLE/NAMP/BV-01-C.