### PR TITLE
nimble/host: Add support for OOB Secure Connections

### DIFF
--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -119,6 +119,9 @@ struct btshell_tx_data_s
 static struct btshell_tx_data_s btshell_tx_data;
 int btshell_full_disc_prev_chr_val;
 
+struct ble_sm_sc_oob_data oob_data_local;
+struct ble_sm_sc_oob_data oob_data_remote;
+
 #define XSTR(s) STR(s)
 #ifndef STR
 #define STR(s) #s
@@ -2102,6 +2105,16 @@ btshell_on_reset(int reason)
 static void
 btshell_on_sync(void)
 {
+#if MYNEWT_VAL(BLE_SM_SC)
+    int rc;
+
+    rc = ble_sm_sc_oob_generate_data(&oob_data_local);
+    if (rc) {
+        console_printf("Error: generating oob data; reason=%d\n", rc);
+        return;
+    }
+#endif
+
     console_printf("Host and controller synced\n");
 }
 

--- a/nimble/host/include/host/ble_sm.h
+++ b/nimble/host/include/host/ble_sm.h
@@ -84,7 +84,16 @@ extern "C" {
 #define BLE_SM_IOACT_INPUT                      2
 #define BLE_SM_IOACT_DISP                       3
 #define BLE_SM_IOACT_NUMCMP                     4
-#define BLE_SM_IOACT_MAX_PLUS_ONE               5
+#define BLE_SM_IOACT_OOB_SC                     5
+#define BLE_SM_IOACT_MAX_PLUS_ONE               6
+
+struct ble_sm_sc_oob_data {
+    /** Random Number. */
+    uint8_t r[16];
+
+    /** Confirm Value. */
+    uint8_t c[16];
+};
 
 struct ble_sm_io {
     uint8_t action;
@@ -92,8 +101,14 @@ struct ble_sm_io {
         uint32_t passkey;
         uint8_t  oob[16];
         uint8_t  numcmp_accept;
+        struct {
+            struct ble_sm_sc_oob_data *local;
+            struct ble_sm_sc_oob_data *remote;
+        } oob_sc_data;
     };
 };
+
+int ble_sm_sc_oob_generate_data(struct ble_sm_sc_oob_data *oob_data);
 
 #if NIMBLE_BLE_SM
 int ble_sm_inject_io(uint16_t conn_handle, struct ble_sm_io *pkey);

--- a/nimble/host/src/ble_sm_alg.c
+++ b/nimble/host/src/ble_sm_alg.c
@@ -44,7 +44,7 @@ static struct trng_dev *g_trng;
 #endif
 
 static void
-ble_sm_alg_xor_128(uint8_t *p, uint8_t *q, uint8_t *r)
+ble_sm_alg_xor_128(const uint8_t *p, const uint8_t *q, uint8_t *r)
 {
     int i;
 
@@ -54,7 +54,8 @@ ble_sm_alg_xor_128(uint8_t *p, uint8_t *q, uint8_t *r)
 }
 
 static int
-ble_sm_alg_encrypt(uint8_t *key, uint8_t *plaintext, uint8_t *enc_data)
+ble_sm_alg_encrypt(const uint8_t *key, const uint8_t *plaintext,
+                   uint8_t *enc_data)
 {
     struct tc_aes_key_sched_struct s;
     uint8_t tmp[16];
@@ -79,7 +80,8 @@ ble_sm_alg_encrypt(uint8_t *key, uint8_t *plaintext, uint8_t *enc_data)
 }
 
 int
-ble_sm_alg_s1(uint8_t *k, uint8_t *r1, uint8_t *r2, uint8_t *out)
+ble_sm_alg_s1(const uint8_t *k, const uint8_t *r1, const uint8_t *r2,
+              uint8_t *out)
 {
     int rc;
 
@@ -114,10 +116,10 @@ ble_sm_alg_s1(uint8_t *k, uint8_t *r1, uint8_t *r2, uint8_t *out)
 }
 
 int
-ble_sm_alg_c1(uint8_t *k, uint8_t *r,
-              uint8_t *preq, uint8_t *pres,
+ble_sm_alg_c1(const uint8_t *k, const uint8_t *r,
+              const uint8_t *preq, const uint8_t *pres,
               uint8_t iat, uint8_t rat,
-              uint8_t *ia, uint8_t *ra,
+              const uint8_t *ia, const uint8_t *ra,
               uint8_t *out_enc_data)
 {
     uint8_t p1[16], p2[16];
@@ -224,8 +226,8 @@ ble_sm_alg_aes_cmac(const uint8_t *key, const uint8_t *in, size_t len,
 }
 
 int
-ble_sm_alg_f4(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t z,
-              uint8_t *out_enc_data)
+ble_sm_alg_f4(const uint8_t *u, const uint8_t *v, const uint8_t *x,
+              uint8_t z, uint8_t *out_enc_data)
 {
     uint8_t xs[16];
     uint8_t m[65];
@@ -269,9 +271,9 @@ ble_sm_alg_f4(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t z,
 }
 
 int
-ble_sm_alg_f5(uint8_t *w, uint8_t *n1, uint8_t *n2, uint8_t a1t,
-              uint8_t *a1, uint8_t a2t, uint8_t *a2, uint8_t *mackey,
-              uint8_t *ltk)
+ble_sm_alg_f5(const uint8_t *w, const uint8_t *n1, const uint8_t *n2,
+              uint8_t a1t, const uint8_t *a1, uint8_t a2t, const uint8_t *a2,
+              uint8_t *mackey, uint8_t *ltk)
 {
     static const uint8_t salt[16] = { 0x6c, 0x88, 0x83, 0x91, 0xaa, 0xf5,
                       0xa5, 0x38, 0x60, 0x37, 0x0b, 0xdb,
@@ -385,8 +387,8 @@ ble_sm_alg_f6(const uint8_t *w, const uint8_t *n1, const uint8_t *n2,
 }
 
 int
-ble_sm_alg_g2(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t *y,
-              uint32_t *passkey)
+ble_sm_alg_g2(const uint8_t *u, const uint8_t *v, const uint8_t *x,
+              const uint8_t *y, uint32_t *passkey)
 {
     uint8_t m[80], xs[16];
     int rc;
@@ -418,8 +420,8 @@ ble_sm_alg_g2(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t *y,
 }
 
 int
-ble_sm_alg_gen_dhkey(uint8_t *peer_pub_key_x, uint8_t *peer_pub_key_y,
-                     uint8_t *our_priv_key, uint8_t *out_dhkey)
+ble_sm_alg_gen_dhkey(const uint8_t *peer_pub_key_x, const uint8_t *peer_pub_key_y,
+                     const uint8_t *our_priv_key, uint8_t *out_dhkey)
 {
     uint8_t dh[32];
     uint8_t pk[64];

--- a/nimble/host/src/ble_sm_priv.h
+++ b/nimble/host/src/ble_sm_priv.h
@@ -294,25 +294,27 @@ void ble_sm_dbg_set_sc_keys(uint8_t *pubkey, uint8_t *privkey);
 
 int ble_sm_num_procs(void);
 
-int ble_sm_alg_s1(uint8_t *k, uint8_t *r1, uint8_t *r2, uint8_t *out);
-int ble_sm_alg_c1(uint8_t *k, uint8_t *r,
-                  uint8_t *preq, uint8_t *pres,
+int ble_sm_alg_s1(const uint8_t *k, const uint8_t *r1, const uint8_t *r2,
+                  uint8_t *out);
+int ble_sm_alg_c1(const uint8_t *k, const uint8_t *r,
+                  const uint8_t *preq, const uint8_t *pres,
                   uint8_t iat, uint8_t rat,
-                  uint8_t *ia, uint8_t *ra,
+                  const uint8_t *ia, const uint8_t *ra,
                   uint8_t *out_enc_data);
-int ble_sm_alg_f4(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t z,
-                  uint8_t *out_enc_data);
-int ble_sm_alg_g2(uint8_t *u, uint8_t *v, uint8_t *x, uint8_t *y,
-                  uint32_t *passkey);
-int ble_sm_alg_f5(uint8_t *w, uint8_t *n1, uint8_t *n2, uint8_t a1t,
-                  uint8_t *a1, uint8_t a2t, uint8_t *a2,
-                  uint8_t *mackey, uint8_t *ltk);
+int ble_sm_alg_f4(const uint8_t *u, const uint8_t *v, const uint8_t *x,
+                  uint8_t z, uint8_t *out_enc_data);
+int ble_sm_alg_g2(const uint8_t *u, const uint8_t *v, const uint8_t *x,
+                  const uint8_t *y, uint32_t *passkey);
+int ble_sm_alg_f5(const uint8_t *w, const uint8_t *n1, const uint8_t *n2,
+                  uint8_t a1t, const uint8_t *a1, uint8_t a2t,
+                  const uint8_t *a2, uint8_t *mackey, uint8_t *ltk);
 int ble_sm_alg_f6(const uint8_t *w, const uint8_t *n1, const uint8_t *n2,
                   const uint8_t *r, const uint8_t *iocap, uint8_t a1t,
                   const uint8_t *a1, uint8_t a2t, const uint8_t *a2,
                   uint8_t *check);
-int ble_sm_alg_gen_dhkey(uint8_t *peer_pub_key_x, uint8_t *peer_pub_key_y,
-                         uint8_t *our_priv_key, uint8_t *out_dhkey);
+int ble_sm_alg_gen_dhkey(const uint8_t *peer_pub_key_x,
+                         const uint8_t *peer_pub_key_y,
+                         const uint8_t *our_priv_key, uint8_t *out_dhkey);
 int ble_sm_alg_gen_key_pair(uint8_t *pub, uint8_t *priv);
 void ble_sm_alg_ecc_init(void);
 

--- a/nimble/host/src/ble_sm_priv.h
+++ b/nimble/host/src/ble_sm_priv.h
@@ -269,6 +269,8 @@ struct ble_sm_proc {
     struct ble_sm_public_key pub_key_peer;
     uint8_t mackey[16];
     uint8_t dhkey[32];
+    const struct ble_sm_sc_oob_data *oob_data_local;
+    const struct ble_sm_sc_oob_data *oob_data_remote;
 #endif
 };
 
@@ -353,6 +355,10 @@ void ble_sm_sc_dhkey_check_exec(struct ble_sm_proc *proc,
                                 struct ble_sm_result *res, void *arg);
 void ble_sm_sc_dhkey_check_rx(uint16_t conn_handle, struct os_mbuf **rxom,
                               struct ble_sm_result *res);
+bool ble_sm_sc_oob_data_check(struct ble_sm_proc *proc,
+                              bool oob_data_local_present,
+                              bool oob_data_remote_present);
+void ble_sm_sc_oob_confirm(struct ble_sm_proc *proc, struct ble_sm_result *res);
 void ble_sm_sc_init(void);
 #else
 #define ble_sm_sc_io_action(proc, action) (BLE_HS_ENOTSUP)

--- a/nimble/host/src/ble_sm_sc.c
+++ b/nimble/host/src/ble_sm_sc.c
@@ -106,7 +106,7 @@ ble_sm_sc_io_action(struct ble_sm_proc *proc, uint8_t *action)
 
     if (pair_req->oob_data_flag == BLE_SM_PAIR_OOB_YES ||
         pair_rsp->oob_data_flag == BLE_SM_PAIR_OOB_YES) {
-        *action = BLE_SM_IOACT_OOB;
+        *action = BLE_SM_IOACT_OOB_SC;
     } else if (!(pair_req->authreq & BLE_SM_PAIR_AUTHREQ_MITM) &&
                !(pair_rsp->authreq & BLE_SM_PAIR_AUTHREQ_MITM)) {
 
@@ -125,7 +125,7 @@ ble_sm_sc_io_action(struct ble_sm_proc *proc, uint8_t *action)
         proc->pair_alg = BLE_SM_PAIR_ALG_JW;
         break;
 
-    case BLE_SM_IOACT_OOB:
+    case BLE_SM_IOACT_OOB_SC:
         proc->pair_alg = BLE_SM_PAIR_ALG_OOB;
         proc->flags |= BLE_SM_PROC_F_AUTHENTICATED;
         break;
@@ -233,11 +233,11 @@ ble_sm_sc_gen_ri(struct ble_sm_proc *proc)
 {
     int byte;
     int bit;
-    int rc;
 
     switch (proc->pair_alg) {
     case BLE_SM_PAIR_ALG_JW:
     case BLE_SM_PAIR_ALG_NUMCMP:
+    case BLE_SM_PAIR_ALG_OOB:
         proc->ri = 0;
         return 0;
 
@@ -253,13 +253,46 @@ ble_sm_sc_gen_ri(struct ble_sm_proc *proc)
 
         return 0;
 
-    case BLE_SM_PAIR_ALG_OOB:
-        rc = ble_hs_hci_util_rand(&proc->ri, 1);
-        return rc;
-
     default:
         BLE_HS_DBG_ASSERT(0);
         return BLE_HS_EUNKNOWN;
+    }
+}
+
+void
+ble_sm_sc_oob_confirm(struct ble_sm_proc *proc, struct ble_sm_result *res)
+{
+    int err;
+    bool match;
+    uint8_t c[16];
+
+    /* Authentication stage 1: Step 5 */
+    if (proc->oob_data_remote) {
+        err = ble_sm_alg_f4(proc->pub_key_peer.x, proc->pub_key_peer.x,
+                            proc->oob_data_remote->r, 0, c);
+        if (err) {
+            res->sm_err = BLE_SM_ERR_UNSPECIFIED;
+            res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_UNSPECIFIED);
+            res->enc_cb = 1;
+            return;
+        }
+
+        match = (memcmp(c, proc->oob_data_remote->c, sizeof(c)) == 0);
+        if (!match) {
+            /* Random number mismatch. */
+            res->sm_err = BLE_SM_ERR_CONFIRM_MISMATCH;
+            res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_CONFIRM_MISMATCH);
+            res->enc_cb = 1;
+            return;
+        }
+    }
+
+    if ((proc->flags & BLE_SM_PROC_F_INITIATOR) ||
+        (proc->flags & BLE_SM_PROC_F_ADVANCE_ON_IO)) {
+        /* If is initiator or was waiting on
+         * IO then execute step 6: send Random
+         */
+        res->execute = 1;
     }
 }
 
@@ -414,8 +447,9 @@ ble_sm_sc_random_rx(struct ble_sm_proc *proc, struct ble_sm_result *res)
     uint8_t rat;
     int rc;
 
-    if (proc->flags & BLE_SM_PROC_F_INITIATOR ||
-        ble_sm_sc_responder_verifies_random(proc)) {
+    if (proc->pair_alg != BLE_SM_PAIR_ALG_OOB && (
+        proc->flags & BLE_SM_PROC_F_INITIATOR ||
+        ble_sm_sc_responder_verifies_random(proc))) {
 
         BLE_HS_LOG(DEBUG, "tk=");
         ble_hs_log_flat_buf(proc->tk, 16);
@@ -487,7 +521,12 @@ ble_sm_sc_random_rx(struct ble_sm_proc *proc, struct ble_sm_result *res)
             res->execute = 1;
         }
     } else {
-        res->execute = 1;
+        if (proc->pair_alg == BLE_SM_PAIR_ALG_OOB &&
+            !(proc->flags & BLE_SM_PROC_F_IO_INJECTED)) {
+            proc->flags |= BLE_SM_PROC_F_ADVANCE_ON_IO;
+        } else {
+            res->execute = 1;
+        }
     }
 }
 
@@ -526,7 +565,11 @@ ble_sm_sc_public_key_exec(struct ble_sm_proc *proc, struct ble_sm_result *res,
     }
 
     if (!(proc->flags & BLE_SM_PROC_F_INITIATOR)) {
-        proc->state = BLE_SM_PROC_STATE_CONFIRM;
+        if (proc->pair_alg == BLE_SM_PAIR_ALG_OOB) {
+            proc->state = BLE_SM_PROC_STATE_RANDOM;
+        } else {
+            proc->state = BLE_SM_PROC_STATE_CONFIRM;
+        }
 
         rc = ble_sm_sc_io_action(proc, &ioact);
         if (rc != 0) {
@@ -587,8 +630,11 @@ ble_sm_sc_public_key_rx(uint16_t conn_handle, struct os_mbuf **om,
             res->enc_cb = 1;
         } else {
             if (proc->flags & BLE_SM_PROC_F_INITIATOR) {
-
-                proc->state = BLE_SM_PROC_STATE_CONFIRM;
+                if (proc->pair_alg == BLE_SM_PAIR_ALG_OOB) {
+                    proc->state = BLE_SM_PROC_STATE_RANDOM;
+                } else {
+                    proc->state = BLE_SM_PROC_STATE_CONFIRM;
+                }
 
                 rc = ble_sm_sc_io_action(proc, &ioact);
                 if (rc != 0) {
@@ -650,6 +696,14 @@ ble_sm_sc_dhkey_check_exec(struct ble_sm_proc *proc, struct ble_sm_result *res,
         iocap = &pair_rsp->io_cap;
     }
 
+    if (proc->pair_alg == BLE_SM_PAIR_ALG_OOB) {
+        if (proc->oob_data_remote) {
+            memcpy(proc->tk, proc->oob_data_remote->r, 16);
+        } else {
+            memset(proc->tk, 0, 16);
+        }
+    }
+
     ble_sm_sc_dhkey_addrs(proc, &our_addr, &peer_addr);
 
     cmd = ble_sm_cmd_get(BLE_SM_OP_PAIR_DHKEY_CHECK, sizeof(*cmd), &txom);
@@ -701,11 +755,27 @@ ble_sm_dhkey_check_process(struct ble_sm_proc *proc,
 
         pair_rsp  = (struct ble_sm_pair_cmd *) &proc->pair_rsp[1];
         iocap = &pair_rsp->io_cap;
+
+        if (proc->pair_alg == BLE_SM_PAIR_ALG_OOB) {
+            if (pair_rsp->oob_data_flag) {
+                memcpy(proc->tk, proc->oob_data_local->r, 16);
+            } else {
+                memset(proc->tk, 0, 16);
+            }
+        }
     } else {
         struct ble_sm_pair_cmd *pair_req;
 
         pair_req  = (struct ble_sm_pair_cmd *) &proc->pair_req[1];
         iocap = &pair_req->io_cap;
+
+        if (proc->pair_alg == BLE_SM_PAIR_ALG_OOB) {
+            if (pair_req->oob_data_flag) {
+                memcpy(proc->tk, proc->oob_data_local->r, 16);
+            } else {
+                memset(proc->tk, 0, 16);
+            }
+        }
     }
 
     ble_sm_sc_dhkey_addrs(proc, &our_addr, &peer_addr);
@@ -777,6 +847,56 @@ ble_sm_sc_dhkey_check_rx(uint16_t conn_handle, struct os_mbuf **om,
         ble_sm_dhkey_check_process(proc, cmd, res);
     }
     ble_hs_unlock();
+}
+
+bool
+ble_sm_sc_oob_data_check(struct ble_sm_proc *proc,
+                         bool oob_data_local_present,
+                         bool oob_data_remote_present)
+{
+    struct ble_sm_pair_cmd *pair_req;
+    struct ble_sm_pair_cmd *pair_rsp;
+    bool req_oob_present;
+    bool rsp_oob_present;
+
+    pair_req = (struct ble_sm_pair_cmd *) &proc->pair_req[1];
+    pair_rsp = (struct ble_sm_pair_cmd *) &proc->pair_rsp[1];
+    req_oob_present = pair_req->oob_data_flag == BLE_SM_PAIR_OOB_YES;
+    rsp_oob_present = pair_rsp->oob_data_flag == BLE_SM_PAIR_OOB_YES;
+
+    if (proc->flags & BLE_SM_PROC_F_INITIATOR) {
+        return req_oob_present == oob_data_remote_present;
+    } else {
+        return rsp_oob_present == oob_data_remote_present;
+    }
+}
+
+int
+ble_sm_sc_oob_generate_data(struct ble_sm_sc_oob_data *oob_data)
+{
+    int rc;
+
+#if !MYNEWT_VAL(BLE_SM_SC)
+    return BLE_HS_ENOTSUP;
+#endif
+
+    rc = ble_sm_sc_ensure_keys_generated();
+    if (rc) {
+        return rc;
+    }
+
+    rc = ble_hs_hci_util_rand(oob_data->r, 16);
+    if (rc) {
+        return rc;
+    }
+
+    rc = ble_sm_alg_f4(ble_sm_sc_pub_key, ble_sm_sc_pub_key, oob_data->r, 0,
+                       oob_data->c);
+    if (rc) {
+        return rc;
+    }
+
+    return 0;
 }
 
 void


### PR DESCRIPTION
Previously we supported only Legacy OOB pairing procedure.
Secure connections version uses a very different Authentication stage
which required some changes to the SM code.

SC OOB uses two 128-bit values as OOB data. OOB communication
is possible in one or both directions. Due to the difference in
OOB Data compared to the Legacy version, we had to introduce additional
IO Action that is used in ble_sm_inject_io() API. Also the CONFIRM
state is omitted as there is no confirmation data sent in-band. The
confirmation is done when application is passing OOB data to the host
using ble_sm_inject_io(). The application should call
ble_sm_sc_oob_generate_data() to generate local OOB data for later use.
