### PR TITLE
nimble/ll: Fix verifying incomplete data when enabling periodic adv

### DIFF
--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -3759,7 +3759,7 @@ ble_ll_adv_periodic_enable(const uint8_t *cmdbuf, uint8_t len)
     }
 
     if (cmd->enable) {
-        if (advsm->props & BLE_LL_ADV_SM_FLAG_PERIODIC_DATA_INCOMPLETE) {
+        if (advsm->flags & BLE_LL_ADV_SM_FLAG_PERIODIC_DATA_INCOMPLETE) {
             return BLE_ERR_CMD_DISALLOWED;
         }
 


### PR DESCRIPTION
Properties were checked instead of flags. This was affecting
HCI/DDI/BI-13-C qualification test case,