### PR TITLE
nimble/mesh: Fix provisioning rx_buf initialization

### DIFF
--- a/nimble/host/mesh/src/prov.c
+++ b/nimble/host/mesh/src/prov.c
@@ -210,6 +210,9 @@ static int reset_state(void)
 #if (MYNEWT_VAL(BLE_MESH_PB_GATT))
 	link.rx.buf = bt_mesh_proxy_get_buf();
 #else
+	if (!rx_buf) {
+	    rx_buf = NET_BUF_SIMPLE(65);
+	}
 	net_buf_simple_init(rx_buf, 0);
 	link.rx.buf = rx_buf;
 #endif /* PB_GATT */


### PR DESCRIPTION
This patch fixes regresion after
 5f56107d nimble/mesh: Sync provisioning code with Zephyr

When PB GATT is not used then rx_buf would be not initialized