### PR TITLE
nimble/ll: Do not drop event on failed PDU reschedule

### DIFF
--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -4437,13 +4437,13 @@ ble_ll_adv_done(struct ble_ll_adv_sm *advsm)
     }
 
     /*
-     * In the unlikely event we cant reschedule this, just post a done
-     * event and we will reschedule the next advertising event
+     * In the unlikely event we can't reschedule this, just post a done event
+     * and we will reschedule the next advertising PDU.
      */
     rc = ble_ll_sched_adv_resched_pdu(&advsm->adv_sch);
     if (rc) {
         STATS_INC(ble_ll_stats, adv_resched_pdu_fail);
-        ble_ll_adv_drop_event(advsm);
+        ble_npl_eventq_put(&g_ble_ll_data.ll_evq, &advsm->adv_txdone_ev);
     }
 }
 


### PR DESCRIPTION
For unknown reason we drop advertising event when failed to reschedule
advertising PDU. This does not affect legacy advertising too much since
we'll just skip one or two channels, but in case of extended advertising
it also removes AUX which means complete extended advertising event is
lost.

In addition, nRF51 is not fast enough to ensure all PDUs on primary
channels can be scheduled before AUX so this effectively means extended
advertising on nRF51 is unusable.

With this fix we won't drop complete event if PDU reschedule fails, just
move to next channel. It allows extended advertising to be usable on
nRF51, but we should also allow to relax AUX scheduling constraints
which will allow to schedule all primary PDUs properly - this will be
addressed later.