### PR TITLE
nimble/ll: Add LLCP tracing via HCI events

### DIFF
--- a/nimble/controller/include/controller/ble_ll_ctrl.h
+++ b/nimble/controller/include/controller/ble_ll_ctrl.h
@@ -281,6 +281,8 @@ void ble_ll_calc_session_key(struct ble_ll_conn_sm *connsm);
 void ble_ll_ctrl_phy_update_proc_complete(struct ble_ll_conn_sm *connsm);
 void ble_ll_ctrl_initiate_dle(struct ble_ll_conn_sm *connsm);
 void ble_ll_hci_ev_send_vendor_err(const char *file, uint32_t line);
+void ble_ll_hci_ev_send_llcp_trace(uint8_t type, uint16_t handle, uint16_t count,
+                                   void *pdu, size_t length);
 
 #ifdef __cplusplus
 }

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -3795,6 +3795,15 @@ ble_ll_conn_enqueue_pkt(struct ble_ll_conn_sm *connsm, struct os_mbuf *om,
     if (hdr_byte == BLE_LL_LLID_CTRL) {
         om->om_len = length;
         OS_MBUF_PKTHDR(om)->omp_len = length;
+
+#if MYNEWT_VAL(BLE_LL_HCI_LLCP_TRACE)
+        /*
+         *  XXX this should be better sent when we actually send PDU, but it may
+         *      introduce some timing side-effects...
+         */
+        ble_ll_hci_ev_send_llcp_trace(0x04, connsm->conn_handle, connsm->event_cntr,
+                                      om->om_data, length);
+#endif
     }
 
     /* Set BLE transmit header */

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -2287,6 +2287,11 @@ ble_ll_ctrl_rx_pdu(struct ble_ll_conn_sm *connsm, struct os_mbuf *om)
     len = dptr[1];
     opcode = dptr[2];
 
+#if MYNEWT_VAL(BLE_LL_HCI_LLCP_TRACE)
+    ble_ll_hci_ev_send_llcp_trace(0x03, connsm->conn_handle, connsm->event_cntr,
+                                  &dptr[2], len);
+#endif
+
     /*
      * rspbuf points to first byte of response. The response buffer does not
      * contain the Data Channel PDU. Thus, the first byte of rspbuf is the

--- a/nimble/controller/src/ble_ll_hci_ev.c
+++ b/nimble/controller/src/ble_ll_hci_ev.c
@@ -520,3 +520,31 @@ ble_ll_hci_ev_send_vendor_err(const char *file, uint32_t line)
         ble_ll_hci_event_send(hci_ev);
     }
 }
+
+#if MYNEWT_VAL(BLE_LL_HCI_LLCP_TRACE)
+void
+ble_ll_hci_ev_send_llcp_trace(uint8_t type, uint16_t handle, uint16_t count,
+                              void *pdu, size_t length)
+{
+    struct ble_hci_ev_vendor_debug *ev;
+    struct ble_hci_ev *hci_ev;
+
+    hci_ev = (void *)ble_hci_trans_buf_alloc(BLE_HCI_TRANS_BUF_EVT_LO);
+    if (hci_ev) {
+        hci_ev->opcode = BLE_HCI_EVCODE_VENDOR_DEBUG;
+        hci_ev->length = sizeof(*ev) + 8 + length;
+        ev = (void *) hci_ev->data;
+
+        ev->id = 0x17;
+        ev->data[0] = type;
+        put_le16(&ev->data[1], handle);
+        put_le16(&ev->data[3], count);
+        ev->data[5] = 0;
+        ev->data[6] = 0;
+        ev->data[7] = 0;
+        memcpy(&ev->data[8], pdu, length);
+
+        ble_ll_hci_event_send(hci_ev);
+    }
+}
+#endif

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -183,6 +183,11 @@ syscfg.defs:
             the HW supports this). This value is in microseconds.
         value: '0'
 
+    BLE_LL_HCI_LLCP_TRACE:
+        description: >
+            Enables LLCP tracing using HCI vendor-specific events.
+        value: '0'
+
     # Configuration for LL supported features.
     #
     # There are a total 8 features that the LL can support. These can be found


### PR DESCRIPTION
This adds option to trace LLCP PDUs via HCI events. Each LLCP PDU is
sent in a vendor-specific HCI event which can be decoded e.g. by btmon.
Identifier and format of HCI event os the same as used by controllers
from Intel so it may be necessary to fake NimBLE's manufacturer id by
setting 'BLE_LL_MFRG_ID: 2' so btmon can decode events properly.