### PR TITLE
Support for BT 5.1 periodic sync transfer

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -246,6 +246,17 @@ extern STATS_SECT_DECL(ble_ll_stats) ble_ll_stats;
 #define BLE_LL_FEAT_CSA2             (0x00004000)
 #define BLE_LL_FEAT_LE_POWER_CLASS_1 (0x00008000)
 #define BLE_LL_FEAT_MIN_USED_CHAN    (0x00010000)
+#define BLE_LL_FEAT_CTE_REQ          (0x00020000)
+#define BLE_LL_FEAT_CTE_RSP          (0x00040000)
+#define BLE_LL_FEAT_CTE_TX           (0x00080000)
+#define BLE_LL_FEAT_CTE_RX           (0x00100000)
+#define BLE_LL_FEAT_CTE_AOD          (0x00200000)
+#define BLE_LL_FEAT_CTE_AOA          (0x00400000)
+#define BLE_LL_FEAT_CTE_RECV         (0x00800000)
+#define BLE_LL_FEAT_SYNC_SEND        (0x01000000)
+#define BLE_LL_FEAT_SYNC_RECV        (0x02000000)
+#define BLE_LL_FEAT_SCA_UPDATE       (0x04000000)
+#define BLE_LL_FEAT_REM_PKEY         (0x08000000)
 
 /* This is initial mask, so if feature exchange will not happen,
  * but host will want to use this procedure, we will try. If not

--- a/nimble/controller/include/controller/ble_ll_adv.h
+++ b/nimble/controller/include/controller/ble_ll_adv.h
@@ -196,6 +196,9 @@ int ble_ll_adv_periodic_set_param(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_adv_periodic_set_data(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_adv_periodic_enable(const uint8_t *cmdbuf, uint8_t len);
 
+int ble_ll_adv_periodic_set_info_transfer(const uint8_t *cmdbuf, uint8_t len,
+                                          uint8_t *rspbuf, uint8_t *rsplen);
+
 /* Called to notify adv code about RPA rotation */
 void ble_ll_adv_rpa_timeout(void);
 

--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -372,6 +372,11 @@ struct ble_ll_conn_sm
     struct hci_ext_create_conn initial_params;
 #endif
 
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+    uint8_t  sync_transfer_mode;
+    uint16_t sync_transfer_skip;
+    uint32_t sync_transfer_sync_timeout;
+#endif
 };
 
 /* Flags */
@@ -404,6 +409,10 @@ struct ble_ll_conn_sm *ble_ll_conn_find_active_conn(uint16_t handle);
 
 /* required for unit testing */
 uint8_t ble_ll_conn_calc_dci(struct ble_ll_conn_sm *conn, uint16_t latency);
+
+/* used to get anchor point for connection event specified */
+void ble_ll_conn_get_anchor(struct ble_ll_conn_sm *connsm, uint16_t conn_event,
+                            uint32_t *anchor, uint8_t *anchor_usecs);
 
 #ifdef __cplusplus
 }

--- a/nimble/controller/include/controller/ble_ll_ctrl.h
+++ b/nimble/controller/include/controller/ble_ll_ctrl.h
@@ -80,14 +80,23 @@ extern "C" {
 #define BLE_LL_CTRL_PHY_RSP             (23)
 #define BLE_LL_CTRL_PHY_UPDATE_IND      (24)
 #define BLE_LL_CTRL_MIN_USED_CHAN_IND   (25)
+#define BLE_LL_CTRL_CTE_REQ             (26)
+#define BLE_LL_CTRL_CTE_RSP             (27)
+#define BLE_LL_CTRL_PERIODIC_SYNC_IND   (28)
+#define BLE_LL_CTRL_CLOCK_ACCURACY_REQ  (29)
+#define BLE_LL_CTRL_CLOCK_ACCURACY_RSP  (30)
 
 /* Maximum opcode value */
-#define BLE_LL_CTRL_OPCODES             (BLE_LL_CTRL_MIN_USED_CHAN_IND + 1)
+#define BLE_LL_CTRL_OPCODES             (BLE_LL_CTRL_CLOCK_ACCURACY_RSP + 1)
 
 extern const uint8_t g_ble_ll_ctrl_pkt_lengths[BLE_LL_CTRL_OPCODES];
 
 /* Maximum LL control PDU size */
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+#define BLE_LL_CTRL_MAX_PDU_LEN         (35)
+#else
 #define BLE_LL_CTRL_MAX_PDU_LEN         (27)
+#endif
 
 /* LL control connection update request */
 struct ble_ll_conn_upd_req
@@ -239,6 +248,19 @@ struct ble_ll_len_req
 /* Min used channels */
 #define BLE_LL_CTRL_MIN_USED_CHAN_LEN   (2)
 
+/* CTE REQ */
+#define BLE_LL_CTRL_CTE_REQ_LEN         (1)
+
+/* CTE RSP (contains no data) */
+#define BLE_LL_CTRL_CTE_RSP_LEN     (0)
+
+/* Periodic Sync Transfer IND */
+#define BLE_LL_CTRL_PERIODIC_SYNC_IND_LEN   (34)
+
+/* Clock accuracy request/response */
+#define BLE_LL_CTRL_CLOCK_ACCURACY_REQ_LEN  (1)
+#define BLE_LL_CTRL_CLOCK_ACCURACY_RSP_LEN  (1)
+
 /* API */
 struct ble_ll_conn_sm;
 void ble_ll_ctrl_proc_start(struct ble_ll_conn_sm *connsm, int ctrl_proc);
@@ -280,6 +302,8 @@ void ble_ll_calc_session_key(struct ble_ll_conn_sm *connsm);
 void ble_ll_ctrl_phy_update_proc_complete(struct ble_ll_conn_sm *connsm);
 void ble_ll_ctrl_initiate_dle(struct ble_ll_conn_sm *connsm);
 void ble_ll_hci_ev_send_vendor_err(const char *file, uint32_t line);
+
+uint8_t ble_ll_ctrl_phy_from_phy_mask(uint8_t phy_mask);
 
 #ifdef __cplusplus
 }

--- a/nimble/controller/include/controller/ble_ll_resolv.h
+++ b/nimble/controller/include/controller/ble_ll_resolv.h
@@ -98,7 +98,10 @@ int ble_ll_resolve_set_priv_mode(const uint8_t *cmdbuf, uint8_t len);
 uint32_t ble_ll_resolv_get_rpa_tmo(void);
 
 /* Resolve a resolvable private address */
-int ble_ll_resolv_rpa(uint8_t *rpa, uint8_t *irk);
+int ble_ll_resolv_rpa(const uint8_t *rpa, const uint8_t *irk);
+
+/* Try to resolve peer RPA and return index on RL if matched */
+int ble_ll_resolv_peer_rpa_any(const uint8_t *rpa);
 
 /* Initialize resolv*/
 void ble_ll_resolv_init(void);

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -172,7 +172,7 @@ int ble_ll_sched_sync_reschedule(struct ble_ll_sched_item *sch,
                                  uint8_t anchor_point_usecs,
                                  uint32_t window_widening, int8_t phy_mode);
 int ble_ll_sched_sync(struct ble_ll_sched_item *sch,
-                      struct ble_mbuf_hdr *ble_hdr, uint32_t offset,
+                      uint32_t beg_cputime, uint32_t rem_usecs, uint32_t offset,
                       int8_t phy_mode);
 
 /* Reschedule an advertising event */

--- a/nimble/controller/include/controller/ble_ll_sync.h
+++ b/nimble/controller/include/controller/ble_ll_sync.h
@@ -56,6 +56,7 @@ uint32_t ble_ll_sync_get_event_end_time(void);
 bool ble_ll_sync_enabled(void);
 
 void ble_ll_sync_reset(void);
+void ble_ll_sync_init(void);
 
 #ifdef __cplusplus
 }

--- a/nimble/controller/include/controller/ble_ll_sync.h
+++ b/nimble/controller/include/controller/ble_ll_sync.h
@@ -24,6 +24,7 @@
 
 #include "nimble/ble.h"
 #include "controller/ble_ll_hci.h"
+#include "controller/ble_ll_conn.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,8 +41,14 @@ int ble_ll_sync_list_clear(void);
 int ble_ll_sync_list_size(uint8_t *rspbuf, uint8_t *rsplen);
 int ble_ll_sync_receive_enable(const uint8_t *cmdbuf, uint8_t len);
 
+void ble_ll_sync_periodic_ind(struct ble_ll_conn_sm *connsm,
+                              const uint8_t *sync_ind, bool reports_disabled,
+                              uint16_t max_skip, uint32_t sync_timeout);
+void ble_ll_sync_transfer_disconnected(struct ble_ll_conn_sm *connsm);
+
 void ble_ll_sync_info_event(const uint8_t *addr, uint8_t addr_type,
-                            uint8_t sid, struct ble_mbuf_hdr *rxhdr,
+                            int rpa_index, uint8_t sid,
+                            struct ble_mbuf_hdr *rxhdr,
                             const uint8_t *syncinfo);
 
 int ble_ll_sync_rx_isr_start(uint8_t pdu_type, struct ble_mbuf_hdr *rxhdr);

--- a/nimble/controller/include/controller/ble_ll_sync.h
+++ b/nimble/controller/include/controller/ble_ll_sync.h
@@ -40,6 +40,8 @@ int ble_ll_sync_list_remove(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_sync_list_clear(void);
 int ble_ll_sync_list_size(uint8_t *rspbuf, uint8_t *rsplen);
 int ble_ll_sync_receive_enable(const uint8_t *cmdbuf, uint8_t len);
+int ble_ll_sync_transfer(const uint8_t *cmdbuf, uint8_t len,
+                         uint8_t *rspbuf, uint8_t *rsplen);
 
 void ble_ll_sync_periodic_ind(struct ble_ll_conn_sm *connsm,
                               const uint8_t *sync_ind, bool reports_disabled,

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1651,6 +1651,7 @@ ble_ll_init(void)
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV)
     features |= BLE_LL_FEAT_PERIODIC_ADV;
+    ble_ll_sync_init();
 #endif
 
     /* Initialize random number generation */

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1656,6 +1656,7 @@ ble_ll_init(void)
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
     features |= BLE_LL_FEAT_SYNC_RECV;
+    features |= BLE_LL_FEAT_SYNC_SEND;
 #endif
 
     /* Initialize random number generation */

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1654,6 +1654,10 @@ ble_ll_init(void)
     ble_ll_sync_init();
 #endif
 
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+    features |= BLE_LL_FEAT_SYNC_RECV;
+#endif
+
     /* Initialize random number generation */
     ble_ll_rand_init();
 

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -77,6 +77,16 @@ struct ble_ll_conn_global_params
 };
 extern struct ble_ll_conn_global_params g_ble_ll_conn_params;
 
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+struct ble_ll_conn_sync_transfer_params
+{
+    uint32_t sync_timeout_us;
+    uint16_t max_skip;
+    uint8_t  mode;
+};
+extern struct ble_ll_conn_sync_transfer_params g_ble_ll_conn_sync_transfer_params;
+#endif
+
 /* Some data structures used by other LL routines */
 SLIST_HEAD(ble_ll_conn_active_list, ble_ll_conn_sm);
 STAILQ_HEAD(ble_ll_conn_free_list, ble_ll_conn_sm);
@@ -203,6 +213,13 @@ int ble_ll_conn_chk_phy_upd_start(struct ble_ll_conn_sm *connsm);
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 int ble_ll_ext_conn_create(const uint8_t *cmdbuf, uint8_t cmdlen);
 #endif
+
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+int ble_ll_set_sync_transfer_params(const uint8_t *cmdbuf, uint8_t len,
+                                    uint8_t *rspbuf, uint8_t *rsplen);
+int ble_ll_set_default_sync_transfer_params(const uint8_t *cmdbuf, uint8_t len);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -711,6 +711,10 @@ ble_ll_is_valid_adv_mode(uint8_t ocf)
 #if MYNEWT_VAL(BLE_VERSION) >= 51
     case BLE_HCI_OCF_LE_PERIODIC_ADV_RECEIVE_ENABLE:
 #endif
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+    case BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER_PARAMS:
+    case BLE_HCI_OCF_LE_SET_DEFAULT_SYNC_TRANSFER_PARAMS:
+#endif
         if (hci_adv_mode == ADV_MODE_LEGACY) {
             return false;
         }
@@ -1122,6 +1126,14 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
     case BLE_HCI_OCF_LE_SET_PRIVACY_MODE:
         rc = ble_ll_resolve_set_priv_mode(cmdbuf, len);
+        break;
+#endif
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+    case BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER_PARAMS:
+        rc = ble_ll_set_sync_transfer_params(cmdbuf, len, rspbuf, rsplen);
+        break;
+    case BLE_HCI_OCF_LE_SET_DEFAULT_SYNC_TRANSFER_PARAMS:
+        rc = ble_ll_set_default_sync_transfer_params(cmdbuf, len);
         break;
 #endif
     default:

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -712,6 +712,8 @@ ble_ll_is_valid_adv_mode(uint8_t ocf)
     case BLE_HCI_OCF_LE_PERIODIC_ADV_RECEIVE_ENABLE:
 #endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+    case BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER:
+    case BLE_HCI_OCF_LE_PERIODIC_ADV_SET_INFO_TRANSFER:
     case BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER_PARAMS:
     case BLE_HCI_OCF_LE_SET_DEFAULT_SYNC_TRANSFER_PARAMS:
 #endif
@@ -1129,6 +1131,12 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
         break;
 #endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+    case BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER:
+        rc = ble_ll_sync_transfer(cmdbuf, len, rspbuf, rsplen);
+        break;
+    case BLE_HCI_OCF_LE_PERIODIC_ADV_SET_INFO_TRANSFER:
+        rc = ble_ll_adv_periodic_set_info_transfer(cmdbuf, len, rspbuf, rsplen);
+        break;
     case BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER_PARAMS:
         rc = ble_ll_set_sync_transfer_params(cmdbuf, len, rspbuf, rsplen);
         break;

--- a/nimble/controller/src/ble_ll_resolv.c
+++ b/nimble/controller/src/ble_ll_resolv.c
@@ -641,15 +641,15 @@ ble_ll_resolv_gen_rpa(uint8_t *addr, uint8_t addr_type, uint8_t *rpa, int local)
  * @return int
  */
 int
-ble_ll_resolv_rpa(uint8_t *rpa, uint8_t *irk)
+ble_ll_resolv_rpa(const uint8_t *rpa, const uint8_t *irk)
 {
     int rc;
-    uint32_t *irk32;
+    const uint32_t *irk32;
     uint32_t *key32;
     uint32_t *pt32;
     struct ble_encryption_block ecb;
 
-    irk32 = (uint32_t *)irk;
+    irk32 = (const uint32_t *)irk;
     key32 = (uint32_t *)&ecb.key[0];
 
     key32[0] = irk32[0];
@@ -676,6 +676,20 @@ ble_ll_resolv_rpa(uint8_t *rpa, uint8_t *irk)
     }
 
     return rc;
+}
+
+int
+ble_ll_resolv_peer_rpa_any(const uint8_t *rpa)
+{
+    int i;
+
+    for (i = 0; i < g_ble_ll_resolv_data.rl_cnt_hw; i++) {
+        if (ble_ll_resolv_rpa(rpa, g_ble_ll_resolv_list[i].rl_peer_irk)) {
+            return i;
+        }
+    }
+
+    return -1;
 }
 
 /**

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -2842,7 +2842,7 @@ done:
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV)
 static void
 check_periodic_sync(const struct os_mbuf *om, struct ble_mbuf_hdr *rxhdr,
-                          uint8_t *adva, uint8_t adva_type)
+                          uint8_t *adva, uint8_t adva_type, int rpa_index)
 {
     uint8_t pdu_len;
     uint8_t ext_hdr_len;
@@ -2889,7 +2889,8 @@ check_periodic_sync(const struct os_mbuf *om, struct ble_mbuf_hdr *rxhdr,
         }
 
         if (ext_hdr_flags & (1 << BLE_LL_EXT_ADV_SYNC_INFO_BIT)) {
-            ble_ll_sync_info_event(adva, adva_type, sid, rxhdr, ext_hdr + i);
+            ble_ll_sync_info_event(adva, adva_type, rpa_index, sid, rxhdr,
+                                   ext_hdr + i);
         }
     }
 }
@@ -3165,8 +3166,8 @@ ble_ll_scan_rx_pkt_in(uint8_t ptype, struct os_mbuf *om, struct ble_mbuf_hdr *hd
      * policy if PDU and adv type match and advertiser address is present
      */
     if ((ptype == BLE_ADV_PDU_TYPE_ADV_EXT_IND) &&
-            (ext_adv_mode == BLE_LL_EXT_ADV_MODE_NON_CONN) && ident_addr) {
-        check_periodic_sync(om, hdr, ident_addr, ident_addr_type);
+            (ext_adv_mode == BLE_LL_EXT_ADV_MODE_NON_CONN) && adv_addr) {
+        check_periodic_sync(om, hdr, adv_addr, txadd, index);
     }
 #endif
 

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -963,7 +963,8 @@ ble_ll_sched_sync_reschedule(struct ble_ll_sched_item *sch,
 }
 
 int
-ble_ll_sched_sync(struct ble_ll_sched_item *sch, struct ble_mbuf_hdr *ble_hdr,
+ble_ll_sched_sync(struct ble_ll_sched_item *sch,
+                  uint32_t beg_cputime, uint32_t rem_usecs,
                   uint32_t offset, int8_t phy_mode)
 {
     struct ble_ll_sched_item *entry;
@@ -979,8 +980,8 @@ ble_ll_sched_sync(struct ble_ll_sched_item *sch, struct ble_mbuf_hdr *ble_hdr,
     off_ticks = os_cputime_usecs_to_ticks(offset);
     off_rem_usecs = offset - os_cputime_ticks_to_usecs(off_ticks);
 
-    start_time = ble_hdr->beg_cputime + off_ticks;
-    start_time_rem_usecs = ble_hdr->rem_usecs + off_rem_usecs;
+    start_time = beg_cputime + off_ticks;
+    start_time_rem_usecs = rem_usecs + off_rem_usecs;
     if (start_time_rem_usecs >= 31) {
         start_time++;
         start_time_rem_usecs -= 31;

--- a/nimble/controller/src/ble_ll_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_supp_cmd.c
@@ -386,6 +386,20 @@
     BLE_SUPP_CMD_LE_PADV_RECV_ENABLE        \
 )
 
+/* Octet 41 */
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+#define BLE_SUPP_CMD_LE_PADV_SYNC_TRANSFER_PARAMS (1 << 0)
+#define BLE_SUPP_CMD_LE_PADV_DEFAULT_SYNC_TRANSFER_PARAMS (1 << 1)
+#else
+#define BLE_SUPP_CMD_LE_PADV_SYNC_TRANSFER_PARAMS (0 << 0)
+#define BLE_SUPP_CMD_LE_PADV_DEFAULT_SYNC_TRANSFER_PARAMS (0 << 1)
+#endif
+#define BLE_LL_SUPP_CMD_OCTET_41                        \
+(                                                       \
+    BLE_SUPP_CMD_LE_PADV_SYNC_TRANSFER_PARAMS |         \
+    BLE_SUPP_CMD_LE_PADV_DEFAULT_SYNC_TRANSFER_PARAMS   \
+)
+
 /* Defines the array of supported commands */
 const uint8_t g_ble_ll_supp_cmds[BLE_LL_SUPP_CMD_LEN] =
 {
@@ -430,5 +444,5 @@ const uint8_t g_ble_ll_supp_cmds[BLE_LL_SUPP_CMD_LEN] =
     BLE_LL_SUPP_CMD_OCTET_38,
     BLE_LL_SUPP_CMD_OCTET_39,
     BLE_LL_SUPP_CMD_OCTET_40,           /* Octet 40 */
-    0,
+    BLE_LL_SUPP_CMD_OCTET_41,
 };

--- a/nimble/controller/src/ble_ll_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_supp_cmd.c
@@ -381,9 +381,19 @@
 #else
 #define BLE_SUPP_CMD_LE_PADV_RECV_ENABLE (0 << 5)
 #endif
-#define BLE_LL_SUPP_CMD_OCTET_40            \
-(                                           \
-    BLE_SUPP_CMD_LE_PADV_RECV_ENABLE        \
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
+#define BLE_SUPP_CMD_LE_PADV_SYNC_TRANSFER (1 << 6)
+#define BLE_SUPP_CMD_LE_PADV_SET_INFO_TRANSFER (1 << 7)
+#else
+#define BLE_SUPP_CMD_LE_PADV_SYNC_TRANSFER (0 << 6)
+#define BLE_SUPP_CMD_LE_PADV_SET_INFO_TRANSFER (0 << 7)
+#endif
+
+#define BLE_LL_SUPP_CMD_OCTET_40             \
+(                                            \
+    BLE_SUPP_CMD_LE_PADV_RECV_ENABLE       | \
+    BLE_SUPP_CMD_LE_PADV_SYNC_TRANSFER     | \
+    BLE_SUPP_CMD_LE_PADV_SET_INFO_TRANSFER   \
 )
 
 /* Octet 41 */

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -999,6 +999,10 @@ ble_ll_sync_rx_pkt_in(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *hdr)
      */
     if (!sm->flags) {
         ble_ll_scan_chk_resume();
+
+#ifdef BLE_XCVR_RFCLK
+        ble_ll_sched_rfclk_chk_restart();
+#endif
         return;
     }
 
@@ -1044,6 +1048,10 @@ ble_ll_sync_rx_pkt_in(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *hdr)
         /* if chain was scheduled we don't end event yet */
         /* TODO should we check resume only if offset is high? */
         ble_ll_scan_chk_resume();
+
+#ifdef BLE_XCVR_RFCLK
+        ble_ll_sched_rfclk_chk_restart();
+#endif
         return;
     }
 

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -276,6 +276,11 @@ syscfg.defs:
             This option is used to configure number of supported periodic syncs.
         value: MYNEWT_VAL(BLE_MAX_PERIODIC_SYNCS)
 
+    BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_LIST_CNT:
+        description: >
+            Size of Periodic Advertiser sync list.
+        value: MYNEWT_VAL(BLE_MAX_PERIODIC_SYNCS)
+
     BLE_LL_EXT_ADV_AUX_PTR_CNT:
          description: >
             This option configure a max number of scheduled outstanding auxiliary

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -110,10 +110,10 @@ syscfg.defs:
         value: '251'
     BLE_LL_SUPP_MAX_RX_BYTES:
         description: 'The maximum supported received PDU size'
-        value: 'MYNEWT_VAL_BLE_LL_MAX_PKT_SIZE'
+        value: MYNEWT_VAL(BLE_LL_MAX_PKT_SIZE)
     BLE_LL_SUPP_MAX_TX_BYTES:
         description: 'The maximum supported transmit PDU size'
-        value: 'MYNEWT_VAL_BLE_LL_MAX_PKT_SIZE'
+        value: MYNEWT_VAL(BLE_LL_MAX_PKT_SIZE)
     BLE_LL_CONN_INIT_MAX_TX_BYTES:
         description: >
             Used to set the initial maximum transmit PDU size in a
@@ -280,6 +280,12 @@ syscfg.defs:
         description: >
             Size of Periodic Advertiser sync list.
         value: MYNEWT_VAL(BLE_MAX_PERIODIC_SYNCS)
+
+    BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER:
+        description: >
+            This option is use to enable/disable support for Periodic
+            Advertising Sync Transfer Feature.
+        value: MYNEWT_VAL(BLE_PERIODIC_ADV_SYNC_TRANSFER)
 
     BLE_LL_EXT_ADV_AUX_PTR_CNT:
          description: >

--- a/nimble/host/src/ble_gap_priv.h
+++ b/nimble/host/src/ble_gap_priv.h
@@ -86,6 +86,7 @@ void ble_gap_rx_adv_set_terminated(const struct ble_hci_ev_le_subev_adv_set_term
 void ble_gap_rx_peroidic_adv_sync_estab(const struct ble_hci_ev_le_subev_periodic_adv_sync_estab *ev);
 void ble_gap_rx_periodic_adv_rpt(const struct ble_hci_ev_le_subev_periodic_adv_rpt *ev);
 void ble_gap_rx_periodic_adv_sync_lost(const struct ble_hci_ev_le_subev_periodic_adv_sync_lost *ev);
+void ble_gap_rx_periodic_adv_sync_transfer(const struct ble_hci_ev_le_subev_periodic_adv_sync_transfer *ev);
 #endif
 void ble_gap_rx_scan_req_rcvd(const struct ble_hci_ev_le_subev_scan_req_rcvd *ev);
 #endif

--- a/nimble/host/src/ble_hs_conn_priv.h
+++ b/nimble/host/src/ble_hs_conn_priv.h
@@ -98,6 +98,10 @@ struct ble_hs_conn {
 
     ble_gap_event_fn *bhc_cb;
     void *bhc_cb_arg;
+
+#if MYNEWT_VAL(BLE_PERIODIC_ADV)
+    struct ble_hs_periodic_sync *psync;
+#endif
 };
 
 struct ble_hs_conn_addrs {

--- a/nimble/host/src/ble_hs_hci_evt.c
+++ b/nimble/host/src/ble_hs_hci_evt.c
@@ -57,6 +57,8 @@ static ble_hs_hci_evt_le_fn ble_hs_hci_evt_le_periodic_adv_rpt;
 static ble_hs_hci_evt_le_fn ble_hs_hci_evt_le_periodic_adv_sync_lost;
 static ble_hs_hci_evt_le_fn ble_hs_hci_evt_le_scan_req_rcvd;
 static ble_hs_hci_evt_le_fn ble_hs_hci_evt_le_enh_conn_complete;
+static ble_hs_hci_evt_le_fn ble_hs_hci_evt_le_periodic_adv_sync_transfer;
+
 /* Statistics */
 struct host_hci_stats
 {
@@ -103,6 +105,7 @@ static ble_hs_hci_evt_le_fn * const ble_hs_hci_evt_le_dispatch[] = {
     [BLE_HCI_LE_SUBEV_SCAN_TIMEOUT] = ble_hs_hci_evt_le_scan_timeout,
     [BLE_HCI_LE_SUBEV_ADV_SET_TERMINATED] = ble_hs_hci_evt_le_adv_set_terminated,
     [BLE_HCI_LE_SUBEV_SCAN_REQ_RCVD] = ble_hs_hci_evt_le_scan_req_rcvd,
+    [BLE_HCI_LE_SUBEV_PERIODIC_ADV_SYNC_TRANSFER] = ble_hs_hci_evt_le_periodic_adv_sync_transfer,
 };
 
 #define BLE_HS_HCI_EVT_LE_DISPATCH_SZ \
@@ -623,6 +626,22 @@ ble_hs_hci_evt_le_periodic_adv_sync_lost(uint8_t subevent, const void *data,
     return 0;
 }
 
+static int
+ble_hs_hci_evt_le_periodic_adv_sync_transfer(uint8_t subevent, const void *data,
+                                             unsigned int len)
+{
+#if MYNEWT_VAL(BLE_PERIODIC_ADV_SYNC_TRANSFER)
+    const struct ble_hci_ev_le_subev_periodic_adv_sync_transfer *ev = data;
+
+    if (len != sizeof(*ev)) {
+        return BLE_HS_EBADDATA;
+    }
+
+    ble_gap_rx_periodic_adv_sync_transfer(ev);
+
+#endif
+    return 0;
+}
 
 static int
 ble_hs_hci_evt_le_scan_timeout(uint8_t subevent, const void *data,

--- a/nimble/host/src/ble_hs_startup.c
+++ b/nimble/host/src/ble_hs_startup.c
@@ -228,6 +228,16 @@ ble_hs_startup_le_set_evmask_tx(void)
         mask |= 0x00000000000ff800;
     }
 
+#if MYNEWT_VAL(BLE_PERIODIC_ADV_SYNC_TRANSFER)
+    if (version >= BLE_HCI_VER_BCS_5_1) {
+        /**
+         * Enable the following LE events:
+         * 0x0000000000800000 LE Periodic Advertising Sync Transfer Received event
+         */
+        mask |= 0x0000000000800000;
+    }
+#endif
+
     cmd.event_mask = htole64(mask);
 
     rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -783,9 +783,45 @@ struct ble_hci_le_periodic_adv_receive_enable_cp {
 } __attribute__((packed));
 
 #define BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER        (0x005A)
+struct ble_hci_le_periodic_adv_sync_transfer_cp {
+    uint16_t conn_handle;
+    uint16_t service_data;
+    uint16_t sync_handle;
+} __attribute__((packed));
+struct ble_hci_le_periodic_adv_sync_transfer_rp {
+    uint16_t conn_handle;
+} __attribute__((packed));
+
 #define BLE_HCI_OCF_LE_PERIODIC_ADV_SET_INFO_TRANSFER    (0x005B)
+struct ble_hci_le_periodic_adv_set_info_transfer_cp {
+    uint16_t conn_handle;
+    uint16_t service_data;
+    uint8_t adv_handle;
+} __attribute__((packed));
+struct ble_hci_le_periodic_adv_set_info_transfer_rp {
+    uint16_t conn_handle;
+} __attribute__((packed));
+
 #define BLE_HCI_OCF_LE_PERIODIC_ADV_SYNC_TRANSFER_PARAMS (0x005C)
+struct ble_hci_le_periodic_adv_sync_transfer_params_cp {
+    uint16_t conn_handle;
+    uint8_t  mode;
+    uint16_t skip;
+    uint16_t sync_timeout;
+    uint8_t  sync_cte_type;
+} __attribute__((packed));
+struct ble_hci_le_periodic_adv_sync_transfer_params_rp {
+    uint16_t conn_handle;
+} __attribute__((packed));
+
 #define BLE_HCI_OCF_LE_SET_DEFAULT_SYNC_TRANSFER_PARAMS  (0x005D)
+struct ble_hci_le_set_default_periodic_sync_transfer_params_cp {
+    uint8_t  mode;
+    uint16_t skip;
+    uint16_t sync_timeout;
+    uint8_t  sync_cte_type;
+} __attribute__((packed));
+
 #define BLE_HCI_OCF_LE_GENERATE_DHKEY_V2                 (0x005E)
 #define BLE_HCI_OCF_LE_MODIFY_SCA                        (0x005F)
 
@@ -1386,7 +1422,21 @@ struct ble_hci_ev_le_subev_chan_sel_alg {
 #define BLE_HCI_LE_SUBEV_CONNLESS_IQ_RPT        (0x15)
 #define BLE_HCI_LE_SUBEV_CONN_IQ_RPT            (0x16)
 #define BLE_HCI_LE_SUBEV_CTE_REQ_FAILED         (0x17)
+
 #define BLE_HCI_LE_SUBEV_PERIODIC_ADV_SYNC_TRANSFER   (0x18)
+struct ble_hci_ev_le_subev_periodic_adv_sync_transfer {
+    uint8_t  subev_code;
+    uint8_t  status;
+    uint16_t conn_handle;
+    uint16_t service_data;
+    uint16_t sync_handle;
+    uint8_t  sid;
+    uint8_t  peer_addr_type;
+    uint8_t  peer_addr[6];
+    uint8_t  phy;
+    uint16_t interval;
+    uint8_t  aca;
+} __attribute__((packed));
 
 /* Data buffer overflow event */
 #define BLE_HCI_EVENT_ACL_BUF_OVERFLOW      (0x01)

--- a/nimble/syscfg.yml
+++ b/nimble/syscfg.yml
@@ -59,6 +59,11 @@ syscfg.defs:
         description: >
             This enables periodic advertising feature.
         value: 0
+    BLE_PERIODIC_ADV_SYNC_TRANSFER:
+        description: >
+            This enables Periodic Advertising Sync Transfer Feature.
+        value: 0
+
     BLE_EXT_ADV_MAX_SIZE:
         description: >
             This allows to configure maximum size of advertising data and
@@ -72,3 +77,7 @@ syscfg.defs:
             integer for easy comparison.
         range: 50, 51
         value: 50
+
+# Allow periodic sync transfer only if 5.1 or higher
+syscfg.restrictions:
+    - "'BLE_PERIODIC_ADV_SYNC_TRANSFER == 0' || 'BLE_VERSION >= 51'"


### PR DESCRIPTION
Feature is enabled by setting BLE_PERIODIC_ADV_SYNC_TRANSFER mynewt value and requires BLE_VERSION>=51

Following qualification tests cases were executed (with 1M, 2M and Coded PHYs enabled):
LL/CON/MAS/BV-84-C
LL/CON/MAS/BV-85-C
LL/CON/MAS/BV-86-C
LL/CON/MAS/BV-87-C
LL/CON/MAS/BV-88-C
LL/CON/MAS/BV-89-C
LL/CON/MAS/BV-90-C
LL/CON/MAS/BV-91-C
LL/CON/MAS/BV-92-C
LL/CON/MAS/BV-93-C
LL/CON/MAS/BV-94-C
LL/CON/MAS/BV-95-C
LL/CON/MAS/BV-96-C
LL/CON/MAS/BV-97-C
LL/CON/MAS/BV-98-C
LL/CON/MAS/BV-99-C
LL/CON/MAS/BV-100-C
LL/CON/MAS/BV-101-C
LL/CON/MAS/BV-102-C
LL/CON/MAS/BV-103-C
LL/CON/MAS/BV-104-C
LL/CON/SLA/BV-88-C
LL/CON/SLA/BV-89-C
LL/CON/SLA/BV-90-C
LL/CON/SLA/BV-91-C
LL/CON/SLA/BV-92-C
LL/CON/SLA/BV-93-C
LL/CON/SLA/BV-94-C
LL/CON/SLA/BV-95-C
LL/CON/SLA/BV-96-C
LL/CON/SLA/BV-97-C
LL/CON/SLA/BV-98-C
LL/CON/SLA/BV-99-C
LL/CON/SLA/BV-100-C
LL/CON/SLA/BV-101-C
LL/CON/SLA/BV-102-C
LL/CON/SLA/BV-103-C
LL/CON/SLA/BV-104-C
LL/CON/SLA/BV-105-C
LL/CON/SLA/BV-106-C
LL/CON/SLA/BV-107-C
LL/CON/SLA/BV-108-C



