### PR TITLE
NimBLE host: Avoid calling stop before initializing `ble_hs_flow_timer` in `ble_hs_flow_startup`

### DIFF
--- a/nimble/host/src/ble_hs_flow.c
+++ b/nimble/host/src/ble_hs_flow.c
@@ -231,7 +231,10 @@ ble_hs_flow_startup(void)
 
     /* Assume failure. */
     ble_hci_trans_set_acl_free_cb(NULL, NULL);
+
+#if MYNEWT_VAL(SELFTEST)
     ble_npl_callout_stop(&ble_hs_flow_timer);
+#endif
 
     enable_cmd.enable = BLE_HCI_CTLR_TO_HOST_FC_ACL;
 


### PR DESCRIPTION
In `ble_hs_flow_startup`, stop `ble_hs_flow_timer` is called before creating it.
This results in accessing invalid/null `TimerHandle`. IMHO ideal solution could have been checking for invalid `co->handle` in `ble_npl_callout_stop` (NPL `nimble_npl_os.h`). But as discussed in [PR!279](https://github.com/apache/mynewt-nimble/pull/279) and in [PR!256](https://github.com/apache/mynewt-nimble/pull/256) I have followed similar solution here as well. 