### PR TITLE
apps/blecent: Remove explicit dependency to controller

### DIFF
--- a/apps/blecent/pkg.yml
+++ b/apps/blecent/pkg.yml
@@ -28,10 +28,9 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
-    - nimble/controller
     - nimble/host
     - nimble/host/util
     - nimble/host/services/gap
     - nimble/host/services/gatt
     - nimble/host/store/ram
-    - nimble/transport/ram
+    - nimble/transport

--- a/apps/blecent/src/main.c
+++ b/apps/blecent/src/main.c
@@ -24,12 +24,8 @@
 
 /* BLE */
 #include "nimble/ble.h"
-#include "controller/ble_ll.h"
 #include "host/ble_hs.h"
 #include "host/util/util.h"
-
-/* RAM HCI transport. */
-#include "transport/ram/ble_hci_ram.h"
 
 /* Mandatory services. */
 #include "services/gap/ble_svc_gap.h"


### PR DESCRIPTION
blecent should work with any transport, it does not need explicit
dependency to controller and RAM transport. nimble/transport meta
package will select proper transport and add controller dependency
automatically if needed.