### PR TITLE
nimble/host: Fix compilation error when asserts are disabled

### DIFF
--- a/nimble/host/services/gap/src/ble_svc_gap.c
+++ b/nimble/host/services/gap/src/ble_svc_gap.c
@@ -205,6 +205,7 @@ ble_svc_gap_access(uint16_t conn_handle, uint16_t attr_handle,
             rc = ble_svc_gap_device_name_write_access(ctxt);
         } else {
             assert(0);
+            rc = BLE_ATT_ERR_UNLIKELY;
         }
         return rc;
 
@@ -215,6 +216,7 @@ ble_svc_gap_access(uint16_t conn_handle, uint16_t attr_handle,
             rc = ble_svc_gap_appearance_write_access(ctxt);
         } else {
             assert(0);
+            rc = BLE_ATT_ERR_UNLIKELY;
         }
         return rc;
 


### PR DESCRIPTION
/home/nimble/host/services/gap/src/ble_svc_gap.c:195:9:
error: 'rc' may be used uninitialized in this function
[-Werror=maybe-uninitialized]
     int rc;
         ^