### PR TITLE
drivers/nrf5x: do not assign IRQ prio when building for RIOT

### DIFF
--- a/nimble/drivers/nrf51/src/ble_hw.c
+++ b/nimble/drivers/nrf51/src/ble_hw.c
@@ -319,7 +319,9 @@ ble_hw_rng_init(ble_rng_isr_cb_t cb, int bias)
 
     /* If we were passed a function pointer we need to enable the interrupt */
     if (cb != NULL) {
+#ifndef RIOT_VERSION
         NVIC_SetPriority(RNG_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+#endif
 #if MYNEWT
         NVIC_SetVector(RNG_IRQn, (uint32_t)ble_rng_isr);
 #else

--- a/nimble/drivers/nrf51/src/ble_phy.c
+++ b/nimble/drivers/nrf51/src/ble_phy.c
@@ -908,7 +908,9 @@ ble_phy_init(void)
     NRF_PPI->CH[5].TEP = (uint32_t)&(NRF_RADIO->TASKS_DISABLE);
 
     /* Set isr in vector table and enable interrupt */
+#ifndef RIOT_VERSION
     NVIC_SetPriority(RADIO_IRQn, 0);
+#endif
 #if MYNEWT
     NVIC_SetVector(RADIO_IRQn, (uint32_t)ble_phy_isr);
 #else

--- a/nimble/drivers/nrf52/src/ble_hw.c
+++ b/nimble/drivers/nrf52/src/ble_hw.c
@@ -319,7 +319,9 @@ ble_hw_rng_init(ble_rng_isr_cb_t cb, int bias)
 
     /* If we were passed a function pointer we need to enable the interrupt */
     if (cb != NULL) {
+#ifndef RIOT_VERSION
         NVIC_SetPriority(RNG_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
+#endif
 #if MYNEWT
         NVIC_SetVector(RNG_IRQn, (uint32_t)ble_rng_isr);
 #else

--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -1440,7 +1440,9 @@ ble_phy_init(void)
     NRF_PPI->CH[5].TEP = (uint32_t)&(NRF_RADIO->TASKS_DISABLE);
 
     /* Set isr in vector table and enable interrupt */
+#ifndef RIOT_VERSION
     NVIC_SetPriority(RADIO_IRQn, 0);
+#endif
 #if MYNEWT
     NVIC_SetVector(RADIO_IRQn, (uint32_t)ble_phy_isr);
 #else


### PR DESCRIPTION
RIOT does not allow for nested interrupts and initializes all IRQs to the same priority during system initialization. Assigning different priorities in the driver leads to system crashes.

For some reasons, the differing IRQ prios had no effect on `nrf52`-based platforms. We found it however causing hard-faults on `nrf51`-based boards. My guess is, that the different interrupt grouping on the Cortex-M0 and M4 are causing this difference?!