### PR TITLE
nimble/mesh: Reset the SAR timer also on SAR_CONT

### DIFF
--- a/nimble/host/mesh/src/proxy.c
+++ b/nimble/host/mesh/src/proxy.c
@@ -590,6 +590,7 @@ static int proxy_recv(uint16_t conn_handle, uint16_t attr_handle,
 			return -EINVAL;
 		}
 
+		k_delayed_work_submit(&client->sar_timer, PROXY_SAR_TIMEOUT);
 		net_buf_simple_add_mem(client->buf, data + 1, len - 1);
 		break;
 


### PR DESCRIPTION
Usually, this type of timer is used to detect inactivity,
so receiving a SAR_CONT pdu counts as progress and should reset
the timer.

This is an update after a discussion in https://github.com/zephyrproject-rtos/zephyr/pull/16601.