### PR TITLE
nimble/mesh: Reject invalid remote public key before sending ours

### DIFF
--- a/nimble/host/mesh/src/prov.c
+++ b/nimble/host/mesh/src/prov.c
@@ -898,17 +898,7 @@ static void send_pub_key(void)
 		goto done;
 	}
 
-	prov_buf_init(buf, PROV_PUB_KEY);
-
-	/* Swap X and Y halves independently to big-endian */
-	sys_memcpy_swap(net_buf_simple_add(buf, 32), key, 32);
-	sys_memcpy_swap(net_buf_simple_add(buf, 32), &key[32], 32);
-
-	memcpy(&link.conf_inputs[81], &buf->om_data[1], 64);
-
-	BT_DBG("Local Public Key: %s", bt_hex(&buf->om_data[1], 64));
-
-	prov_send(buf);
+	/* bt_dh_key_gen() will verify that the remote's public key is valid. */
 
 	/* Copy remote key in little-endian for bt_dh_key_gen().
 	 * X and Y halves are swapped independently.
@@ -923,6 +913,18 @@ static void send_pub_key(void)
 		atomic_set_bit(link.flags, LINK_INVALID);
 		goto done;
 	}
+
+	prov_buf_init(buf, PROV_PUB_KEY);
+
+	/* Swap X and Y halves independently to big-endian */
+	sys_memcpy_swap(net_buf_simple_add(buf, 32), key, 32);
+	sys_memcpy_swap(net_buf_simple_add(buf, 32), &key[32], 32);
+
+	memcpy(&link.conf_inputs[81], &buf->om_data[1], 64);
+
+	BT_DBG("Local Public Key: %s", bt_hex(&buf->om_data[1], 64));
+
+	prov_send(buf);
 
 	link.expect = PROV_CONFIRM;
 


### PR DESCRIPTION
Mesh Profile Spec v1.0.1 | Section 5.4.2.3:
`The Provisioner and the device shall check whether the public key
provided by the peer device or obtained OOB is valid (see Section 5.4.3.1).

When the Provisioner receives an invalid public key, then provisioning fails,
and the Provisioner shall act as described in Section 5.4.4. When the device
receives an invalid public key, then provisioning fails, and
the device shall act as described in Section 5.4.4.`

Described also in Erratum 10395 which is Mandatory for Mesh v1.0.

Fixes MESH/NODE/PROV/BI-13-C.

This test verifies that we do not send our public key if remote's
public key is invalid.

