### PR TITLE
nimble/ll: Simplify and cleanup PDU RX flow in scanner

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -401,6 +401,10 @@ struct ble_dev_addr
 #define BLE_SCAN_RSP_MAX_LEN        (37)
 #define BLE_SCAN_RSP_MAX_EXT_LEN    (251)
 
+#define BLE_LL_ADDR_SUBTYPE_IDENTITY    (0)
+#define BLE_LL_ADDR_SUBTYPE_RPA         (1)
+#define BLE_LL_ADDR_SUBTYPE_NRPA        (2)
+
 /*--- External API ---*/
 /* Initialize the Link Layer */
 void ble_ll_init(void);
@@ -430,6 +434,8 @@ uint16_t ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode);
 
 /* Is this address a resolvable private address? */
 int ble_ll_is_rpa(const uint8_t *addr, uint8_t addr_type);
+
+int ble_ll_addr_subtype(const uint8_t *addr, uint8_t addr_type);
 
 /* Is this address an identity address? */
 int ble_ll_addr_is_id(uint8_t *addr, uint8_t addr_type);

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -444,6 +444,23 @@ ble_ll_addr_is_id(uint8_t *addr, uint8_t addr_type)
 }
 
 int
+ble_ll_addr_subtype(const uint8_t *addr, uint8_t addr_type)
+{
+    if (!addr_type) {
+        return BLE_LL_ADDR_SUBTYPE_IDENTITY;
+    }
+
+    switch (addr[5] >> 6) {
+    case 0:
+        return BLE_LL_ADDR_SUBTYPE_NRPA; /* NRPA */
+    case 1:
+        return BLE_LL_ADDR_SUBTYPE_RPA; /* RPA */
+    default:
+        return BLE_LL_ADDR_SUBTYPE_IDENTITY; /* static random */
+    }
+}
+
+int
 ble_ll_is_valid_public_addr(const uint8_t *addr)
 {
     int i;

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -865,7 +865,7 @@ ble_ll_scan_send_adv_report(uint8_t pdu_type,
     if (BLE_MBUF_HDR_RESOLVED(hdr)) {
         adva_type += 2;
     }
-    if (BLE_MBUF_HDR_INITA_RESOLVED(hdr)) {
+    if (BLE_MBUF_HDR_TARGETA_RESOLVED(hdr)) {
         inita_type += 2;
     }
 #endif
@@ -2267,7 +2267,7 @@ ble_ll_scan_rx_isr_end(struct os_mbuf *rxpdu, uint8_t crcok)
                     if (!ble_ll_resolv_rpa(targeta, g_ble_ll_resolv_list[rpa_index].rl_local_irk)) {
                         goto scan_rx_isr_exit;
                     }
-                    ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_INITA_RESOLVED;
+                    ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_TARGETA_RESOLVED;
                 }
             } else {
                 if (chk_wl) {
@@ -2291,7 +2291,7 @@ ble_ll_scan_rx_isr_end(struct os_mbuf *rxpdu, uint8_t crcok)
                 goto scan_rx_isr_exit;
             }
 
-            ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_INITA_RESOLVED;
+            ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_TARGETA_RESOLVED;
         }
     }
 
@@ -2570,7 +2570,7 @@ ble_ll_hci_send_ext_adv_report(uint8_t ptype, uint8_t *adva, uint8_t adva_type,
     if (BLE_MBUF_HDR_RESOLVED(hdr)) {
         adva_type += 2;
     }
-    if (BLE_MBUF_HDR_INITA_RESOLVED(hdr)) {
+    if (BLE_MBUF_HDR_TARGETA_RESOLVED(hdr)) {
         inita_type += 2;
     }
 #endif

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -240,13 +240,6 @@ syscfg.defs:
             This option is used to enable/disable LL privacy.
         value: '1'
 
-    BLE_LL_CFG_FEAT_EXT_SCAN_FILT:
-        description: >
-            This option is used to enable/disable the extended scanner filter
-            policy feature. Currently, this feature is not supported by the
-            nimble controller.
-        value: '0'
-
     BLE_LL_CFG_FEAT_LE_CSA2:
         description: >
             This option is used to enable/disable support for LE Channel

--- a/nimble/include/nimble/ble.h
+++ b/nimble/include/nimble/ble.h
@@ -82,6 +82,7 @@ struct ble_mbuf_hdr_rxinfo
 };
 
 /* Flag definitions for rxinfo  */
+#define BLE_MBUF_HDR_F_IGNORED          (0x8000)
 #define BLE_MBUF_HDR_F_SCAN_REQ_TXD     (0x4000)
 #define BLE_MBUF_HDR_F_INITA_RESOLVED   (0x2000)
 #define BLE_MBUF_HDR_F_EXT_ADV_SEC      (0x1000)
@@ -114,6 +115,9 @@ struct ble_mbuf_hdr
     uint32_t beg_cputime;
     uint32_t rem_usecs;
 };
+
+#define BLE_MBUF_HDR_IGNORED(hdr) \
+    (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_IGNORED))
 
 #define BLE_MBUF_HDR_SCAN_REQ_TXD(hdr) \
     (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_SCAN_REQ_TXD))

--- a/nimble/include/nimble/ble.h
+++ b/nimble/include/nimble/ble.h
@@ -85,6 +85,7 @@ struct ble_mbuf_hdr_rxinfo
 #define BLE_MBUF_HDR_F_IGNORED          (0x8000)
 #define BLE_MBUF_HDR_F_SCAN_REQ_TXD     (0x4000)
 #define BLE_MBUF_HDR_F_INITA_RESOLVED   (0x2000)
+#define BLE_MBUF_HDR_F_TARGETA_RESOLVED (0x2000)
 #define BLE_MBUF_HDR_F_EXT_ADV_SEC      (0x1000)
 #define BLE_MBUF_HDR_F_EXT_ADV          (0x0800)
 #define BLE_MBUF_HDR_F_RESOLVED         (0x0400)
@@ -151,6 +152,9 @@ struct ble_mbuf_hdr
 
 #define BLE_MBUF_HDR_INITA_RESOLVED(hdr)      \
     (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_INITA_RESOLVED))
+
+#define BLE_MBUF_HDR_TARGETA_RESOLVED(hdr)      \
+    (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_TARGETA_RESOLVED))
 
 #define BLE_MBUF_HDR_RX_STATE(hdr)      \
     ((uint8_t)((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_RXSTATE_MASK))


### PR DESCRIPTION
This mostly refactors PDU RX flow through scanner into smaller functions and separates legacy and ext adv code paths to remove lots of checks in the code. It also adds proper support for privacy modes while scanning and does some more optimizations to reduce processing time. See commit messages for details on each change.