### PR TITLE
nimble/sm: Fix rejecting stronger bond

### DIFF
--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -1961,9 +1961,7 @@ ble_sm_sec_req_rx(uint16_t conn_handle, struct os_mbuf **om,
              * requested minimum authreq.
              */
             authreq_mitm = cmd->authreq & BLE_SM_PAIR_AUTHREQ_MITM;
-            if ((!authreq_mitm && value_sec.authenticated) ||
-                (authreq_mitm && !value_sec.authenticated)) {
-
+            if (authreq_mitm && !value_sec.authenticated) {
                 res->app_status = BLE_HS_EREJECT;
             }
         }


### PR DESCRIPTION
If there exists an authenticated bond and the slave sends
a security request with No MITM we should not try to pair again
as the stored bond is stronger than the requested one.