### PR TITLE
nimble/host: Fix missing hs lock in ble_gap_unpair

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -5210,13 +5210,18 @@ ble_gap_unpair(const ble_addr_t *peer_addr)
         return BLE_HS_EINVAL;
     }
 
+    ble_hs_lock();
+
     conn = ble_hs_conn_find_by_addr(peer_addr);
     if (conn != NULL) {
-        rc = ble_gap_terminate(conn->bhc_handle, BLE_ERR_REM_USER_CONN_TERM);
+        rc = ble_gap_terminate_with_conn(conn, BLE_ERR_REM_USER_CONN_TERM);
         if ((rc != BLE_HS_EALREADY) && (rc != BLE_HS_ENOTCONN)) {
+            ble_hs_unlock();
             return rc;
         }
     }
+
+    ble_hs_unlock();
 
     rc = ble_hs_pvcy_remove_entry(peer_addr->type,
                                   peer_addr->val);


### PR DESCRIPTION
ble_hs_conn_find_by_addr needs to be called with hs_lock locked.