### PR TITLE
nimble/mesh: Fix null pointer access on prov_init

### DIFF
--- a/nimble/host/mesh/src/proxy.c
+++ b/nimble/host/mesh/src/proxy.c
@@ -681,7 +681,9 @@ struct os_mbuf *bt_mesh_proxy_get_buf(void)
 {
 	struct os_mbuf *buf = clients[0].buf;
 
-	net_buf_simple_init(buf, 0);
+	if (buf != NULL) {
+		net_buf_simple_init(buf, 0);
+	}
 
 	return buf;
 }


### PR DESCRIPTION
During bt_mesh_prov_init() a bt_mesh_proxy_get_buf() function
is called that returns a buffer that tries to initialize
unallocated buffer. With this patch, we just return NULL
here, and then the buffer is allocated after Proxy is initialized.