### PR TITLE
nimble/ll: Update scan backoff if halted while pending scan response

### DIFF
--- a/nimble/controller/include/controller/ble_ll_scan.h
+++ b/nimble/controller/include/controller/ble_ll_scan.h
@@ -263,8 +263,8 @@ void ble_ll_scan_aux_data_unref(struct ble_ll_aux_data *aux_scan);
 void ble_ll_scan_end_adv_evt(struct ble_ll_aux_data *aux_data);
 #endif
 
-/* Called to clean up current aux data */
-void ble_ll_scan_clean_cur_aux_data(void);
+/* Called to halt currently running scan */
+void ble_ll_scan_halt(void);
 
 #ifdef __cplusplus
 }

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -512,11 +512,8 @@ ble_ll_scan_end_adv_evt(struct ble_ll_aux_data *aux_data)
     }
 }
 #endif
-/**
- * Do scan machine clean up on PHY disabled
- *
- */
-void
+
+static void
 ble_ll_scan_clean_cur_aux_data(void)
 {
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
@@ -529,6 +526,20 @@ ble_ll_scan_clean_cur_aux_data(void)
         scansm->cur_aux_data = NULL;
     }
 #endif
+}
+
+void
+ble_ll_scan_halt(void)
+{
+    struct ble_ll_scan_sm *scansm = &g_ble_ll_scan_sm;
+
+    ble_ll_scan_clean_cur_aux_data();
+
+    /* Update backoff if we failed to receive scan response */
+    if (scansm->scan_rsp_pending) {
+        scansm->scan_rsp_pending = 0;
+        ble_ll_scan_req_backoff(scansm, 0);
+    }
 }
 
 /**

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -1482,10 +1482,10 @@ ble_ll_sched_execute_item(struct ble_ll_sched_item *sch)
 
     if (lls == BLE_LL_STATE_SCANNING) {
         ble_ll_state_set(BLE_LL_STATE_STANDBY);
-        ble_ll_scan_clean_cur_aux_data();
+        ble_ll_scan_halt();
     } else if (lls == BLE_LL_STATE_INITIATING) {
         ble_ll_state_set(BLE_LL_STATE_STANDBY);
-        ble_ll_scan_clean_cur_aux_data();
+        ble_ll_scan_halt();
         /* PHY is disabled - make sure we do not wait for AUX_CONNECT_RSP */
         ble_ll_conn_reset_pending_aux_conn_rsp();
     } else if (lls == BLE_LL_STATE_ADV) {


### PR DESCRIPTION
Make sure we cleanup scan response pending state.