### PR TITLE
nimble/controller: Packet counter size in connection incorrect.

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -81,14 +81,20 @@ enum conn_enc_state {
 /*
  * Note that the LTK is the key, the SDK is the plain text, and the
  * session key is the cipher text portion of the encryption block.
+ *
+ * NOTE: we have intentionally violated the specification by making the
+ * transmit and receive packet counters 32-bits as opposed to 39 (as per the
+ * specification). We do this to save code space, ram and calculation time. The
+ * only drawback is that any encrypted connection that sends more than 2^32
+ * packets will suffer a MIC failure and thus be disconnected.
  */
 struct ble_ll_conn_enc_data
 {
     uint8_t enc_state;
     uint8_t tx_encrypted;
     uint16_t enc_div;
-    uint16_t tx_pkt_cntr;
-    uint16_t rx_pkt_cntr;
+    uint32_t tx_pkt_cntr;
+    uint32_t rx_pkt_cntr;
     uint64_t host_rand_num;
     uint8_t iv[8];
     struct ble_encryption_block enc_block;


### PR DESCRIPTION
The transmit and receive packet counters were incorrectly sized at
16 bits. The specification dictates 39 bits of packet counter. The
fix makes them 32 bits as opposed to the full 39 as we do not think
the chance of there being more than 2^32 packets during a connection
likely and thus does not warrant the additional RAM usage per
connection (nor the slight addition to code space and speed).