### PR TITLE
apps/bttester: Handle peripheral privacy

### DIFF
--- a/apps/bttester/syscfg.yml
+++ b/apps/bttester/syscfg.yml
@@ -83,7 +83,7 @@ syscfg.vals:
     BLE_L2CAP_COC_MAX_NUM: 2
     # Some testcases require MPS < MTU
     BLE_L2CAP_COC_MPS: 100
-    BLE_RPA_TIMEOUT: 10
+    BLE_RPA_TIMEOUT: 30
     BLE_SM_BONDING: 1
     BLE_SM_MITM: 1
     BLE_SM_SC: 1


### PR DESCRIPTION
Bluetooth Core Spec v5.1 | Section 10.7.1
`If a privacy-enabled Peripheral, that has a stored bond,
receives a resolvable private address, the Host may resolve
the resolvable private address [...]
If the resolution is successful, the Host may accept the connection.
If the resolution procedure fails, then the Host shall disconnect
with the error code "Authentication failure" [...]`

This allows passing GAP/PRIV/CONN/BI-01-C.
