### PR TITLE
call ble_gap_event_listener_call for every ble_gap_notify_tx_event

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -5373,6 +5373,7 @@ ble_gap_notify_tx_event(int status, uint16_t conn_handle, uint16_t attr_handle,
     event.notify_tx.status = status;
     event.notify_tx.attr_handle = attr_handle;
     event.notify_tx.indication = is_indication;
+    ble_gap_event_listener_call(&event);
     ble_gap_call_conn_event_cb(&event, conn_handle);
 }
 


### PR DESCRIPTION
This PR adds a call to the listener for `notify_tx` only, but it might be desirable to also catch some other events.

As discussed on slack, it is needed to get the notification transmitted event with a listener
registered by `ble_gap_event_listener_register` to be able to chain ble notifications.
If there are two different modules on different application levels and both are using nimble, then it is not possible for the lower-level module to register a "feature-complete" callback via `ble_gap_adv_start`, because this function should only be called by the higher-level module, because it knows, when the application is ready for advertising.