### PR TITLE
nimble/l2cap: Fix extracting proc from the list

### DIFF
--- a/nimble/host/src/ble_l2cap_sig.c
+++ b/nimble/host/src/ble_l2cap_sig.c
@@ -286,6 +286,7 @@ ble_l2cap_sig_proc_extract(uint16_t conn_handle, uint8_t op,
             }
             break;
         }
+        prev = proc;
     }
 
     ble_hs_unlock();


### PR DESCRIPTION
When we were creating more than one channel at the time (we are doing it
in the auto pts test enviroment), we will end up with removing from the
list not that proc which we want as prev is always set to NULL wich
means, we always remove HEAD of the list