### PR TITLE
nimble/host: Fix periodic sync API naming convention

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -3692,7 +3692,7 @@ cmd_sync_create(int argc, char **argv)
     }
 
     if (argc > 1 && strcmp(argv[1], "cancel") == 0) {
-        rc = ble_gap_periodic_adv_create_sync_cancel();
+        rc = ble_gap_periodic_adv_sync_create_cancel();
         if (rc != 0) {
             console_printf("Sync create cancel fail: %d\n", rc);
             return rc;
@@ -3728,7 +3728,7 @@ cmd_sync_create(int argc, char **argv)
         return rc;
     }
 
-    rc = ble_gap_periodic_adv_create_sync(addr_param, sid, &params,
+    rc = ble_gap_periodic_adv_sync_create(addr_param, sid, &params,
                                           btshell_gap_event, NULL);
     if (rc) {
         console_printf("Failed to create sync (%d)\n", rc);
@@ -3772,7 +3772,7 @@ cmd_sync_terminate(int argc, char **argv)
         return rc;
     }
 
-    rc = ble_gap_periodic_adv_terminate_sync(sync_handle);
+    rc = ble_gap_periodic_adv_sync_terminate(sync_handle);
     if (rc) {
         console_printf("Failed to terminate sync (%d)\n", rc);
     }

--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -1359,7 +1359,7 @@ int ble_gap_periodic_adv_set_data(uint8_t instance, struct os_mbuf *data);
  *
  * @return                   0 on success; nonzero on failure.
  */
-int ble_gap_periodic_adv_create_sync(const ble_addr_t *addr, uint8_t adv_sid,
+int ble_gap_periodic_adv_sync_create(const ble_addr_t *addr, uint8_t adv_sid,
                                      const struct ble_gap_periodic_sync_params *params,
                                      ble_gap_event_fn *cb, void *cb_arg);
 
@@ -1368,7 +1368,7 @@ int ble_gap_periodic_adv_create_sync(const ble_addr_t *addr, uint8_t adv_sid,
  *
  * @return                   0 on success; nonzero on failure.
  */
-int ble_gap_periodic_adv_create_sync_cancel(void);
+int ble_gap_periodic_adv_sync_create_cancel(void);
 
 /**
  * Terminate synchronization procedure.
@@ -1377,7 +1377,7 @@ int ble_gap_periodic_adv_create_sync_cancel(void);
  *
  * @return                   0 on success; nonzero on failure.
  */
-int ble_gap_periodic_adv_terminate_sync(uint16_t sync_handle);
+int ble_gap_periodic_adv_sync_terminate(uint16_t sync_handle);
 
 /**
  * Add peer device to periodic synchronization list.

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -3412,7 +3412,7 @@ ble_gap_npl_sync_lost(struct ble_npl_event *ev)
 }
 
 int
-ble_gap_periodic_adv_create_sync(const ble_addr_t *addr, uint8_t adv_sid,
+ble_gap_periodic_adv_sync_create(const ble_addr_t *addr, uint8_t adv_sid,
                                  const struct ble_gap_periodic_sync_params *params,
                                  ble_gap_event_fn *cb, void *cb_arg)
 {
@@ -3490,7 +3490,7 @@ ble_gap_periodic_adv_create_sync(const ble_addr_t *addr, uint8_t adv_sid,
 }
 
 int
-ble_gap_periodic_adv_create_sync_cancel(void)
+ble_gap_periodic_adv_sync_create_cancel(void)
 {
     uint16_t opcode;
     int rc = 0;
@@ -3513,7 +3513,7 @@ ble_gap_periodic_adv_create_sync_cancel(void)
 }
 
 int
-ble_gap_periodic_adv_terminate_sync(uint16_t sync_handle)
+ble_gap_periodic_adv_sync_terminate(uint16_t sync_handle)
 {
     struct ble_hci_le_periodic_adv_term_sync_cp cmd;
     struct ble_hs_periodic_sync *psync;

--- a/nimble/host/src/ble_hs_stop.c
+++ b/nimble/host/src/ble_hs_stop.c
@@ -92,7 +92,7 @@ ble_hs_stop_terminate_all_periodic_sync(void)
          * ble_hs_periodic_sync_first yields the next psync handle
          */
         sync_handle = psync->sync_handle;
-        rc = ble_gap_periodic_adv_terminate_sync(sync_handle);
+        rc = ble_gap_periodic_adv_sync_terminate(sync_handle);
         if (rc != 0 && rc != BLE_HS_ENOTCONN) {
             BLE_HS_LOG(ERROR, "failed to terminate periodic sync=0x%04x, rc=%d\n",
                        sync_handle, rc);


### PR DESCRIPTION
This makes periodic sync API names consistent. Future periodic sync
transfer API will also follow this convention.