### PR TITLE
nimble/ble_store: Fix assert when BLE_HS_DEBUG is enabled

### DIFF
--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1695,7 +1695,14 @@ ble_gatts_bonding_established(uint16_t conn_handle)
             cccd_value.chr_val_handle = clt_cfg->chr_val_handle;
             cccd_value.flags = clt_cfg->flags;
             cccd_value.value_changed = 0;
+
+            /* Store write use ble_hs_lock */
+            ble_hs_unlock();
             ble_store_write_cccd(&cccd_value);
+            ble_hs_lock();
+
+            conn = ble_hs_conn_find(conn_handle);
+            BLE_HS_DBG_ASSERT(conn != NULL);
         }
     }
 


### PR DESCRIPTION
This patch fixes folliwing assert:

BLE_HS_DBG_ASSERT(!ble_hs_locked_by_cur_task())

0  ble_hs_lock () at repos/apache-mynewt-nimble/nimble/host/src/ble_hs.c:193
1  0x00035724 in ble_store_write (obj_type=obj_type@entry=3, val=val@entry=0x20003950 <g_os_main_stack+1768>) at repos/apache-mynewt-nimble/nimble/host/src/ble_store.c:54
2  0x000358a8 in ble_store_write_cccd (value=value@entry=0x20003950 <g_os_main_stack+1768>) at repos/apache-mynewt-nimble/nimble/host/src/ble_store.c:273
3  0x0002cee2 in ble_gatts_bonding_established (conn_handle=conn_handle@entry=1) at repos/apache-mynewt-nimble/nimble/host/src/ble_gatts.c:1692
4  0x00028e66 in ble_gap_enc_event (conn_handle=conn_handle@entry=1, status=0, security_restored=0) at repos/apache-mynewt-nimble/nimble/host/src/ble_gap.c:5299
5  0x00034036 in ble_sm_process_result (conn_handle=conn_handle@entry=1, res=res@entry=0x200039e0 <g_os_main_stack+1912>) at repos/apache-mynewt-nimble/nimble/host/src/ble_sm.c:925
6  0x000341d0 in ble_sm_rx (chan=0x20005e14 <ble_l2cap_chan_mem+56>) at repos/apache-mynewt-nimble/nimble/host/src/ble_sm.c:2610
7  0x00030a90 in ble_hs_hci_evt_acl_process (om=0x0, om@entry=0x20003dec <os_msys_1_data+876>) at repos/apache-mynewt-nimble/nimble/host/src/ble_hs_hci_evt.c:1040
8  0x0002d76e in ble_hs_process_rx_data_queue () at repos/apache-mynewt-nimble/nimble/host/src/ble_hs.c:228
9  0x0002d786 in ble_hs_event_rx_data (ev=<optimized out>) at repos/apache-mynewt-nimble/nimble/host/src/ble_hs.c:547
10 0x00012326 in os_eventq_run (evq=<optimized out>) at repos/apache-mynewt-core/kernel/os/src/os_eventq.c:196
11 0x0000da82 in main (argc=<optimized out>, argv=<optimized out>) at repos/apache-mynewt-nimble/apps/leaudio/src/main.c:2464

It happens when bonding is happening after peer registered for
notifications