### PR TITLE
controller: fix '-Wsometimes-uninitialized' issue

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1426,7 +1426,7 @@ uint16_t
 ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode)
 {
     uint32_t header_tx_time;
-    uint16_t octets;
+    uint16_t octets = 0;
 
     BLE_LL_ASSERT(phy_mode < BLE_PHY_NUM_MODE);
 


### PR DESCRIPTION
In ble_ll_pdu_max_tx_octets_get(), LLVM complains about the
possibility of the `octets` variable not being intialized. This is
the case, if no assert() function is compiled in. This PR
fixes this by initializing `octets` to a save value.