### PR TITLE
nimble/ll: Fix build issue when BLE_LL_STRICT_CONN_SCHEDULING is set

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1814,9 +1814,6 @@ ble_ll_conn_end(struct ble_ll_conn_sm *connsm, uint8_t ble_err)
     struct os_mbuf *m;
     struct os_mbuf_pkthdr *pkthdr;
     os_sr_t sr;
-#if MYNEWT_VAL(BLE_LL_STRICT_CONN_SCHEDULING)
-    os_sr_t sr;
-#endif
 
     /* Remove scheduler events just in case */
     ble_ll_sched_rmv_elem(&connsm->conn_sch);


### PR DESCRIPTION
This patch fixes that:

Error: repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_conn.c: In function 'ble_ll_conn_end':
repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_conn.c:1818:13: error: redeclaration of 'sr' with no linkage
     os_sr_t sr;
             ^~