### PR TITLE
NimBLE/host: `ble_gap_unpair` should continue un-pairing after connection termination

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -5185,7 +5185,6 @@ int
 ble_gap_unpair(const ble_addr_t *peer_addr)
 {
     struct ble_hs_conn *conn;
-    int rc;
 
     if (ble_addr_cmp(peer_addr, BLE_ADDR_ANY) == 0) {
         return BLE_HS_EINVAL;
@@ -5195,20 +5194,13 @@ ble_gap_unpair(const ble_addr_t *peer_addr)
 
     conn = ble_hs_conn_find_by_addr(peer_addr);
     if (conn != NULL) {
-        rc = ble_gap_terminate_with_conn(conn, BLE_ERR_REM_USER_CONN_TERM);
-        if ((rc != BLE_HS_EALREADY) && (rc != BLE_HS_ENOTCONN)) {
-            ble_hs_unlock();
-            return rc;
-        }
+        ble_gap_terminate_with_conn(conn, BLE_ERR_REM_USER_CONN_TERM);
     }
 
     ble_hs_unlock();
 
-    rc = ble_hs_pvcy_remove_entry(peer_addr->type,
-                                  peer_addr->val);
-    if (rc != 0) {
-        return rc;
-    }
+    ble_hs_pvcy_remove_entry(peer_addr->type,
+                             peer_addr->val);
 
     return ble_store_util_delete_peer(peer_addr);
 }

--- a/nimble/host/src/ble_hs_pvcy.c
+++ b/nimble/host/src/ble_hs_pvcy.c
@@ -65,7 +65,7 @@ ble_hs_pvcy_remove_entry(uint8_t addr_type, const uint8_t *addr)
     struct ble_hci_le_rmv_resolve_list_cp cmd;
 
     if (addr_type > BLE_ADDR_RANDOM) {
-        return BLE_ERR_INV_HCI_CMD_PARMS;
+        addr_type = addr_type % 2;
     }
 
     cmd.peer_addr_type = addr_type;


### PR DESCRIPTION
1. Modifies `ble_hs_pvcy.c` to translate the `peer_addr_type` to valid HCI parameters (0x00, 0x01). Modify `ble_hs_pvcy_remove_entry` to not treat return code `BLE_ERR_UNK_CONN_ID` as an error. The reason for this change is in `ble_gap_unpair`, `ble_hs_pvcy_remove_entry` is called now as per the spec Vol 2, Part E, section 7.8.39 

> When a Controller cannot remove a device from the resolving list because it is
not found, it shall return the error code Unknown Connection Identifier (0x02).

In `ble_gap_unpair` this is treated as an error and un-pairing is discontinued.     

2. In `ble_gap_unpair`, if peer is connected we should not stop with just terminating
  connection, instead we should continue the un-pairing process after disconnection.