### PR TITLE
nimble/host: Fix NULL pointer passed as a parameter

### DIFF
--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -228,7 +228,7 @@ ble_hs_hci_process_ack(uint16_t expected_opcode,
     }
 
     if (rc == 0) {
-        if (params_buf == NULL) {
+        if (params_buf == NULL || out_ack->bha_params == NULL) {
             out_ack->bha_params_len = 0;
         } else {
             if (out_ack->bha_params_len > params_buf_len) {


### PR DESCRIPTION
The value of out_ack->bha_params might be NULL. It could cause some problems when calling memcpy in line 238.