### PR TITLE
Add the following sanity checks for Notify/Indicate

### DIFF
--- a/nimble/host/src/ble_gatt_priv.h
+++ b/nimble/host/src/ble_gatt_priv.h
@@ -186,6 +186,13 @@ int ble_gatts_register_svcs(const struct ble_gatt_svc_def *svcs,
 int ble_gatts_clt_cfg_access(uint16_t conn_handle, uint16_t attr_handle,
                              uint8_t op, uint16_t offset, struct os_mbuf **om,
                              void *arg);
+int ble_gatts_check_cccd_enabled(struct ble_hs_conn *conn,
+                                 uint16_t chr_val_handle,
+                                 uint8_t flag);
+int ble_gattc_notify_now(uint16_t conn_handle, uint16_t chr_val_handle,
+                         struct os_mbuf *txom, uint8_t now);
+int ble_gattc_indicate_now(uint16_t conn_handle, uint16_t chr_val_handle,
+                           struct os_mbuf *txom, uint8_t now);
 
 /*** @misc. */
 int ble_gatts_conn_can_alloc(void);

--- a/nimble/host/test/src/ble_gatt_conn_test.c
+++ b/nimble/host/test/src/ble_gatt_conn_test.c
@@ -485,7 +485,7 @@ TEST_CASE_SELF(ble_gatt_conn_test_disconnect)
         3, &attr, 1, ble_gatt_conn_test_write_rel_cb, &write_rel_arg);
     TEST_ASSERT_FATAL(rc == 0);
 
-    rc = ble_gattc_indicate(3, attr_handle);
+    rc = ble_gattc_indicate_now(3, attr_handle, NULL, 1);
     TEST_ASSERT_FATAL(rc == 0);
 
     /*** Start the procedures. */
@@ -735,7 +735,7 @@ TEST_CASE_SELF(ble_gatt_conn_test_timeout)
 
     /*** Indication. */
     ble_hs_test_util_create_conn(1, peer_addr, NULL, NULL);
-    rc = ble_gattc_indicate(1, attr_handle);
+    rc = ble_gattc_indicate_now(1, attr_handle, NULL, 1);
     TEST_ASSERT_FATAL(rc == 0);
     ble_gatt_conn_test_util_timeout(1, NULL);
 


### PR DESCRIPTION
- Check for the connection handle.
- Check for a correct entry for the attribute handle.
- Check for enable state for the provided attribute handle.

With the added checks for the following APIs:
- ble_gattc_notify()
- ble_gattc_notify_custom()
- ble_gattc_indicate()
- ble_gattc_indicate_custom()

Host will send the following errors in gap event BLE_GAP_EVENT_NOTIFY_TX
 - BLE_HS_ENOTCONN : If there is no connection with the provided conn_handle.
 - BLE_HS_ENOENT : If there is no entry for the provided att_handle.
 - BLE_HS_EDISABLED: If the cccd is disabled for the provided att_handle.