### PR TITLE
nimble/ll: Fix regression in chained scan response

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -1944,12 +1944,12 @@ ble_ll_scan_get_aux_data(struct ble_mbuf_hdr *ble_hdr, uint8_t *rxbuf)
             }
 
             BLE_LL_AUX_SET_FLAG(new_aux, BLE_LL_AUX_CHAIN_BIT);
+            BLE_LL_AUX_SET_FLAG(new_aux, BLE_LL_AUX_INCOMPLETE_BIT);
         } else {
             if (ble_ll_scan_ext_adv_init(&new_aux) < 0) {
             /* Out of memory */
             return -1;
             }
-            BLE_LL_AUX_SET_FLAG(new_aux, BLE_LL_AUX_INCOMPLETE_BIT);
         }
 
         new_aux->aux_phy = tmp_aux_data.aux_phy;


### PR DESCRIPTION
Regression after
7c17723d nimble/ll: Simplify aux_data ref counter usage

Setting BLE_LL_AUX_INCOMPLETE_BIT has been incorrectly moved in mentioned
patch.

This fixes LL/DDI/SCN/BV-24-C