### PR TITLE
Mynewt: Define logs in packages' syscfg files

### DIFF
--- a/nimble/host/include/host/ble_hs_log.h
+++ b/nimble/host/include/host/ble_hs_log.h
@@ -21,6 +21,9 @@
 #define H_BLE_HS_LOG_
 
 #include "modlog/modlog.h"
+#if MYNEWT
+#include "os/mynewt.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,14 +31,28 @@ extern "C" {
 
 struct os_mbuf;
 
+/* Logging macros are generated automatically for Mynewt.  Define them here for
+ * other OSes.
+ */
+#if !MYNEWT
+
+#define BLE_HS_LOG_DEBUG(...) MODLOG_DEBUG(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+#define BLE_HS_LOG_INFO(...)  MODLOG_INFO(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+#define BLE_HS_LOG_WARN(...)  MODLOG_WARN(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+#define BLE_HS_LOG_ERROR(...) MODLOG_ERROR(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+#define BLE_HS_LOG_CRITICAL(...)    \
+    MODLOG_CRITICAL(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+
+#endif
+
 #define BLE_HS_LOG(lvl, ...) \
-    MODLOG_ ## lvl(LOG_MODULE_NIMBLE_HOST, __VA_ARGS__)
+    BLE_HS_LOG_ ## lvl(__VA_ARGS__)
 
 #define BLE_HS_LOG_ADDR(lvl, addr)                      \
-    MODLOG_ ## lvl(LOG_MODULE_NIMBLE_HOST,              \
-                   "%02x:%02x:%02x:%02x:%02x:%02x",     \
-                   (addr)[5], (addr)[4], (addr)[3],     \
-                   (addr)[2], (addr)[1], (addr)[0])
+    BLE_HS_LOG_ ## lvl("%02x:%02x:%02x:%02x:%02x:%02x", \
+                       (addr)[5], (addr)[4], (addr)[3], \
+                       (addr)[2], (addr)[1], (addr)[0])
+
 
 void ble_hs_log_mbuf(const struct os_mbuf *om);
 void ble_hs_log_flat_buf(const void *data, int len);

--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -446,5 +446,19 @@ syscfg.defs:
             Sysinit stage for the NimBLE host.
         value: 200
 
+    ### Log settings.
+
+    BLE_HS_LOG_MOD:
+        description: 'Numeric module ID to use for BLE host log messages.'
+        value: 4
+    BLE_HS_LOG_LVL:
+        description: 'Minimum level for the BLE host log.'
+        value: 1
+
+syscfg.logs:
+    BLE_HS_LOG:
+        module: MYNEWT_VAL(BLE_HS_LOG_MOD)
+        level: MYNEWT_VAL(BLE_HS_LOG_LVL)
+
 syscfg.vals.BLE_MESH:
     BLE_SM_SC: 1


### PR DESCRIPTION
This is a Mynewt-specific PR.

Defining logs in syscfg files provides a few benefits:

1. Ability to set log level per module at build time.  Setting a global log level of 0 (`LOG_LEVEL=0`) might produce an image that is too big.  Instead, we can enable debug logging only for the modules we are interested in.

2. Easier to visualize system log configuration (see below).

3. Log modules can be remapped at build time in case of conflicts.

To see the system-wide log configuration, use either of these commands:

```
newt target logcfg brief <target-name>
newt target logcfg show <target-name>
```