### PR TITLE
nimble/host: Cleanup address type conversion

### DIFF
--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -718,6 +718,8 @@ ble_gatts_clt_cfg_access_locked(struct ble_hs_conn *conn, uint16_t attr_handle,
             /* Successful writes get persisted for bonded connections. */
             if (conn->bhc_sec_state.bonded) {
                 out_cccd->peer_addr = conn->bhc_peer_addr;
+                out_cccd->peer_addr.type =
+                    ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);
                 out_cccd->chr_val_handle = chr_val_handle;
                 out_cccd->flags = clt_cfg->flags;
                 out_cccd->value_changed = 0;
@@ -1449,6 +1451,8 @@ ble_gatts_rx_indicate_ack(uint16_t conn_handle, uint16_t chr_val_handle)
                   !(clt_cfg->flags & BLE_GATTS_CLT_CFG_F_MODIFIED);
         if (persist) {
             cccd_value.peer_addr = conn->bhc_peer_addr;
+            cccd_value.peer_addr.type =
+                ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);
             cccd_value.chr_val_handle = chr_val_handle;
             cccd_value.flags = clt_cfg->flags;
             cccd_value.value_changed = 0;
@@ -1677,6 +1681,8 @@ ble_gatts_bonding_established(uint16_t conn_handle)
     BLE_HS_DBG_ASSERT(conn->bhc_sec_state.bonded);
 
     cccd_value.peer_addr = conn->bhc_peer_addr;
+    cccd_value.peer_addr.type =
+        ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);
     gatt_srv = &conn->bhc_gatt_svr;
 
     for (i = 0; i < gatt_srv->num_clt_cfgs; ++i) {
@@ -1721,6 +1727,8 @@ ble_gatts_bonding_restored(uint16_t conn_handle)
     BLE_HS_DBG_ASSERT(conn->bhc_sec_state.bonded);
 
     cccd_key.peer_addr = conn->bhc_peer_addr;
+    cccd_key.peer_addr.type =
+        ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);
     cccd_key.chr_val_handle = 0;
     cccd_key.idx = 0;
 

--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -390,7 +390,7 @@ ble_hs_conn_addrs(const struct ble_hs_conn *conn,
 
     /* Determine our address information. */
     addrs->our_id_addr.type =
-        ble_hs_misc_addr_type_to_id(conn->bhc_our_addr_type);
+        ble_hs_misc_own_addr_type_to_id(conn->bhc_our_addr_type);
 
 #if MYNEWT_VAL(BLE_EXT_ADV)
     /* With EA enabled random address for slave connection is per advertising

--- a/nimble/host/src/ble_hs_id.c
+++ b/nimble/host/src/ble_hs_id.c
@@ -182,7 +182,7 @@ ble_hs_id_addr_type_usable(uint8_t own_addr_type)
 
     case BLE_OWN_ADDR_RPA_PUBLIC_DEFAULT:
     case BLE_OWN_ADDR_RPA_RANDOM_DEFAULT:
-        id_addr_type = ble_hs_misc_addr_type_to_id(own_addr_type);
+        id_addr_type = ble_hs_misc_own_addr_type_to_id(own_addr_type);
         rc = ble_hs_id_addr(id_addr_type, NULL, &nrpa);
         if (rc != 0) {
             return rc;

--- a/nimble/host/src/ble_hs_misc.c
+++ b/nimble/host/src/ble_hs_misc.c
@@ -77,7 +77,7 @@ ble_hs_misc_conn_chan_find_reqd(uint16_t conn_handle, uint16_t cid,
 }
 
 uint8_t
-ble_hs_misc_addr_type_to_id(uint8_t own_addr_type)
+ble_hs_misc_own_addr_type_to_id(uint8_t own_addr_type)
 {
     switch (own_addr_type) {
     case BLE_OWN_ADDR_PUBLIC:
@@ -91,6 +91,24 @@ ble_hs_misc_addr_type_to_id(uint8_t own_addr_type)
     default:
         BLE_HS_DBG_ASSERT(0);
         return BLE_ADDR_PUBLIC;
+    }
+}
+
+uint8_t
+ble_hs_misc_peer_addr_type_to_id(uint8_t peer_addr_type)
+{
+    switch (peer_addr_type) {
+        case BLE_ADDR_PUBLIC:
+        case BLE_ADDR_PUBLIC_ID:
+            return BLE_ADDR_PUBLIC;
+
+        case BLE_ADDR_RANDOM:
+        case BLE_ADDR_RANDOM_ID:
+            return BLE_ADDR_RANDOM;
+
+        default:
+            BLE_HS_DBG_ASSERT(0);
+            return BLE_ADDR_PUBLIC;
     }
 }
 

--- a/nimble/host/src/ble_hs_priv.h
+++ b/nimble/host/src/ble_hs_priv.h
@@ -118,7 +118,8 @@ int ble_hs_misc_conn_chan_find(uint16_t conn_handle, uint16_t cid,
 void ble_hs_misc_conn_chan_find_reqd(uint16_t conn_handle, uint16_t cid,
                                      struct ble_hs_conn **out_conn,
                                      struct ble_l2cap_chan **out_chan);
-uint8_t ble_hs_misc_addr_type_to_id(uint8_t addr_type);
+uint8_t ble_hs_misc_own_addr_type_to_id(uint8_t addr_type);
+uint8_t ble_hs_misc_peer_addr_type_to_id(uint8_t addr_type);
 int ble_hs_misc_restore_irks(void);
 
 int ble_hs_locked_by_cur_task(void);

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -548,7 +548,8 @@ ble_sm_persist_keys(struct ble_sm_proc *proc)
         }
     } else {
         peer_addr = conn->bhc_peer_addr;
-        peer_addr.type = ble_hs_misc_addr_type_to_id(conn->bhc_peer_addr.type);
+        peer_addr.type =
+            ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);
     }
 
     ble_hs_unlock();

--- a/nimble/host/test/src/ble_sm_test_util.c
+++ b/nimble/host/test/src/ble_sm_test_util.c
@@ -476,7 +476,7 @@ ble_sm_test_util_params_to_entity(struct ble_sm_test_params *params,
     }
 
     out_entity->id_addr_type =
-        ble_hs_misc_addr_type_to_id(out_entity->addr_type);
+        ble_hs_misc_own_addr_type_to_id(out_entity->addr_type);
 }
 
 static void
@@ -1634,7 +1634,7 @@ ble_sm_test_util_peer_bonding_good(int send_enc_req,
     /* Ensure the LTK request event got sent to the application. */
     TEST_ASSERT(ble_sm_test_store_obj_type == BLE_STORE_OBJ_TYPE_OUR_SEC);
     TEST_ASSERT(ble_sm_test_store_key.sec.peer_addr.type ==
-                ble_hs_misc_addr_type_to_id(peer_addr_type));
+                ble_hs_misc_peer_addr_type_to_id(peer_addr_type));
     TEST_ASSERT(ble_sm_test_store_key.sec.ediv_rand_present);
     TEST_ASSERT(ble_sm_test_store_key.sec.ediv == ediv);
     TEST_ASSERT(ble_sm_test_store_key.sec.rand_num == rand_num);
@@ -2237,7 +2237,7 @@ ble_sm_test_util_us_lgcy_good(struct ble_sm_test_params *params)
     ble_sm_test_util_bonding_all(params, 1);
 
     /* Verify programmatic unbonding. */
-    peer_addr.type = ble_hs_misc_addr_type_to_id(params->resp_addr_type);
+    peer_addr.type = ble_hs_misc_peer_addr_type_to_id(params->resp_addr_type);
     memcpy(peer_addr.val, params->resp_id_addr, sizeof peer_addr.val);
     rc = ble_store_util_delete_peer(&peer_addr);
     TEST_ASSERT(rc == 0);
@@ -2401,7 +2401,7 @@ ble_sm_test_util_peer_lgcy_good(struct ble_sm_test_params *params)
     ble_sm_test_util_repeat_pairing(params, 0);
 
     /* Verify programmatic unbonding. */
-    peer_addr.type = ble_hs_misc_addr_type_to_id(params->init_addr_type);
+    peer_addr.type = ble_hs_misc_peer_addr_type_to_id(params->init_addr_type);
     memcpy(peer_addr.val, params->init_id_addr, sizeof peer_addr.val);
     rc = ble_store_util_delete_peer(&peer_addr);
     TEST_ASSERT(rc == 0);
@@ -2594,7 +2594,7 @@ ble_sm_test_util_us_sc_good(struct ble_sm_test_params *params)
     ble_sm_test_util_bonding_all(params, 1);
 
     /* Verify programmatic unbonding. */
-    peer_addr.type = ble_hs_misc_addr_type_to_id(params->resp_addr_type);
+    peer_addr.type = ble_hs_misc_peer_addr_type_to_id(params->resp_addr_type);
     memcpy(peer_addr.val, params->resp_id_addr, sizeof peer_addr.val);
     rc = ble_store_util_delete_peer(&peer_addr);
     TEST_ASSERT(rc == 0);
@@ -2815,7 +2815,7 @@ ble_sm_test_util_peer_sc_good(struct ble_sm_test_params *params)
     ble_sm_test_util_repeat_pairing(params, 1);
 
     /* Verify programmatic unbonding. */
-    peer_addr.type = ble_hs_misc_addr_type_to_id(params->init_addr_type);
+    peer_addr.type = ble_hs_misc_peer_addr_type_to_id(params->init_addr_type);
     memcpy(peer_addr.val, params->init_id_addr, sizeof peer_addr.val);
     rc = ble_store_util_delete_peer(&peer_addr);
     TEST_ASSERT(rc == 0);


### PR DESCRIPTION
We should consistently store sec/cccds using public/random address types.
To do this we introduce dedicated conversion functions for own and
peer address types. Even though they use the same values it makes
code easier to follow.