### PR TITLE
nimble/ll: Fix unaligned access in addr resolver

### DIFF
--- a/nimble/controller/include/controller/ble_ll_resolv.h
+++ b/nimble/controller/include/controller/ble_ll_resolv.h
@@ -35,6 +35,7 @@ struct ble_ll_resolv_entry
     uint8_t rl_addr_type;
     uint8_t rl_reserved;
     uint8_t rl_priv_mode;
+    uint8_t _pad;
     uint8_t rl_local_irk[16];
     uint8_t rl_peer_irk[16];
     uint8_t rl_identity_addr[BLE_DEV_ADDR_LEN];

--- a/nimble/controller/src/ble_ll_resolv.c
+++ b/nimble/controller/src/ble_ll_resolv.c
@@ -43,6 +43,7 @@ struct ble_ll_resolv_data
 };
 struct ble_ll_resolv_data g_ble_ll_resolv_data;
 
+__attribute__((aligned(4)))
 struct ble_ll_resolv_entry g_ble_ll_resolv_list[MYNEWT_VAL(BLE_LL_RESOLV_LIST_SIZE)];
 
 static int


### PR DESCRIPTION
ble_ll_resolv_rpa() casts IRK parameter to uint32_t* for faster access,
but this parameter is a pointer to member of struct ble_ll_resolv_entry
which is not word aligned thus it will hardfault on cm0.

This patch forces proper aligmnent of IRKs.