### PR TITLE
nimble/ll: Refactor PHY transitions

### DIFF
--- a/nimble/controller/include/controller/ble_phy.h
+++ b/nimble/controller/include/controller/ble_phy.h
@@ -215,7 +215,7 @@ void ble_phy_resolv_list_disable(void);
 
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY) || MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY))
 uint32_t ble_phy_mode_pdu_start_off(int phy);
-void ble_phy_mode_set(uint8_t new_phy_mode, uint8_t txtorx_phy_mode);
+void ble_phy_mode_set(uint8_t tx_phy_mode, uint8_t rx_phy_mode);
 #else
 #define ble_phy_mode_pdu_start_off(phy)     (40)
 

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1110,10 +1110,6 @@ conn_tx_pdu:
     }
 #endif
 
-#if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-    ble_phy_mode_set(connsm->phy_data.tx_phy_mode,connsm->phy_data.rx_phy_mode);
-#endif
-
     /* Set transmit end callback */
     ble_phy_set_txend_cb(txend_func, connsm);
     rc = ble_phy_tx(ble_ll_tx_mbuf_pducb, m, end_transition);
@@ -1193,6 +1189,10 @@ ble_ll_conn_event_start_cb(struct ble_ll_sched_item *sch)
     ble_phy_resolv_list_disable();
 #endif
 
+#if (BLE_LL_BT5_PHY_SUPPORTED == 1)
+    ble_phy_mode_set(connsm->phy_data.tx_phy_mode, connsm->phy_data.rx_phy_mode);
+#endif
+
     if (connsm->conn_role == BLE_LL_CONN_ROLE_MASTER) {
         /* Set start time of transmission */
         start = sch->start_time + g_ble_ll_sched_offset_ticks;
@@ -1229,11 +1229,6 @@ ble_ll_conn_event_start_cb(struct ble_ll_sched_item *sch)
         } else {
             ble_phy_encrypt_disable();
         }
-#endif
-
-#if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-        ble_phy_mode_set(connsm->phy_data.rx_phy_mode,
-                             connsm->phy_data.rx_phy_mode);
 #endif
 
         /* XXX: what is this really for the slave? */


### PR DESCRIPTION
This changes semantics of ble_phy_mode_set(). Instead of only setting
current phy_mode and TX-to-RX phy_mode, it will set an actual phy_modes
used on every TX and RX during packet sequence. This allows ble_phy to
configure RF properly for both transitions and also makes it resonsible
for changing phy_mode on each transition - ble_ll shall now only call
ble_phy_mode_set before 1st packet in an event, i.e. before calling
ble_phy_tx/rx_set_start_time.