### PR TITLE
apps/blehci: Allow HCI transport to be configured

### DIFF
--- a/apps/blehci/pkg.yml
+++ b/apps/blehci/pkg.yml
@@ -17,7 +17,7 @@
 #
 pkg.name: apps/blehci
 pkg.type: app
-pkg.description: BLE controller application exposing HCI over UART
+pkg.description: BLE controller application exposing HCI over external interface
 pkg.author: "Johan Hedberg <johan.hedberg@intel.com>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
@@ -28,4 +28,7 @@ pkg.deps:
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/kernel/os"
     - nimble/controller
-    - nimble/transport/uart
+    - nimble/transport
+
+pkg.req_apis:
+    - ble_transport

--- a/apps/blehci/syscfg.yml
+++ b/apps/blehci/syscfg.yml
@@ -19,3 +19,5 @@
 syscfg.vals:
     # Default task settings
     OS_MAIN_STACK_SIZE: 64
+    # Use UART transport by default
+    BLE_HCI_TRANSPORT: uart


### PR DESCRIPTION
Even though we always use blehci over UART, it may be useful to have
transport configurable in case someone develops an USB transport or
something else...