### PR TITLE
apps/btshell: Make address input easier

### DIFF
--- a/apps/btshell/src/cmd.h
+++ b/apps/btshell/src/cmd.h
@@ -53,6 +53,7 @@ int parse_arg_kv_dflt(char *name, const struct kv_pair *kvs, int def_val,
 int parse_arg_byte_stream(char *name, int max_len, uint8_t *dst, int *out_len);
 int parse_arg_byte_stream_exact_length(char *name, uint8_t *dst, int len);
 int parse_arg_mac(char *name, uint8_t *dst);
+int parse_arg_addr(char *name, ble_addr_t *addr);
 int parse_arg_uuid(char *name, ble_uuid_any_t *uuid);
 int parse_arg_all(int argc, char **argv);
 int parse_eddystone_url(char *full_url, uint8_t *out_scheme, char *out_body,

--- a/apps/btshell/src/parse.c
+++ b/apps/btshell/src/parse.c
@@ -512,6 +512,54 @@ parse_arg_mac(char *name, uint8_t *dst)
 }
 
 int
+parse_arg_addr(char *name, ble_addr_t *addr)
+{
+    char *arg;
+    size_t len;
+    uint8_t addr_type;
+    bool addr_type_found;
+    int rc;
+
+    arg = parse_arg_peek(name);
+    if (!arg) {
+        return ENOENT;
+    }
+
+    len = strlen(arg);
+    if (len < 2) {
+        return EINVAL;
+    }
+
+    addr_type_found = false;
+    if ((arg[len - 2] == ':') || (arg[len - 2] == '-')) {
+        if (tolower(arg[len - 1]) == 'p') {
+            addr_type = BLE_ADDR_PUBLIC;
+            addr_type_found = true;
+        } else if (tolower(arg[len - 1]) == 'r') {
+            addr_type = BLE_ADDR_RANDOM;
+            addr_type_found = true;
+        }
+
+        if (addr_type_found) {
+            arg[len - 2] = '\0';
+        }
+}
+
+    rc = parse_arg_mac(name, addr->val);
+    if (rc != 0) {
+        return rc;
+    }
+
+    if (addr_type_found) {
+        addr->type = addr_type;
+    } else {
+        rc = EAGAIN;
+    }
+
+    return rc;
+}
+
+int
 parse_arg_uuid(char *str, ble_uuid_any_t *uuid)
 {
     uint16_t uuid16;


### PR DESCRIPTION
This makes address arguments input easier by allowing providing both address and type as a single argument. Also parsing of all address arguments is changed to use common helper which provides the same functionality for all such arguments.

For each `addr` and `addr_type` (with optional prefix) arguments pair it is possible to specify address as follows:
- 6 bytes in `addr` only, `addr_type` defaults to `0` (i.e. `public`)
- 6 bytes in `addr` and type in `addr_type`
- 6 bytes in `addr` plus extra token with type indicator which is either `p` (for `public`) or `r` (for `random`); for example: `11:22:33:44:55:66:p`; `addr_type` shall not be included in such case