### PR TITLE
nimble/gatt: Fix null pointer dereference

### DIFF
--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -912,7 +912,7 @@ ble_gattc_proc_matches_conn_rx_entry(struct ble_gattc_proc *proc, void *arg)
     criteria->matching_rx_entry = ble_gattc_rx_entry_find(
         proc->op, criteria->rx_entries, criteria->num_rx_entries);
 
-    return 1;
+    return (criteria->matching_rx_entry != NULL);
 }
 
 static void


### PR DESCRIPTION
Modify ble_gattc_proc_matches_conn_rx_entry to return 0 in case no matching entry found to avoid accessing Null Pointer.