### PR TITLE
nimble/transport: Add option to use custom HCI transport

### DIFF
--- a/nimble/transport/syscfg.yml
+++ b/nimble/transport/syscfg.yml
@@ -27,6 +27,7 @@ syscfg.defs:
         restrictions: $notnull
         choices:
             - builtin   # Built-in NimBLE controller and RAM transport
+            - custom    # Custom transport, has to be included manually by user
             - ram       # RAM transport
             - uart      # UART HCI H4 transport
             - socket    # Socket transport (for native builds)


### PR DESCRIPTION
Since it's recommended for apps to explicitly include only meta-package
for HCI transport (so it can be easily changed in target for any BSP),
we should also have an option to allow HCI transport other than one of
those we have in tree. This is useful for development and 3rd party
solutions which may have own HCI transport.