### PR TITLE
DTM extensions

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -567,7 +567,7 @@ extern uint32_t g_bletest_IVm;
 extern uint32_t g_bletest_IVs;
 #endif
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 void ble_ll_dtm_init(void);
 #endif
 

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -214,7 +214,7 @@ void ble_ll_sched_stop(void);
 void ble_ll_sched_rfclk_chk_restart(void);
 #endif
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 int ble_ll_sched_dtm(struct ble_ll_sched_item *sch);
 #endif
 

--- a/nimble/controller/include/controller/ble_phy.h
+++ b/nimble/controller/include/controller/ble_phy.h
@@ -243,7 +243,7 @@ static inline int ble_ll_phy_to_phy_mode(int phy, int phy_options)
     return phy_mode;
 }
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 void ble_phy_enable_dtm(void);
 void ble_phy_disable_dtm(void);
 #endif

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -45,7 +45,7 @@
 #include "controller/ble_ll_sync.h"
 #include "ble_ll_conn_priv.h"
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 #include "ble_ll_dtm_priv.h"
 #endif
 
@@ -617,7 +617,7 @@ ble_ll_wfr_timer_exp(void *arg)
         case BLE_LL_STATE_INITIATING:
             ble_ll_conn_init_wfr_timer_exp();
             break;
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
         case BLE_LL_STATE_DTM:
             ble_ll_dtm_wfr_timer_exp();
             break;
@@ -717,7 +717,7 @@ ble_ll_count_rx_stats(struct ble_mbuf_hdr *hdr, uint16_t len, uint8_t pdu_type)
     crcok = BLE_MBUF_HDR_CRC_OK(hdr);
     connection_data = (BLE_MBUF_HDR_RX_STATE(hdr) == BLE_LL_STATE_CONNECTION);
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
     /* Reuse connection stats for DTM */
     connection_data = (BLE_MBUF_HDR_RX_STATE(hdr) == BLE_LL_STATE_DTM);
 #endif
@@ -794,7 +794,7 @@ ble_ll_rx_pkt_in(void)
         case BLE_LL_STATE_INITIATING:
             ble_ll_init_rx_pkt_in(pdu_type, rxbuf, ble_hdr);
             break;
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
         case BLE_LL_STATE_DTM:
             ble_ll_dtm_rx_pkt_in(m, ble_hdr);
             break;
@@ -930,7 +930,7 @@ ble_ll_rx_start(uint8_t *rxbuf, uint8_t chan, struct ble_mbuf_hdr *rxhdr)
     case BLE_LL_STATE_SCANNING:
         rc = ble_ll_scan_rx_isr_start(pdu_type, &rxhdr->rxinfo.flags);
         break;
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
     case BLE_LL_STATE_DTM:
         rc = ble_ll_dtm_rx_isr_start(rxhdr, ble_phy_access_addr_get());
         break;
@@ -983,7 +983,7 @@ ble_ll_rx_end(uint8_t *rxbuf, struct ble_mbuf_hdr *rxhdr)
     ble_ll_trace_u32x3(BLE_LL_TRACE_ID_RX_END, pdu_type, len,
                        rxhdr->rxinfo.flags);
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
     if (BLE_MBUF_HDR_RX_STATE(rxhdr) == BLE_LL_STATE_DTM) {
         rc = ble_ll_dtm_rx_isr_end(rxbuf, rxhdr);
         return rc;
@@ -1318,7 +1318,7 @@ ble_ll_reset(void)
     /* Stop any advertising */
     ble_ll_adv_reset();
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
     ble_ll_dtm_reset();
 #endif
 
@@ -1628,7 +1628,7 @@ ble_ll_init(void)
                             "ble_ll");
     SYSINIT_PANIC_ASSERT(rc == 0);
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
     ble_ll_dtm_init();
 #endif
 

--- a/nimble/controller/src/ble_ll_dtm.c
+++ b/nimble/controller/src/ble_ll_dtm.c
@@ -20,7 +20,7 @@
 #include "syscfg/syscfg.h"
 #include "sysinit/sysinit.h"
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 
 #include <assert.h>
 #include "os/os.h"

--- a/nimble/controller/src/ble_ll_dtm_priv.h
+++ b/nimble/controller/src/ble_ll_dtm_priv.h
@@ -24,7 +24,7 @@
 #include <stdbool.h>
 #include "nimble/ble.h"
 
-int ble_ll_dtm_tx_test(uint8_t *cmdbuf, bool enhanced);
+int ble_ll_dtm_tx_test(uint8_t *cmdbuf, uint8_t cmdlen, bool enhanced);
 int ble_ll_dtm_rx_test(uint8_t *cmdbuf, bool enhanced);
 int ble_ll_dtm_end_test(uint8_t *rsp, uint8_t *rsplen);
 

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -38,7 +38,7 @@
 #include "hal/hal_gpio.h"
 #endif
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 #include "ble_ll_dtm_priv.h"
 #endif
 
@@ -982,9 +982,7 @@ ble_ll_hci_le_cmd_proc(uint8_t *cmdbuf, uint16_t ocf, uint8_t *rsplen,
         break;
 #if MYNEWT_VAL(BLE_LL_DTM)
     case BLE_HCI_OCF_LE_TX_TEST:
-        if (len == BLE_HCI_TX_TEST_LEN) {
-            rc = ble_ll_dtm_tx_test(cmdbuf, false);
-        }
+        rc = ble_ll_dtm_tx_test(cmdbuf, len, false);
         break;
     case BLE_HCI_OCF_LE_RX_TEST:
         if (len == BLE_HCI_RX_TEST_LEN) {
@@ -1090,16 +1088,14 @@ ble_ll_hci_le_cmd_proc(uint8_t *cmdbuf, uint16_t ocf, uint8_t *rsplen,
         }
         break;
 #endif
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
     case BLE_HCI_OCF_LE_ENH_RX_TEST:
         if (len == BLE_HCI_LE_ENH_RX_TEST_LEN) {
             rc = ble_ll_dtm_rx_test(cmdbuf, true);
         }
         break;
     case BLE_HCI_OCF_LE_ENH_TX_TEST:
-        if (len == BLE_HCI_LE_ENH_TX_TEST_LEN) {
-            rc = ble_ll_dtm_tx_test(cmdbuf, true);
-        }
+        rc = ble_ll_dtm_tx_test(cmdbuf, len, true);
         break;
 #endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -980,7 +980,7 @@ ble_ll_hci_le_cmd_proc(uint8_t *cmdbuf, uint16_t ocf, uint8_t *rsplen,
             rc = ble_ll_hci_le_read_supp_states(rspbuf, rsplen);
         }
         break;
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
     case BLE_HCI_OCF_LE_TX_TEST:
         if (len == BLE_HCI_TX_TEST_LEN) {
             rc = ble_ll_dtm_tx_test(cmdbuf, false);

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -1793,7 +1793,7 @@ done:
 }
 #endif
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 int ble_ll_sched_dtm(struct ble_ll_sched_item *sch)
 {
     int rc;

--- a/nimble/controller/src/ble_ll_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_supp_cmd.c
@@ -137,7 +137,7 @@
 #endif
 #define BLE_SUPP_CMD_LE_READ_SUPP_STATES    (1 << 3)
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 #define BLE_SUPP_CMD_LE_RX_TEST             (1 << 4)
 #define BLE_SUPP_CMD_LE_TX_TEST             (1 << 5)
 #define BLE_SUPP_CMD_LE_TEST_END            (1 << 6)
@@ -233,7 +233,7 @@
 #define BLE_SUPP_CMD_LE_SET_PHY             (0 << 6)
 #endif
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 #define BLE_SUPP_CMD_LE_ENHANCED_RX_TEST    (1 << 7)
 #else
 #define BLE_SUPP_CMD_LE_ENHANCED_RX_TEST    (0 << 7)
@@ -252,7 +252,7 @@
 )
 
 /* Octet 36 */
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 #define BLE_SUPP_CMD_LE_ENHANCED_TX_TEST    (1 << 0)
 #else
 #define BLE_SUPP_CMD_LE_ENHANCED_TX_TEST    (0 << 0)

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -296,6 +296,24 @@ syscfg.defs:
         description: >
              Enables HCI Test commands needed for Bluetooth SIG certification
         value: MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+    BLE_LL_DTM_EXTENSIONS_ENABLE:
+        description: >
+             Enables non-standard extensions to HCI test commands. Once enabled,
+             HCI_LE_Transmitter_Test accepts extra parameters in addition to
+             those defined in Core specification
+               interval (2 octets)   interval between packets (usecs), overrides
+                                     standard interval
+               pkt_count (2 octets)  number of packets to transmit, controller
+                                     will automatically stop sending packets
+                                     after given number of packets was sent
+             Setting either of these parameters to 0 will configure for default
+             behavior, as per Core specification.
+             If specified interval is shorter then allowed by specification it
+             will be ignored.
+             Extended parameters shall immediately follow standard parameters.
+             Controller can accept both standard and extended version of command
+             depending on specified HCI command length.
+        value: 0
 
     BLE_LL_VND_EVENT_ON_ASSERT:
         description: >

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -292,10 +292,10 @@ syscfg.defs:
             be used.
         value: "(uint8_t[6]){0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
 
-    BLE_LL_DIRECT_TEST_MODE:
+    BLE_LL_DTM:
         description: >
              Enables HCI Test commands needed for Bluetooth SIG certification
-        value: 0
+        value: MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
 
     BLE_LL_VND_EVENT_ON_ASSERT:
         description: >
@@ -321,6 +321,11 @@ syscfg.defs:
             state when HCI event is being sent and back to low state when event
             was sent from controller.
         value: -1
+
+# deprecated settings (to be defunct/removed eventually)
+    BLE_LL_DIRECT_TEST_MODE:
+        description: use BLE_LL_DTM instead
+        value: 0
 
 # defunct settings (to be removed eventually)
     BLE_DEVICE:

--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -2061,7 +2061,7 @@ ble_phy_resolv_list_disable(void)
 }
 #endif
 
-#if MYNEWT_VAL(BLE_LL_DIRECT_TEST_MODE)
+#if MYNEWT_VAL(BLE_LL_DTM)
 void ble_phy_enable_dtm(void)
 {
     /* When DTM is enabled we need to disable whitening as per

--- a/porting/npl/riot/include/syscfg/syscfg.h
+++ b/porting/npl/riot/include/syscfg/syscfg.h
@@ -517,8 +517,8 @@
 #define MYNEWT_VAL_BLE_LL_DBG_HCI_EV_PIN (-1)
 #endif
 
-#ifndef MYNEWT_VAL_BLE_LL_DIRECT_TEST_MODE
-#define MYNEWT_VAL_BLE_LL_DIRECT_TEST_MODE (0)
+#ifndef MYNEWT_VAL_BLE_LL_DTM
+#define MYNEWT_VAL_BLE_LL_DTM (0)
 #endif
 
 /* Overridden by nimble/controller (defined by nimble/controller) */


### PR DESCRIPTION
this adds custom extensions to DTM which allows to:
- configure interval between test packets in TX
- configure number of packets to TX

to make things as simple as possible, there are new parameters added to standard HCI command which, if extensions are enabled, can be handled by controller. At the same time controller will accept standard command as usual. Extensions are disabled by default to be compliant with spec (I think we are still compliant even with extensions enabled, but better not accept anything outside spec by default).