### PR TITLE
apps: Stop using ble_npl api

### DIFF
--- a/apps/blemesh_models_example_2/src/app_gpio.c
+++ b/apps/blemesh_models_example_2/src/app_gpio.c
@@ -46,11 +46,11 @@ int led_device[] = {
 	LED_4,
 };
 
-static struct ble_npl_callout button_work;
+static struct os_callout button_work;
 
 static void button_pressed(struct os_event *ev)
 {
-	k_work_submit(&button_work);
+	os_callout_reset(&button_work, 0);
 }
 
 static struct os_event button_event;
@@ -72,7 +72,7 @@ void app_gpio_init(void)
 
 	/* Buttons configiuratin & setting */
 
-	k_work_init(&button_work, publish);
+	os_callout_init(&button_work, os_eventq_dflt_get(), publish, NULL);
 
 	button_event.ev_cb = button_pressed;
 

--- a/apps/blemesh_models_example_2/src/device_composition.c
+++ b/apps/blemesh_models_example_2/src/device_composition.c
@@ -261,7 +261,7 @@ static void gen_onoff_set_unack(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -328,7 +328,7 @@ static void gen_onoff_set(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -456,7 +456,7 @@ static void gen_level_set_unack(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -529,7 +529,7 @@ static void gen_level_set(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -611,7 +611,7 @@ static void gen_delta_set_unack(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -701,7 +701,7 @@ static void gen_delta_set(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -840,7 +840,7 @@ static void gen_move_set_unack(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -922,7 +922,7 @@ static void gen_move_set(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -1119,8 +1119,8 @@ static void gen_onpowerup_publish(struct bt_mesh_model *model)
 }
 
 static bool gen_onpowerup_setunack(struct bt_mesh_model *model,
-				struct bt_mesh_msg_ctx *ctx,
-				struct os_mbuf *buf)
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct os_mbuf *buf)
 {
 	u8_t onpowerup;
 	struct generic_onpowerup_state *state = model->user_data;
@@ -1324,7 +1324,7 @@ static void light_lightness_set_unack(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -1395,7 +1395,7 @@ static void light_lightness_set(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -1517,7 +1517,7 @@ static void light_lightness_linear_set_unack(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -1581,7 +1581,7 @@ static void light_lightness_linear_set(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -1949,7 +1949,7 @@ static void light_ctl_set_unack(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -2033,7 +2033,7 @@ static void light_ctl_set(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -2214,7 +2214,7 @@ static void light_ctl_temp_range_publish(struct bt_mesh_model *model)
 
 static bool light_ctl_temp_range_setunack(struct bt_mesh_model *model,
 					  struct bt_mesh_msg_ctx *ctx,
-                      struct os_mbuf *buf)
+					  struct os_mbuf *buf)
 {
 	u16_t min, max;
 	struct light_ctl_state *state = model->user_data;
@@ -2233,14 +2233,14 @@ static bool light_ctl_temp_range_setunack(struct bt_mesh_model *model,
 	if (min <= max) {
 		state->status_code = RANGE_SUCCESSFULLY_UPDATED;
 
-			if (state->temp_range_min != min ||
-			    state->temp_range_max != max) {
+		if (state->temp_range_min != min ||
+		    state->temp_range_max != max) {
 
-				state->temp_range_min = min;
-				state->temp_range_max = max;
+			state->temp_range_min = min;
+			state->temp_range_max = max;
 
-				save_on_flash(TEMPERATURE_RANGE);
-			}
+			save_on_flash(TEMPERATURE_RANGE);
+		}
 	} else {
 		/* The provided value for Range Max cannot be set */
 		state->status_code = CANNOT_SET_RANGE_MAX;
@@ -2424,7 +2424,7 @@ static void light_ctl_temp_set_unack(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;
@@ -2504,7 +2504,7 @@ static void light_ctl_temp_set(struct bt_mesh_model *model,
 	}
 
 	*ptr_counter = 0;
-	ble_npl_callout_stop(ptr_timer);
+	os_callout_stop(ptr_timer);
 
 	state->last_tid = tid;
 	state->last_src_addr = ctx->addr;

--- a/apps/blemesh_models_example_2/src/main.c
+++ b/apps/blemesh_models_example_2/src/main.c
@@ -165,7 +165,7 @@ void update_light_state(void)
 
 	if (*ptr_counter == 0 || reset == false) {
 		reset = true;
-		k_work_submit(&no_transition_work);
+		os_callout_reset(&no_transition_work, 0);
 	}
 }
 
@@ -183,22 +183,22 @@ static void short_time_multireset_bt_mesh_unprovisioning(void)
 	save_on_flash(RESET_COUNTER);
 }
 
-static void reset_counter_timer_handler(struct ble_npl_event *dummy)
+static void reset_counter_timer_handler(struct os_event *dummy)
 {
 	reset_counter = 0;
 	save_on_flash(RESET_COUNTER);
 	printk("Reset Counter set to Zero\n");
 }
 
-struct ble_npl_callout reset_counter_timer;
+struct os_callout reset_counter_timer;
 
 static void init_timers(void)
 {
 
-	ble_npl_callout_init(&reset_counter_timer, ble_npl_eventq_dflt_get(),
-			     reset_counter_timer_handler, NULL);
-	ble_npl_callout_reset(&reset_counter_timer,
-			      ble_npl_time_ms_to_ticks32(K_MSEC(7000)));
+	os_callout_init(&reset_counter_timer, os_eventq_dflt_get(),
+			reset_counter_timer_handler, NULL);
+	os_callout_reset(&reset_counter_timer,
+			 os_time_ms_to_ticks32(K_MSEC(7000)));
 
 	no_transition_work_init();
 }

--- a/apps/blemesh_models_example_2/src/no_transition_work_handler.c
+++ b/apps/blemesh_models_example_2/src/no_transition_work_handler.c
@@ -29,7 +29,7 @@
 
 #include "storage.h"
 
-static void unsolicitedly_publish_states_work_handler(struct ble_npl_event *work)
+static void unsolicitedly_publish_states_work_handler(struct os_event *work)
 {
 	gen_onoff_publish(&root_models[2]);
 	gen_level_publish(&root_models[4]);
@@ -41,49 +41,49 @@ static void unsolicitedly_publish_states_work_handler(struct ble_npl_event *work
 	light_ctl_temp_publish(&s0_models[2]);
 }
 
-struct ble_npl_callout unsolicitedly_publish_states_work;
+struct os_callout unsolicitedly_publish_states_work;
 
-static void unsolicitedly_publish_states_timer_handler(struct ble_npl_event *dummy)
+static void unsolicitedly_publish_states_timer_handler(struct os_event *dummy)
 {
-	k_work_submit(&unsolicitedly_publish_states_work);
+	os_callout_reset(&unsolicitedly_publish_states_work, 0);
 }
 
-struct ble_npl_callout unsolicitedly_publish_states_timer;
+struct os_callout unsolicitedly_publish_states_timer;
 
-static void save_lightness_temp_last_values_timer_handler(struct ble_npl_event *dummy)
+static void save_lightness_temp_last_values_timer_handler(struct os_event *dummy)
 {
 	save_on_flash(LIGHTNESS_TEMP_LAST_STATE);
 }
 
-struct ble_npl_callout save_lightness_temp_last_values_timer;
+struct os_callout save_lightness_temp_last_values_timer;
 
-static void no_transition_work_handler(struct ble_npl_event *work)
+static void no_transition_work_handler(struct os_event *work)
 {
-	ble_npl_callout_reset(&unsolicitedly_publish_states_timer,
-			      ble_npl_time_ms_to_ticks32(K_MSEC(5000)));
+	os_callout_reset(&unsolicitedly_publish_states_timer,
+			 os_time_ms_to_ticks32(K_MSEC(5000)));
 
 	/* If Lightness & Temperature values remains stable for
 	 * 10 Seconds then & then only get stored on SoC flash.
 	 */
 	if (gen_power_onoff_srv_user_data.onpowerup == STATE_RESTORE) {
-		ble_npl_callout_reset(&save_lightness_temp_last_values_timer,
-				      ble_npl_time_ms_to_ticks32(
-					      K_MSEC(10000)));
+		os_callout_reset(&save_lightness_temp_last_values_timer,
+				 os_time_ms_to_ticks32(
+					 K_MSEC(10000)));
 	}
 }
 
-struct ble_npl_callout no_transition_work;
+struct os_callout no_transition_work;
 
 void no_transition_work_init(void)
 {
-	ble_npl_callout_init(&no_transition_work, ble_npl_eventq_dflt_get(),
-			     no_transition_work_handler, NULL);
-	ble_npl_callout_init(&save_lightness_temp_last_values_timer,
-			     ble_npl_eventq_dflt_get(),
-			     save_lightness_temp_last_values_timer_handler,
-			     NULL);
-	ble_npl_callout_init(&unsolicitedly_publish_states_work, ble_npl_eventq_dflt_get(),
-			     unsolicitedly_publish_states_work_handler, NULL);
-	ble_npl_callout_init(&unsolicitedly_publish_states_timer, ble_npl_eventq_dflt_get(),
-			     unsolicitedly_publish_states_timer_handler, NULL);
+	os_callout_init(&no_transition_work, os_eventq_dflt_get(),
+			no_transition_work_handler, NULL);
+	os_callout_init(&save_lightness_temp_last_values_timer,
+			os_eventq_dflt_get(),
+			save_lightness_temp_last_values_timer_handler,
+			NULL);
+	os_callout_init(&unsolicitedly_publish_states_work, os_eventq_dflt_get(),
+			unsolicitedly_publish_states_work_handler, NULL);
+	os_callout_init(&unsolicitedly_publish_states_timer, os_eventq_dflt_get(),
+			unsolicitedly_publish_states_timer_handler, NULL);
 }

--- a/apps/blemesh_models_example_2/src/no_transition_work_handler.h
+++ b/apps/blemesh_models_example_2/src/no_transition_work_handler.h
@@ -27,7 +27,7 @@
 #ifndef _NO_TRANSITION_WORK_HANDLER_H
 #define _NO_TRANSITION_WORK_HANDLER_H
 
-extern struct ble_npl_callout no_transition_work;
+extern struct os_callout no_transition_work;
 
 void no_transition_work_init(void);
 

--- a/apps/blemesh_models_example_2/src/publisher.c
+++ b/apps/blemesh_models_example_2/src/publisher.c
@@ -66,7 +66,7 @@ static u32_t button_read(int button)
 	return (uint32_t) hal_gpio_read(button);
 }
 
-void publish(struct ble_npl_event *work)
+void publish(struct os_event *work)
 {
 	int err = 0;
 

--- a/apps/blemesh_models_example_2/src/publisher.h
+++ b/apps/blemesh_models_example_2/src/publisher.h
@@ -41,6 +41,6 @@
 #define LEVEL_U100 65535
 
 void randomize_publishers_TID(void);
-void publish(struct ble_npl_event *work);
+void publish(struct os_event *work);
 
 #endif

--- a/apps/blemesh_models_example_2/src/storage.c
+++ b/apps/blemesh_models_example_2/src/storage.c
@@ -133,7 +133,7 @@ static void save_temperature_range(void)
 	settings_save_one("ps/tr", buf);
 }
 
-static void storage_work_handler(struct ble_npl_event *work)
+static void storage_work_handler(struct os_event *work)
 {
 	switch (storage_id) {
 	case RESET_COUNTER:
@@ -160,13 +160,12 @@ static void storage_work_handler(struct ble_npl_event *work)
 	}
 }
 
-struct ble_npl_callout storage_work;
+struct os_callout storage_work;
 
 void save_on_flash(u8_t id)
 {
 	storage_id = id;
-	k_work_submit(&storage_work);
-	ble_npl_callout_reset(&storage_work, 0);
+	os_callout_reset(&storage_work, 0);
 }
 
 static int ps_set(int argc, char **argv, char *val)
@@ -243,7 +242,7 @@ int ps_settings_init(void)
 {
 	int err;
 
-	ble_npl_callout_init(&storage_work, ble_npl_eventq_dflt_get(),
+	os_callout_init(&storage_work, os_eventq_dflt_get(),
 			     storage_work_handler, NULL);
 
 	err = conf_register(&ps_settings);

--- a/apps/blemesh_models_example_2/src/storage.h
+++ b/apps/blemesh_models_example_2/src/storage.h
@@ -39,7 +39,7 @@ enum ps_variables_id {
 
 extern u8_t reset_counter;
 
-extern struct ble_npl_callout storage_work;
+extern struct os_callout storage_work;
 
 int ps_settings_init(void);
 void save_on_flash(u8_t id);

--- a/apps/blemesh_models_example_2/src/transition.c
+++ b/apps/blemesh_models_example_2/src/transition.c
@@ -30,19 +30,19 @@
 #include "state_binding.h"
 #include "transition.h"
 
-struct ble_npl_callout onoff_work;
-struct ble_npl_callout level_lightness_work;
-struct ble_npl_callout level_temp_work;
-struct ble_npl_callout light_lightness_actual_work;
-struct ble_npl_callout light_lightness_linear_work;
-struct ble_npl_callout light_ctl_work;
-struct ble_npl_callout light_ctl_temp_work;
+struct os_callout onoff_work;
+struct os_callout level_lightness_work;
+struct os_callout level_temp_work;
+struct os_callout light_lightness_actual_work;
+struct os_callout light_lightness_linear_work;
+struct os_callout light_ctl_work;
+struct os_callout light_ctl_temp_work;
 
-struct ble_npl_callout dummy_timer;
+struct os_callout dummy_timer;
 
 u8_t transition_type, default_tt;
 u32_t *ptr_counter;
-struct ble_npl_callout *ptr_timer = &dummy_timer;
+struct os_callout *ptr_timer = &dummy_timer;
 
 struct transition lightness_transition, temp_transition;
 
@@ -156,7 +156,7 @@ void onoff_tt_values(struct generic_onoff_state *state, u8_t tt, u8_t delay)
 	}
 
 	state->transition->quo_tt = state->transition->total_duration /
-					state->transition->counter;
+				    state->transition->counter;
 
 	state->tt_delta = ((float) (lightness - target_lightness) /
 			   state->transition->counter);
@@ -181,7 +181,7 @@ void level_tt_values(struct generic_level_state *state, u8_t tt, u8_t delay)
 	}
 
 	state->transition->quo_tt = state->transition->total_duration /
-					state->transition->counter;
+				    state->transition->counter;
 
 	state->tt_delta = ((float) (state->level - state->target_level) /
 			   state->transition->counter);
@@ -202,7 +202,7 @@ void light_lightness_actual_tt_values(struct light_lightness_state *state,
 	}
 
 	state->transition->quo_tt = state->transition->total_duration /
-					state->transition->counter;
+				    state->transition->counter;
 
 	state->tt_delta_actual =
 		((float) (state->actual - state->target_actual) /
@@ -224,7 +224,7 @@ void light_lightness_linear_tt_values(struct light_lightness_state *state,
 	}
 
 	state->transition->quo_tt = state->transition->total_duration /
-					state->transition->counter;
+				    state->transition->counter;
 
 	state->tt_delta_linear =
 		((float) (state->linear - state->target_linear) /
@@ -245,7 +245,7 @@ void light_ctl_tt_values(struct light_ctl_state *state, u8_t tt, u8_t delay)
 	}
 
 	state->transition->quo_tt = state->transition->total_duration /
-					state->transition->counter;
+				    state->transition->counter;
 
 	state->tt_delta_lightness =
 		((float) (state->lightness - state->target_lightness) /
@@ -275,7 +275,7 @@ void light_ctl_temp_tt_values(struct light_ctl_state *state,
 	}
 
 	state->transition->quo_tt = state->transition->total_duration /
-					state->transition->counter;
+				    state->transition->counter;
 
 	state->tt_delta_temp = ((float) (state->temp - state->target_temp) /
 				state->transition->counter);
@@ -286,7 +286,7 @@ void light_ctl_temp_tt_values(struct light_ctl_state *state,
 }
 
 /* Timers related handlers & threads (Start) */
-static void onoff_work_handler(struct ble_npl_event *work)
+static void onoff_work_handler(struct os_event *work)
 {
 	struct generic_onoff_state *state = &gen_onoff_srv_root_user_data;
 
@@ -297,7 +297,7 @@ static void onoff_work_handler(struct ble_npl_event *work)
 			state_binding(ONOFF, IGNORE_TEMP);
 			update_light_state();
 
-			ble_npl_callout_stop(ptr_timer);
+			os_callout_stop(ptr_timer);
 		} else {
 			state->transition->start_timestamp = k_uptime_get();
 
@@ -325,11 +325,11 @@ static void onoff_work_handler(struct ble_npl_event *work)
 		state_binding(IGNORE, IGNORE_TEMP);
 		update_light_state();
 
-		ble_npl_callout_stop(ptr_timer);
+		os_callout_stop(ptr_timer);
 	}
 }
 
-static void level_lightness_work_handler(struct ble_npl_event *work)
+static void level_lightness_work_handler(struct os_event *work)
 {
 	u8_t level;
 	struct generic_level_state *state = &gen_level_srv_root_user_data;
@@ -355,7 +355,7 @@ static void level_lightness_work_handler(struct ble_npl_event *work)
 			state_binding(level, IGNORE_TEMP);
 			update_light_state();
 
-			ble_npl_callout_stop(ptr_timer);
+			os_callout_stop(ptr_timer);
 		} else {
 			state->transition->start_timestamp = k_uptime_get();
 		}
@@ -378,11 +378,11 @@ static void level_lightness_work_handler(struct ble_npl_event *work)
 		state_binding(level, IGNORE_TEMP);
 		update_light_state();
 
-		ble_npl_callout_stop(ptr_timer);
+		os_callout_stop(ptr_timer);
 	}
 }
 
-static void level_temp_work_handler(struct ble_npl_event *work)
+static void level_temp_work_handler(struct os_event *work)
 {
 	struct generic_level_state *state = &gen_level_srv_s0_user_data;
 
@@ -404,7 +404,7 @@ static void level_temp_work_handler(struct ble_npl_event *work)
 			state_binding(IGNORE, LEVEL_TEMP);
 			update_light_state();
 
-			ble_npl_callout_stop(ptr_timer);
+			os_callout_stop(ptr_timer);
 		} else {
 			state->transition->start_timestamp = k_uptime_get();
 		}
@@ -427,11 +427,11 @@ static void level_temp_work_handler(struct ble_npl_event *work)
 		state_binding(IGNORE, LEVEL_TEMP);
 		update_light_state();
 
-		ble_npl_callout_stop(ptr_timer);
+		os_callout_stop(ptr_timer);
 	}
 }
 
-static void light_lightness_actual_work_handler(struct ble_npl_event *work)
+static void light_lightness_actual_work_handler(struct os_event *work)
 {
 	struct light_lightness_state *state = &light_lightness_srv_user_data;
 
@@ -442,7 +442,7 @@ static void light_lightness_actual_work_handler(struct ble_npl_event *work)
 			state_binding(ACTUAL, IGNORE_TEMP);
 			update_light_state();
 
-			ble_npl_callout_stop(ptr_timer);
+			os_callout_stop(ptr_timer);
 		} else {
 			state->transition->start_timestamp = k_uptime_get();
 		}
@@ -465,11 +465,11 @@ static void light_lightness_actual_work_handler(struct ble_npl_event *work)
 		state_binding(ACTUAL, IGNORE_TEMP);
 		update_light_state();
 
-		ble_npl_callout_stop(ptr_timer);
+		os_callout_stop(ptr_timer);
 	}
 }
 
-static void light_lightness_linear_work_handler(struct ble_npl_event *work)
+static void light_lightness_linear_work_handler(struct os_event *work)
 {
 	struct light_lightness_state *state = &light_lightness_srv_user_data;
 
@@ -480,7 +480,7 @@ static void light_lightness_linear_work_handler(struct ble_npl_event *work)
 			state_binding(LINEAR, IGNORE_TEMP);
 			update_light_state();
 
-			ble_npl_callout_stop(ptr_timer);
+			os_callout_stop(ptr_timer);
 		} else {
 			state->transition->start_timestamp = k_uptime_get();
 		}
@@ -503,11 +503,11 @@ static void light_lightness_linear_work_handler(struct ble_npl_event *work)
 		state_binding(LINEAR, IGNORE_TEMP);
 		update_light_state();
 
-		ble_npl_callout_stop(ptr_timer);
+		os_callout_stop(ptr_timer);
 	}
 }
 
-static void light_ctl_work_handler(struct ble_npl_event *work)
+static void light_ctl_work_handler(struct os_event *work)
 {
 	struct light_ctl_state *state = &light_ctl_srv_user_data;
 
@@ -518,7 +518,7 @@ static void light_ctl_work_handler(struct ble_npl_event *work)
 			state_binding(CTL, CTL_TEMP);
 			update_light_state();
 
-			ble_npl_callout_stop(ptr_timer);
+			os_callout_stop(ptr_timer);
 		} else {
 			state->transition->start_timestamp = k_uptime_get();
 		}
@@ -550,11 +550,11 @@ static void light_ctl_work_handler(struct ble_npl_event *work)
 		state_binding(CTL, CTL_TEMP);
 		update_light_state();
 
-		ble_npl_callout_stop(ptr_timer);
+		os_callout_stop(ptr_timer);
 	}
 }
 
-static void light_ctl_temp_work_handler(struct ble_npl_event *work)
+static void light_ctl_temp_work_handler(struct os_event *work)
 {
 	struct light_ctl_state *state = &light_ctl_srv_user_data;
 
@@ -565,7 +565,7 @@ static void light_ctl_temp_work_handler(struct ble_npl_event *work)
 			state_binding(IGNORE, CTL_TEMP);
 			update_light_state();
 
-			ble_npl_callout_stop(ptr_timer);
+			os_callout_stop(ptr_timer);
 		} else {
 			state->transition->start_timestamp = k_uptime_get();
 		}
@@ -593,88 +593,88 @@ static void light_ctl_temp_work_handler(struct ble_npl_event *work)
 		state_binding(IGNORE, CTL_TEMP);
 		update_light_state();
 
-		ble_npl_callout_stop(ptr_timer);
+		os_callout_stop(ptr_timer);
 	}
 }
 
-static void dummy_timer_handler(struct ble_npl_event *ev)
+static void dummy_timer_handler(struct os_event *ev)
 { }
 
-static void onoff_tt_handler(struct ble_npl_event *ev)
+static void onoff_tt_handler(struct os_event *ev)
 {
-	struct generic_onoff_state *state = ble_npl_event_get_arg(ev);
+	struct generic_onoff_state *state = ev->ev_arg;
 
 	assert(state != NULL);
-	ble_npl_callout_reset(&onoff_work, 0);
-	ble_npl_callout_reset(&state->transition->timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(state->transition->quo_tt)));
+	os_callout_reset(&onoff_work, 0);
+	os_callout_reset(&state->transition->timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(state->transition->quo_tt)));
 }
 
-static void level_lightness_tt_handler(struct ble_npl_event *ev)
+static void level_lightness_tt_handler(struct os_event *ev)
 {
-	struct generic_level_state *state = ble_npl_event_get_arg(ev);
+	struct generic_level_state *state = ev->ev_arg;
 
 	assert(state != NULL);
-	ble_npl_callout_reset(&level_lightness_work, 0);
-	ble_npl_callout_reset(&state->transition->timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(state->transition->quo_tt)));
+	os_callout_reset(&level_lightness_work, 0);
+	os_callout_reset(&state->transition->timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(state->transition->quo_tt)));
 }
 
-static void level_temp_tt_handler(struct ble_npl_event *ev)
+static void level_temp_tt_handler(struct os_event *ev)
 {
-	struct generic_level_state *state = ble_npl_event_get_arg(ev);
+	struct generic_level_state *state = ev->ev_arg;
 
 	assert(state != NULL);
-	ble_npl_callout_reset(&level_temp_work, 0);
-	ble_npl_callout_reset(&state->transition->timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(state->transition->quo_tt)));
+	os_callout_reset(&level_temp_work, 0);
+	os_callout_reset(&state->transition->timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(state->transition->quo_tt)));
 }
 
-static void light_lightness_actual_tt_handler(struct ble_npl_event *ev)
+static void light_lightness_actual_tt_handler(struct os_event *ev)
 {
-	struct light_lightness_state *state = ble_npl_event_get_arg(ev);
+	struct light_lightness_state *state = ev->ev_arg;
 
 	assert(state != NULL);
-	ble_npl_callout_reset(&light_lightness_actual_work, 0);
-	ble_npl_callout_reset(&state->transition->timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(state->transition->quo_tt)));
+	os_callout_reset(&light_lightness_actual_work, 0);
+	os_callout_reset(&state->transition->timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(state->transition->quo_tt)));
 }
 
-static void light_lightness_linear_tt_handler(struct ble_npl_event *ev)
+static void light_lightness_linear_tt_handler(struct os_event *ev)
 {
-	struct light_lightness_state *state = ble_npl_event_get_arg(ev);
+	struct light_lightness_state *state = ev->ev_arg;
 
 	assert(state != NULL);
-	ble_npl_callout_reset(&light_lightness_linear_work, 0);
-	ble_npl_callout_reset(&state->transition->timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(state->transition->quo_tt)));
+	os_callout_reset(&light_lightness_linear_work, 0);
+	os_callout_reset(&state->transition->timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(state->transition->quo_tt)));
 }
 
-static void light_ctl_tt_handler(struct ble_npl_event *ev)
+static void light_ctl_tt_handler(struct os_event *ev)
 {
-	struct light_ctl_state *state = ble_npl_event_get_arg(ev);
+	struct light_ctl_state *state = ev->ev_arg;
 
 	assert(state != NULL);
-	ble_npl_callout_reset(&light_ctl_work, 0);
-	ble_npl_callout_reset(&state->transition->timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(state->transition->quo_tt)));
+	os_callout_reset(&light_ctl_work, 0);
+	os_callout_reset(&state->transition->timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(state->transition->quo_tt)));
 }
 
-static void light_ctl_temp_tt_handler(struct ble_npl_event *ev)
+static void light_ctl_temp_tt_handler(struct os_event *ev)
 {
-	struct light_ctl_state *state = ble_npl_event_get_arg(ev);
+	struct light_ctl_state *state = ev->ev_arg;
 
 	assert(state != NULL);
-	ble_npl_callout_reset(&light_ctl_temp_work, 0);
-	ble_npl_callout_reset(&state->transition->timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(state->transition->quo_tt)));
+	os_callout_reset(&light_ctl_temp_work, 0);
+	os_callout_reset(&state->transition->timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(state->transition->quo_tt)));
 }
 /* Timers related handlers & threads (End) */
 
@@ -683,112 +683,110 @@ void onoff_handler(struct generic_onoff_state *state)
 {
 	ptr_timer = &state->transition->timer;
 
-	ble_npl_callout_init(ptr_timer, ble_npl_eventq_dflt_get(),
-			     onoff_tt_handler, NULL);
-	ble_npl_callout_set_arg(ptr_timer, state);
-	ble_npl_callout_reset(ptr_timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(5 * state->transition->delay)));
+	os_callout_init(ptr_timer, os_eventq_dflt_get(),
+			onoff_tt_handler, NULL);
+	ptr_timer->c_ev.ev_arg = state;
+	os_callout_reset(ptr_timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(5 * state->transition->delay)));
 }
 
 void level_lightness_handler(struct generic_level_state *state)
 {
 	ptr_timer = &state->transition->timer;
 
-	ble_npl_callout_init(ptr_timer, ble_npl_eventq_dflt_get(),
-			     level_lightness_tt_handler, NULL);
-	ble_npl_callout_set_arg(ptr_timer, state);
-	ble_npl_callout_reset(ptr_timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(5 * state->transition->delay)));
+	os_callout_init(ptr_timer, os_eventq_dflt_get(),
+			level_lightness_tt_handler, NULL);
+	ptr_timer->c_ev.ev_arg = state;
+	os_callout_reset(ptr_timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(5 * state->transition->delay)));
 }
 
 void level_temp_handler(struct generic_level_state *state)
 {
 	ptr_timer = &state->transition->timer;
 
-	ble_npl_callout_init(ptr_timer, ble_npl_eventq_dflt_get(),
-			     level_temp_tt_handler, NULL);
-	ble_npl_callout_set_arg(ptr_timer, state);
-	ble_npl_callout_reset(ptr_timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(5 * state->transition->delay)));
+	os_callout_init(ptr_timer, os_eventq_dflt_get(),
+			level_temp_tt_handler, NULL);
+	ptr_timer->c_ev.ev_arg = state;
+	os_callout_reset(ptr_timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(5 * state->transition->delay)));
 }
 
 void light_lightness_actual_handler(struct light_lightness_state *state)
 {
 	ptr_timer = &state->transition->timer;
 
-	ble_npl_callout_init(ptr_timer, ble_npl_eventq_dflt_get(),
-			     light_lightness_actual_tt_handler, NULL);
-	ble_npl_callout_set_arg(ptr_timer,
-				state);
-	ble_npl_callout_reset(ptr_timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(5 * state->transition->delay)));
+	os_callout_init(ptr_timer, os_eventq_dflt_get(),
+			light_lightness_actual_tt_handler, NULL);
+	ptr_timer->c_ev.ev_arg = state;
+	os_callout_reset(ptr_timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(5 * state->transition->delay)));
 }
 
 void light_lightness_linear_handler(struct light_lightness_state *state)
 {
 	ptr_timer = &state->transition->timer;
 
-	ble_npl_callout_init(ptr_timer, ble_npl_eventq_dflt_get(),
-			     light_lightness_linear_tt_handler, NULL);
-	ble_npl_callout_set_arg(ptr_timer,
-				state);
-	ble_npl_callout_reset(ptr_timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(5 * state->transition->delay)));
+	os_callout_init(ptr_timer, os_eventq_dflt_get(),
+			light_lightness_linear_tt_handler, NULL);
+	ptr_timer->c_ev.ev_arg = state;
+	os_callout_reset(ptr_timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(5 * state->transition->delay)));
 }
 
 void light_ctl_handler(struct light_ctl_state *state)
 {
 	ptr_timer = &state->transition->timer;
 
-	ble_npl_callout_init(ptr_timer, ble_npl_eventq_dflt_get(),
-			     light_ctl_tt_handler, NULL);
-	ble_npl_callout_set_arg(ptr_timer, state);
-	ble_npl_callout_reset(ptr_timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(5 * state->transition->delay)));
+	os_callout_init(ptr_timer, os_eventq_dflt_get(),
+			light_ctl_tt_handler, NULL);
+	ptr_timer->c_ev.ev_arg = state;
+	os_callout_reset(ptr_timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(5 * state->transition->delay)));
 }
 
 void light_ctl_temp_handler(struct light_ctl_state *state)
 {
 	ptr_timer = &state->transition->timer;
 
-	ble_npl_callout_init(ptr_timer, ble_npl_eventq_dflt_get(),
-			     light_ctl_temp_tt_handler, NULL);
-	ble_npl_callout_set_arg(ptr_timer, state);
-	ble_npl_callout_reset(ptr_timer,
-			      ble_npl_time_ms_to_ticks32(
-				      K_MSEC(5 * state->transition->delay)));
+	os_callout_init(ptr_timer, os_eventq_dflt_get(),
+			light_ctl_temp_tt_handler, NULL);
+	ptr_timer->c_ev.ev_arg = state;
+	os_callout_reset(ptr_timer,
+			 os_time_ms_to_ticks32(
+				 K_MSEC(5 * state->transition->delay)));
 }
 /* Messages handlers (End) */
 
 void transition_timers_init(void)
 {
-	ble_npl_callout_init(&onoff_work, ble_npl_eventq_dflt_get(),
-			     onoff_work_handler, NULL);
+	os_callout_init(&onoff_work, os_eventq_dflt_get(),
+			onoff_work_handler, NULL);
 
-	ble_npl_callout_init(&level_lightness_work, ble_npl_eventq_dflt_get(),
-			     level_lightness_work_handler, NULL);
-	ble_npl_callout_init(&level_temp_work, ble_npl_eventq_dflt_get(),
-			     level_temp_work_handler, NULL);
+	os_callout_init(&level_lightness_work, os_eventq_dflt_get(),
+			level_lightness_work_handler, NULL);
+	os_callout_init(&level_temp_work, os_eventq_dflt_get(),
+			level_temp_work_handler, NULL);
 
-	ble_npl_callout_init(&light_lightness_actual_work,
-			     ble_npl_eventq_dflt_get(),
-			     light_lightness_actual_work_handler, NULL);
-	ble_npl_callout_init(&light_lightness_linear_work,
-			     ble_npl_eventq_dflt_get(),
-			     light_lightness_linear_work_handler, NULL);
+	os_callout_init(&light_lightness_actual_work,
+			os_eventq_dflt_get(),
+			light_lightness_actual_work_handler, NULL);
+	os_callout_init(&light_lightness_linear_work,
+			os_eventq_dflt_get(),
+			light_lightness_linear_work_handler, NULL);
 
-	ble_npl_callout_init(&light_ctl_work, ble_npl_eventq_dflt_get(),
-			     light_ctl_work_handler, NULL);
-	ble_npl_callout_init(&light_ctl_temp_work, ble_npl_eventq_dflt_get(),
-			     light_ctl_temp_work_handler, NULL);
+	os_callout_init(&light_ctl_work, os_eventq_dflt_get(),
+			light_ctl_work_handler, NULL);
+	os_callout_init(&light_ctl_temp_work, os_eventq_dflt_get(),
+			light_ctl_temp_work_handler, NULL);
 
-	ble_npl_callout_init(&dummy_timer, ble_npl_eventq_dflt_get(),
-			     dummy_timer_handler, NULL);
+	os_callout_init(&dummy_timer, os_eventq_dflt_get(),
+			dummy_timer_handler, NULL);
 }
 

--- a/apps/blemesh_models_example_2/src/transition.h
+++ b/apps/blemesh_models_example_2/src/transition.h
@@ -50,16 +50,16 @@ struct transition {
 	u32_t total_duration;
 	s64_t start_timestamp;
 
-	struct ble_npl_callout timer;
+	struct os_callout timer;
 };
 
 extern u8_t transition_type, default_tt;
 extern u32_t *ptr_counter;
-extern struct ble_npl_callout *ptr_timer;
+extern struct os_callout *ptr_timer;
 
 extern struct transition lightness_transition, temp_transition;
 
-extern struct ble_npl_callout dummy_timer;
+extern struct os_callout dummy_timer;
 
 void calculate_rt(struct transition *transition);
 


### PR DESCRIPTION
This api should only be used between the OS and Nimble. Apps should
use OS specific APIs.