### PR TITLE
nimble/ll: Use bigger LL task stack with ext adv

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -229,7 +229,11 @@ static void ble_ll_event_dbuf_overflow(struct ble_npl_event *ev);
 #if MYNEWT
 
 /* The BLE LL task data structure */
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+#define BLE_LL_STACK_SIZE   (120)
+#else
 #define BLE_LL_STACK_SIZE   (90)
+#endif
 
 struct os_task g_ble_ll_task;
 


### PR DESCRIPTION
This was removed in 275718ac but as it turns out, we need more stack for
extended and (especially) periodic advertising when running on CM0.
120 words give us few words to spare when running all features on CM0.