### PR TITLE
nimble/ll: Schedule for periodic chain PDU before reporting data on HCI

### DIFF
--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -748,9 +748,10 @@ ble_ll_sync_rx_isr_end(uint8_t *rxbuf, struct ble_mbuf_hdr *rxhdr)
         ble_ll_event_send(&g_ble_ll_sync_sm_current->sync_ev_end);
     }
 
+    /* PHY is disabled here */
     ble_ll_sync_current_sm_over();
 
-    return -1;
+    return 1;
 }
 
 /**


### PR DESCRIPTION
Make sure to schedule for next PDu in chain as soon as possible (that
means before data is reported to host). Case when we are left with no
buffers but with scheduled PDU is handled by additional flag which
allows to end event early when PDU is received.

This is important on slow MCUs (eg CM0) where HCI reports handling can
take too much time resulting in not being able to scan whole chain.

This was affecting following qualification test cases:
LL/CON/INI/BV-25-C
LL/DDI/SCN/BV-21-C
LL/DDI/SCN/BV-46-C