### PR TITLE
nimble/ll: Randomize initial advertising event

### DIFF
--- a/nimble/controller/include/controller/ble_ll_xcvr.h
+++ b/nimble/controller/include/controller/ble_ll_xcvr.h
@@ -32,7 +32,7 @@ extern "C" {
 #define BLE_RFCLK_STATE_SETTLED (2)
 
 int ble_ll_xcvr_rfclk_state(void);
-void ble_ll_xcvr_rfclk_start_now(uint32_t now);
+void ble_ll_xcvr_rfclk_start_now(void);
 void ble_ll_xcvr_rfclk_stop(void);
 void ble_ll_xcvr_rfclk_enable(void);
 void ble_ll_xcvr_rfclk_disable(void);

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -2613,7 +2613,7 @@ ble_ll_adv_sm_start(struct ble_ll_adv_sm *advsm)
     if (xtal_state != BLE_RFCLK_STATE_SETTLED) {
         if (xtal_state == BLE_RFCLK_STATE_OFF) {
             advsm->adv_pdu_start_time += g_ble_ll_data.ll_xtal_ticks;
-            ble_ll_xcvr_rfclk_start_now(os_cputime_get32());
+            ble_ll_xcvr_rfclk_start_now();
         } else {
             advsm->adv_pdu_start_time += ble_ll_xcvr_rfclk_time_till_settled();
         }

--- a/nimble/controller/src/ble_ll_dtm.c
+++ b/nimble/controller/src/ble_ll_dtm.c
@@ -415,7 +415,7 @@ ble_ll_dtm_rx_start(void)
 #ifdef BLE_XCVR_RFCLK
     OS_ENTER_CRITICAL(sr);
     if (ble_ll_xcvr_rfclk_state() == BLE_RFCLK_STATE_OFF) {
-        ble_ll_xcvr_rfclk_start_now(os_cputime_get32());
+        ble_ll_xcvr_rfclk_start_now();
     }
     OS_EXIT_CRITICAL(sr);
 #endif

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -1600,7 +1600,7 @@ ble_ll_scan_event_proc(struct ble_npl_event *ev)
              * the clock setting time.
              */
             if (xtal_state == BLE_RFCLK_STATE_OFF) {
-                ble_ll_xcvr_rfclk_start_now(now);
+                ble_ll_xcvr_rfclk_start_now();
             }
             next_event_time = now + xtal_ticks;
             goto done;
@@ -1621,7 +1621,7 @@ ble_ll_scan_event_proc(struct ble_npl_event *ev)
             /* Start the clock if necessary */
             if (start_scan) {
                 if (ble_ll_xcvr_rfclk_state() == BLE_RFCLK_STATE_OFF) {
-                    ble_ll_xcvr_rfclk_start_now(now);
+                    ble_ll_xcvr_rfclk_start_now();
                     next_event_time = now + g_ble_ll_data.ll_xtal_ticks;
                 }
             }

--- a/nimble/controller/src/ble_ll_xcvr.c
+++ b/nimble/controller/src/ble_ll_xcvr.c
@@ -102,7 +102,7 @@ void
 ble_ll_xcvr_rfclk_timer_exp(void *arg)
 {
     if (g_ble_ll_data.ll_rfclk_state == BLE_RFCLK_STATE_OFF) {
-        ble_ll_xcvr_rfclk_start_now(os_cputime_get32());
+        ble_ll_xcvr_rfclk_start_now();
     }
 }
 
@@ -115,10 +115,12 @@ ble_ll_xcvr_rfclk_timer_exp(void *arg)
  * @param now
  */
 void
-ble_ll_xcvr_rfclk_start_now(uint32_t now)
+ble_ll_xcvr_rfclk_start_now(void)
 {
+    BLE_LL_ASSERT(g_ble_ll_data.ll_rfclk_state == BLE_RFCLK_STATE_OFF);
+
     ble_ll_xcvr_rfclk_enable();
-    g_ble_ll_data.ll_rfclk_start_time = now;
+    g_ble_ll_data.ll_rfclk_start_time = os_cputime_get32();
 }
 
 /**


### PR DESCRIPTION
When starting advertising we can also randomize first event. This is
primary useful for mesh relay where multiple devices starts advertising
at the same time.

This is a bit of RFC :)

Also I don't think we need 5ms fixed delay anymore but I've left it as is for now...