### PR TITLE
nimble/ll: Remove pointer to unreferenced aux_data

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -1171,6 +1171,7 @@ static void
 ble_ll_scan_sched_remove(struct ble_ll_sched_item *sch)
 {
     ble_ll_scan_aux_data_unref(sch->cb_arg);
+    sch->cb_arg = NULL;
 }
 #endif
 /**


### PR DESCRIPTION
When removing aux scheduler entry from the scheduler, make sure to remove
the reference to the aux_data.