### PR TITLE
nimble/ll: Fix concurrent ext adv and scan

### DIFF
--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -4545,13 +4545,13 @@ ble_ll_adv_sec_done(struct ble_ll_adv_sm *advsm)
         return;
     }
 
+    /* Check if we need to resume scanning */
+    ble_ll_scan_chk_resume();
+
     /* Turn off the clock if not doing anything else */
 #ifdef BLE_XCVR_RFCLK
     ble_ll_sched_rfclk_chk_restart();
 #endif
-
-    /* Check if we need to resume scanning */
-    ble_ll_scan_chk_resume();
 
     /* Check if advertising timed out */
     if (advsm->duration && (advsm->adv_pdu_start_time >= advsm->adv_end_time)) {


### PR DESCRIPTION
After extended advertising event is done we should first try restart
scanner and then check if clocks should be disabled. Otherwise we may
disable clock and then restart scanner so it won't scan too much in
current window...