### PR TITLE
nimble/ll: Fix peer address check with privacy

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -438,6 +438,9 @@ uint16_t ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode);
 /* Is this address a resolvable private address? */
 int ble_ll_is_rpa(uint8_t *addr, uint8_t addr_type);
 
+/* Is this address an identity address? */
+int ble_ll_addr_is_id(uint8_t *addr, uint8_t addr_type);
+
 /* Is 'addr' our device address? 'addr_type' is public (0) or random (!=0) */
 int ble_ll_is_our_devaddr(uint8_t *addr, int addr_type);
 

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -426,6 +426,12 @@ ble_ll_is_rpa(uint8_t *addr, uint8_t addr_type)
     return rc;
 }
 
+int
+ble_ll_addr_is_id(uint8_t *addr, uint8_t addr_type)
+{
+    return !addr_type || ((addr[5] & 0xc0) == 0xc0);
+}
+
 /* Checks to see that the device is a valid random address */
 int
 ble_ll_is_valid_random_addr(uint8_t *addr)

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -2524,7 +2524,7 @@ ble_ll_conn_is_peer_adv(uint8_t addr_type, uint8_t *adva, int index)
     /* Fall-through intentional */
     case BLE_HCI_CONN_PEER_ADDR_PUBLIC:
     case BLE_HCI_CONN_PEER_ADDR_RANDOM:
-        if (addr_type == connsm->peer_addr_type) {
+        if (ble_ll_addr_is_id(adva, addr_type)) {
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
                 /* Peer uses its identity address. Let's verify privacy mode.
                  *


### PR DESCRIPTION
We should explicitly chceck if AdvA is identity instead of just comparing address types. Comparing address types can give incorrect result if peer identity address is static random since both static random and RPA are random addresses.
