### PR TITLE
nimble/ll: Fix extended scanner data fragmentation issues

### DIFF
--- a/nimble/controller/include/controller/ble_ll_scan.h
+++ b/nimble/controller/include/controller/ble_ll_scan.h
@@ -91,10 +91,6 @@ struct ble_ll_scan_params
 #define BLE_LL_AUX_HAS_DIR_ADDRA                0x02
 #define BLE_LL_AUX_HAS_ADI                      0x04
 
-#define BLE_LL_AUX_SET_FLAG(aux_data, flag) ((aux_data)->flags |= (flag))
-#define BLE_LL_AUX_CLEAR_FLAG(aux_data, flag) ((aux_data)->flags &= ~(flag))
-#define BLE_LL_AUX_CHECK_FLAG(aux_data, flag) ((aux_data)->flags & (flag))
-
 #define BLE_LL_AUX_FLAG_AUX_RECEIVED            0x01
 #define BLE_LL_AUX_FLAG_HCI_SENT_ANY            0x02
 #define BLE_LL_AUX_FLAG_HCI_SENT_COMPLETED      0x04

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -1705,10 +1705,14 @@ ble_ll_ext_adv_phy_mode_to_local_phy(uint8_t adv_phy_mode)
     switch (adv_phy_mode) {
     case 0x00:
         return BLE_PHY_1M;
-    case 0x01:
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY)
+     case 0x01:
         return BLE_PHY_2M;
+#endif
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
     case 0x02:
         return BLE_PHY_CODED;
+#endif
     }
 
     return 0;

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -497,9 +497,7 @@ ble_ll_scan_get_adi(struct ble_ll_aux_data *aux_data, uint16_t *adi)
 
     return 0;
 }
-#endif
 
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 void
 ble_ll_scan_end_adv_evt(struct ble_ll_aux_data *aux_data)
 {


### PR DESCRIPTION
This fixes major issue with aux_data->flags which are updated from both ISR and LL at the same time so LL may use incorrect flags state to process data which leads to data stream which cannot be reassembled properly.

...and few small fixes for other things.