### PR TITLE
nimble/ll: Fix RX timing on DTM

### DIFF
--- a/nimble/controller/src/ble_ll_dtm.c
+++ b/nimble/controller/src/ble_ll_dtm.c
@@ -373,8 +373,7 @@ ble_ll_dtm_rx_start(void)
 #endif
 
     OS_ENTER_CRITICAL(sr);
-    rc = ble_phy_rx_set_start_time(os_cputime_get32() +
-                                   g_ble_ll_sched_offset_ticks, 0);
+    rc = ble_phy_rx_set_start_time(os_cputime_get32(), 0);
     OS_EXIT_CRITICAL(sr);
     if (rc && rc != BLE_PHY_ERR_RX_LATE) {
         return rc;


### PR DESCRIPTION
There is no need to delay RX restart by scheduler delay since it's not
called from scheduler - we can start asap.