### PR TITLE
nimble/apps: Use the correct connection handle in update event

### DIFF
--- a/apps/bleprph/src/main.c
+++ b/apps/bleprph/src/main.c
@@ -207,7 +207,7 @@ bleprph_gap_event(struct ble_gap_event *event, void *arg)
         /* The central has updated the connection parameters. */
         MODLOG_DFLT(INFO, "connection updated; status=%d ",
                     event->conn_update.status);
-        rc = ble_gap_conn_find(event->connect.conn_handle, &desc);
+        rc = ble_gap_conn_find(event->conn_update.conn_handle, &desc);
         assert(rc == 0);
         bleprph_print_conn_desc(&desc);
         MODLOG_DFLT(INFO, "\n");


### PR DESCRIPTION
Event BLE_GAP_EVENT_CONN_UPDATE should use `event->conn_update.conn_handle` instead of `event->connect.conn_handle`