### PR TITLE
nimble/gatt: fix custom notify/indicate to work with proper connection handle

### DIFF
--- a/nimble/host/src/ble_att_priv.h
+++ b/nimble/host/src/ble_att_priv.h
@@ -106,6 +106,8 @@ STATS_SECT_START(ble_att_stats)
 STATS_SECT_END
 extern STATS_SECT_DECL(ble_att_stats) ble_att_stats;
 
+#define BLE_ATT_SVR_CHECK_PERMS_MASK     0xF000
+
 struct ble_att_prep_entry {
     SLIST_ENTRY(ble_att_prep_entry) bape_next;
     uint16_t bape_handle;

--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -386,11 +386,19 @@ ble_att_svr_read(uint16_t conn_handle,
 
     att_err = 0;    /* Silence gcc warning. */
 
-    if (conn_handle != BLE_HS_CONN_HANDLE_NONE) {
+    /* if conn_handle is BLE_HS_CONN_HANDLE_NONE or has
+     * BLE_ATT_SVR_CHECK_PERMS_MASK set, then no permission check is done */
+    if (!(conn_handle & BLE_ATT_SVR_CHECK_PERMS_MASK)) {
         rc = ble_att_svr_check_perms(conn_handle, 1, entry, &att_err);
         if (rc != 0) {
             goto err;
         }
+    }
+
+    /* if conn_handle has BLE_ATT_SVR_CHECK_PERMS_MASK byte set,
+     * then remove it and send right connection handle only */
+    if (conn_handle != BLE_HS_CONN_HANDLE_NONE) {
+        conn_handle &= ~BLE_ATT_SVR_CHECK_PERMS_MASK;
     }
 
     BLE_HS_DBG_ASSERT(entry->ha_cb != NULL);

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -4166,8 +4166,8 @@ ble_gattc_notify_custom(uint16_t conn_handle, uint16_t chr_val_handle,
             rc = BLE_HS_ENOMEM;
             goto done;
         }
-        rc = ble_att_svr_read_handle(BLE_HS_CONN_HANDLE_NONE,
-                                     chr_val_handle, 0, txom, NULL);
+        rc = ble_att_svr_read_handle(conn_handle |
+                BLE_ATT_SVR_CHECK_PERMS_MASK, chr_val_handle, 0, txom, NULL);
         if (rc != 0) {
             /* Fatal error; application disallowed attribute read. */
             rc = BLE_HS_EAPP;
@@ -4323,8 +4323,8 @@ ble_gattc_indicate_custom(uint16_t conn_handle, uint16_t chr_val_handle,
             goto done;
         }
 
-        rc = ble_att_svr_read_handle(BLE_HS_CONN_HANDLE_NONE, chr_val_handle,
-                                     0, txom, NULL);
+        rc = ble_att_svr_read_handle(conn_handle |
+                BLE_ATT_SVR_CHECK_PERMS_MASK, chr_val_handle, 0, txom, NULL);
         if (rc != 0) {
             /* Fatal error; application disallowed attribute read. */
             BLE_HS_DBG_ASSERT(0);

--- a/nimble/host/test/src/ble_gatts_notify_test.c
+++ b/nimble/host/test/src/ble_gatts_notify_test.c
@@ -387,7 +387,6 @@ ble_gatts_notify_test_misc_access(uint16_t conn_handle,
     int rc;
 
     TEST_ASSERT_FATAL(ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR);
-    TEST_ASSERT(conn_handle == 0xffff);
 
     if (attr_handle == ble_gatts_notify_test_chr_1_def_handle + 1) {
         TEST_ASSERT(ctxt->chr ==


### PR DESCRIPTION
suppose using service that has multiple clients (i.e. ans), and each client has different instance for service characteristics.
when server notifies this characteristic using ble_gattc_notify(), then server can not read the proper instance using connection handle in the service access callback, because conn_handle is overwritten in ble_gattc_notify_custom() API with BLE_HS_CONN_HANDLE_NONE