### PR TITLE
nimble/ll: Do not access OS structs internals

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -118,8 +118,10 @@ struct ble_ll_obj
 
 #ifdef BLE_XCVR_RFCLK
     uint8_t ll_rfclk_state;
+    uint8_t ll_rfclk_is_sched;
     uint16_t ll_xtal_ticks;
     uint32_t ll_rfclk_start_time;
+    uint32_t ll_rfclk_sched_time;
     struct hal_timer ll_rfclk_timer;
 #endif
 


### PR DESCRIPTION
We should not access os_cputime internals directly as on some platform
hal_timer may be used in some tricky way so it may fail. Instead, let's
use helper variables instead.