### PR TITLE
nimble/ll: Remove not needed BLE_LL_CTRL_MAX_PAYLOAD define

### DIFF
--- a/nimble/controller/include/controller/ble_ll_ctrl.h
+++ b/nimble/controller/include/controller/ble_ll_ctrl.h
@@ -86,8 +86,7 @@ extern "C" {
 
 extern const uint8_t g_ble_ll_ctrl_pkt_lengths[BLE_LL_CTRL_OPCODES];
 
-/* Maximum # of payload bytes in a LL control PDU */
-#define BLE_LL_CTRL_MAX_PAYLOAD         (26)
+/* Maximum LL control PDU size */
 #define BLE_LL_CTRL_MAX_PDU_LEN         (27)
 
 /* LL control connection update request */

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -983,7 +983,7 @@ ble_ll_conn_hci_param_rr(const uint8_t *cmdbuf, uint8_t len,
     if (connsm->csmflags.cfbit.awaiting_host_reply) {
         /* Get a control packet buffer */
         if (rc == BLE_ERR_SUCCESS) {
-            om = os_msys_get_pkthdr(BLE_LL_CTRL_MAX_PAYLOAD + 1,
+            om = os_msys_get_pkthdr(BLE_LL_CTRL_MAX_PDU_LEN,
                                     sizeof(struct ble_mbuf_hdr));
             if (om) {
                 dptr = om->om_data;


### PR DESCRIPTION
It was always used as BLE_LL_CTRL_MAX_PDU_LEN.