### PR TITLE
nimble/ll: Add support for disabling periodic advertising reports

### DIFF
--- a/nimble/controller/include/controller/ble_ll_hci.h
+++ b/nimble/controller/include/controller/ble_ll_hci.h
@@ -27,7 +27,7 @@ extern "C" {
 #include "nimble/hci_common.h"
 
 /* For supported commands */
-#define BLE_LL_SUPP_CMD_LEN (40)
+#define BLE_LL_SUPP_CMD_LEN (42)
 extern const uint8_t g_ble_ll_supp_cmds[BLE_LL_SUPP_CMD_LEN];
 
 /* The largest event the controller will send. */

--- a/nimble/controller/include/controller/ble_ll_sync.h
+++ b/nimble/controller/include/controller/ble_ll_sync.h
@@ -36,6 +36,7 @@ int ble_ll_sync_list_add(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_sync_list_remove(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_sync_list_clear(void);
 int ble_ll_sync_list_size(uint8_t *rspbuf, uint8_t *rsplen);
+int ble_ll_sync_receive_enable(const uint8_t *cmdbuf, uint8_t len);
 
 void ble_ll_sync_info_event(const uint8_t *addr, uint8_t addr_type,
                             uint8_t sid, struct ble_mbuf_hdr *rxhdr,

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -708,6 +708,9 @@ ble_ll_is_valid_adv_mode(uint8_t ocf)
     case BLE_HCI_OCF_LE_REM_DEV_FROM_PERIODIC_ADV_LIST:
     case BLE_HCI_OCF_LE_CLEAR_PERIODIC_ADV_LIST:
     case BLE_HCI_OCF_LE_RD_PERIODIC_ADV_LIST_SIZE:
+#if MYNEWT_VAL(BLE_VERSION) >= 51
+    case BLE_HCI_OCF_LE_PERIODIC_ADV_RECEIVE_ENABLE:
+#endif
         if (hci_adv_mode == ADV_MODE_LEGACY) {
             return false;
         }
@@ -1101,6 +1104,11 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
             rc = ble_ll_sync_list_size(rspbuf, rsplen);
         }
         break;
+#if MYNEWT_VAL(BLE_VERSION) >= 51
+    case BLE_HCI_OCF_LE_PERIODIC_ADV_RECEIVE_ENABLE:
+        rc = ble_ll_sync_receive_enable(cmdbuf, len);
+        break;
+#endif
 #endif
     case BLE_HCI_OCF_LE_RD_TRANSMIT_POWER:
         rc = ble_ll_read_tx_power(rspbuf, rsplen);

--- a/nimble/controller/src/ble_ll_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_supp_cmd.c
@@ -375,6 +375,17 @@
     BLE_SUPP_CMD_LE_SET_PRIVACY_MODE        \
 )
 
+/* Octet 40 */
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV) && MYNEWT_VAL(BLE_VERSION) >= 51
+#define BLE_SUPP_CMD_LE_PADV_RECV_ENABLE (1 << 5)
+#else
+#define BLE_SUPP_CMD_LE_PADV_RECV_ENABLE (0 << 5)
+#endif
+#define BLE_LL_SUPP_CMD_OCTET_40            \
+(                                           \
+    BLE_SUPP_CMD_LE_PADV_RECV_ENABLE        \
+)
+
 /* Defines the array of supported commands */
 const uint8_t g_ble_ll_supp_cmds[BLE_LL_SUPP_CMD_LEN] =
 {
@@ -418,4 +429,6 @@ const uint8_t g_ble_ll_supp_cmds[BLE_LL_SUPP_CMD_LEN] =
     BLE_LL_SUPP_CMD_OCTET_37,
     BLE_LL_SUPP_CMD_OCTET_38,
     BLE_LL_SUPP_CMD_OCTET_39,
+    BLE_LL_SUPP_CMD_OCTET_40,           /* Octet 40 */
+    0,
 };

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -699,6 +699,7 @@ struct ble_hci_le_ext_create_conn_cp {
 } __attribute__((packed));
 
 #define BLE_HCI_LE_PERIODIC_ADV_CREATE_SYNC_OPT_FILTER      0x01
+#define BLE_HCI_LE_PERIODIC_ADV_CREATE_SYNC_OPT_DISABLED    0x02
 
 #define BLE_HCI_OCF_LE_PERIODIC_ADV_CREATE_SYNC          (0x0044)
 struct ble_hci_le_periodic_adv_create_sync_cp {
@@ -774,7 +775,13 @@ struct ble_hci_le_set_privacy_mode_cp {
 #define BLE_HCI_OCF_LE_SET_CONN_CTE_REQ_ENABLE           (0x0056)
 #define BLE_HCI_OCF_LE_SET_CONN_CTE_RESP_ENABLE          (0x0057)
 #define BLE_HCI_OCF_LE_RD_ANTENNA_INFO                   (0x0058)
+
 #define BLE_HCI_OCF_LE_PERIODIC_ADV_RECEIVE_ENABLE       (0x0059)
+struct ble_hci_le_periodic_adv_receive_enable_cp {
+    uint16_t sync_handle;
+    uint8_t enable;
+} __attribute__((packed));
+
 #define BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER        (0x005A)
 #define BLE_HCI_OCF_LE_PERIODIC_ADV_SET_INFO_TRANSFER    (0x005B)
 #define BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER_PARAMS (0x005C)


### PR DESCRIPTION
This is Core 5.1 feature and allows to pass LL/DDI/SCN-BV-38-C
qualification test.