### PR TITLE
apps/btshell: Fix full discovery

### DIFF
--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -64,6 +64,7 @@ struct btshell_svc {
     SLIST_ENTRY(btshell_svc) next;
     struct ble_gatt_svc svc;
     struct btshell_chr_list chrs;
+    bool discovered;
 };
 
 SLIST_HEAD(btshell_svc_list, btshell_svc);
@@ -95,6 +96,7 @@ int btshell_disc_svcs(uint16_t conn_handle);
 int btshell_disc_svc_by_uuid(uint16_t conn_handle, const ble_uuid_t *uuid);
 int btshell_disc_all_chrs(uint16_t conn_handle, uint16_t start_handle,
                            uint16_t end_handle);
+int btshell_disc_all_chrs_in_svc(uint16_t conn_handle, struct btshell_svc *svc);
 int btshell_disc_chrs_by_uuid(uint16_t conn_handle, uint16_t start_handle,
                                uint16_t end_handle, const ble_uuid_t *uuid);
 int btshell_disc_all_dscs(uint16_t conn_handle, uint16_t start_handle,


### PR DESCRIPTION
During full discovery, if last service does not have any characteristic
but its end handle is 65535 (which is allowed by Core spec), discovery
will loop forever since it assumes service was discovered if either
start handle == end handle or there are characteristics discovered.

This patch fixes this by adding "discovered" property to service struct
which is used to check if service was already discovered.