### PR TITLE
nimble/ll: Don't use bigger LL task stack when ext adv is enabled

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -228,12 +228,7 @@ static void ble_ll_event_dbuf_overflow(struct ble_npl_event *ev);
 #if MYNEWT
 
 /* The BLE LL task data structure */
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-/* TODO: This is for testing. Check it we really need it */
-#define BLE_LL_STACK_SIZE   (128)
-#else
 #define BLE_LL_STACK_SIZE   (90)
-#endif
 
 struct os_task g_ble_ll_task;
 


### PR DESCRIPTION
There is no need to use bigger task for extended advertising.
Current usage:
 - 6 active adv instances (including 1680 chains): 56 words
 - ext scan with both PHYs enabled: 78 words