### PR TITLE
nimble/ll: Fix scan disable with aux scan scheduled

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -1238,6 +1238,7 @@ ble_ll_scan_aux_data_unref(struct ble_ll_aux_data *aux_data)
 static void
 ble_ll_scan_sched_remove(struct ble_ll_sched_item *sch)
 {
+    ble_ll_scan_end_adv_evt(sch->cb_arg);
     ble_ll_scan_aux_data_unref(sch->cb_arg);
     sch->cb_arg = NULL;
 }


### PR DESCRIPTION
If aux scan is scheduled while disabling scan, we need to make sure ext
adv event is properly finished so we can properly pass sanity check when
removing last ref from aux data (ble_ll_scan.c:1232).