### PR TITLE
nimble/host: Fix cleaning conn when sync transfer enabled

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -1467,8 +1467,13 @@ int ble_gap_periodic_adv_sync_set_info(uint8_t instance,
 
 /**
  * Enables or disables sync transfer reception on specified connection.
- * When BLE_GAP_EVENT_PERIODIC_TRANSFER is sent transfer reception is terminated
- * on that connection.
+ * When sync transfer arrives, BLE_GAP_EVENT_PERIODIC_TRANSFER is sent to the user.
+ * After that, sync transfer reception on that connection is terminated and user needs
+ * to call this API again when expect to receive next sync transfers.
+ *
+ * Note: If ACL connection gets disconnected before sync transfer arrived, user will
+ * not receive BLE_GAP_EVENT_PERIODIC_TRANSFER. Instead, sync transfer reception
+ * is terminated by the host automatically.
  *
  * @param conn_handle        Handle identifying connection.
  * @param params             Parameters for enabled sync transfer reception.

--- a/nimble/host/src/ble_hs_atomic.c
+++ b/nimble/host/src/ble_hs_atomic.c
@@ -28,6 +28,11 @@ ble_hs_atomic_conn_delete(uint16_t conn_handle)
     conn = ble_hs_conn_find(conn_handle);
     if (conn != NULL) {
         ble_hs_conn_remove(conn);
+#if MYNEWT_VAL(BLE_PERIODIC_ADV_SYNC_TRANSFER)
+        if (conn->psync) {
+            ble_hs_periodic_sync_free(conn->psync);
+        }
+#endif
         ble_hs_conn_free(conn);
 
     }


### PR DESCRIPTION
When host is waiting for the sync transfer, conn->psync is allocated.
If ACL disconnection happen before sync is established, make sure to
free it.