### PR TITLE
NimBLE/host: Fix return code in `ble_hs_tx_data`

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -707,8 +707,7 @@ ble_hs_tx_data(struct os_mbuf *om)
     ble_monitor_send_om(BLE_MONITOR_OPCODE_ACL_TX_PKT, om);
 #endif
 
-    ble_hci_trans_hs_acl_tx(om);
-    return 0;
+    return ble_hci_trans_hs_acl_tx(om);
 }
 
 void


### PR DESCRIPTION
Minor fix: Currently `ble_hs_tx_data` returns 0 irrespective of error code returned by `ble_hci_trans_hs_acl_tx`, this PR fixes it.