### PR TITLE
nimble/ll: Don't allow to modify RL when synchronizing periodic

### DIFF
--- a/nimble/controller/include/controller/ble_ll_sync.h
+++ b/nimble/controller/include/controller/ble_ll_sync.h
@@ -53,6 +53,8 @@ void ble_ll_sync_rmvd_from_sched(struct ble_ll_sync_sm *sm);
 
 uint32_t ble_ll_sync_get_event_end_time(void);
 
+bool ble_ll_sync_enabled(void);
+
 void ble_ll_sync_reset(void);
 
 #ifdef __cplusplus

--- a/nimble/controller/src/ble_ll_resolv.c
+++ b/nimble/controller/src/ble_ll_resolv.c
@@ -28,6 +28,7 @@
 #include "controller/ble_ll_hci.h"
 #include "controller/ble_ll_scan.h"
 #include "controller/ble_ll_adv.h"
+#include "controller/ble_ll_sync.h"
 #include "controller/ble_hw.h"
 #include "ble_ll_conn_priv.h"
 
@@ -49,6 +50,12 @@ struct ble_ll_resolv_entry g_ble_ll_resolv_list[MYNEWT_VAL(BLE_LL_RESOLV_LIST_SI
 static int
 ble_ll_is_controller_busy(void)
 {
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV)
+    if (ble_ll_sync_enabled()) {
+        return 1;
+    }
+#endif
+
     return ble_ll_adv_enabled() || ble_ll_scan_enabled() ||
            g_ble_ll_conn_create_sm;
 }

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -1647,6 +1647,12 @@ ble_ll_sync_rmvd_from_sched(struct ble_ll_sync_sm *sm)
     ble_ll_event_send(&sm->sync_ev_end);
 }
 
+bool
+ble_ll_sync_enabled(void)
+{
+    return g_ble_ll_sync_pending > 0;
+}
+
 void
 ble_ll_sync_reset(void)
 {


### PR DESCRIPTION
This was affecting CCO/BI-05-C test case.