### PR TITLE
nimble/ll_scan: Set filter duplicate only when controller allowed

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -3559,8 +3559,10 @@ ble_ll_scan_set_enable(uint8_t *cmd, uint8_t ext)
             }
         }
 
+#if MYNEWT_VAL(BLE_LL_NUM_SCAN_DUP_ADVS)
         /* update filter policy */
         scansm->scan_filt_dups = filter_dups;
+#endif
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
         /* restart timers according to new settings */
@@ -3576,7 +3578,9 @@ ble_ll_scan_set_enable(uint8_t *cmd, uint8_t ext)
      * disabled now
      */
 
+#if MYNEWT_VAL(BLE_LL_NUM_SCAN_DUP_ADVS)
     scansm->scan_filt_dups = filter_dups;
+#endif
     scansm->cur_phy = PHY_NOT_CONFIGURED;
     scansm->next_phy = PHY_NOT_CONFIGURED;
 


### PR DESCRIPTION
If BLE_LL_NUM_SCAN_DUP_ADVS is 0 then never set filter duplicats in
scansm as it does not makes sense.