### PR TITLE
nimble/ll: Fix using ID address types when filtering duplicates

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -141,10 +141,10 @@ g_ble_ll_scan_rsp_advs[MYNEWT_VAL(BLE_LL_NUM_SCAN_RSP_ADVS)];
 
 /* Duplicates filtering data */
 #define BLE_LL_SCAN_ENTRY_TYPE_LEGACY(addr_type) \
-    (addr_type)
+    ((addr_type) & 1)
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 #define BLE_LL_SCAN_ENTRY_TYPE_EXT(addr_type, has_aux, is_anon, adi) \
-    (((adi >> 8) & 0xF0) | (1 << 3) | (is_anon << 2) | (has_aux << 1) | (addr_type))
+    (((adi >> 8) & 0xF0) | (1 << 3) | (is_anon << 2) | (has_aux << 1) | ((addr_type) & 1))
 #endif
 
 #define BLE_LL_SCAN_DUP_F_ADV_REPORT_SENT       (0x01)


### PR DESCRIPTION
The duplicate list should store only public/random address types 
and not public_id/random_id.

Without this change there would be an assert in
ble_ll_scan_dup_update_legacy when scanning resolved address.