### PR TITLE
Add more detail about the MACRO description

### DIFF
--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -31,13 +31,13 @@ extern "C" {
 /*
  * Worst case time needed for scheduled advertising item. This is the longest
  * possible time to receive a scan request and send a scan response (with the
- * appropriate IFS time between them). This number is calculated using the
+ * appropriate IFS time between them) on LE Uncoded PHY 1M. This number is calculated using the
  * following formula: IFS + SCAN_REQ + IFS + SCAN_RSP = 150 + 176 + 150 + 376.
  * Note: worst case time to tx adv, rx scan req and send scan rsp is 1228 usecs.
  * This assumes maximum sized advertising PDU and scan response PDU.
  *
  * For connectable advertising events no scan request is allowed. In this case
- * we just need to receive a connect request PDU: IFS + CONNECT_REQ = 150 + 352.
+ * we just need to receive a connect request PDU: IFS + CONNECT_IND = 150 + 352.
  * Note: worst-case is 376 + 150 + 352 = 878 usecs
  *
  * NOTE: The advertising PDU transmit time is NOT included here since we know


### PR DESCRIPTION
1. Add LE Uncoded PHY 1M
   In the formula: IFS + SCAN_REQ + IFS + SCAN_RSP = 150 + 176 + 150 + 376.
 SCAN_REQ are about 176u, it means 176 bit = 1B(Preamble) + 4B(AA) + 14B(Payload) + 3B(CRC)=22B=22*8bits = 176bits.
this formula should be for LE Uncoded PHY 1M.
for 2M PHY, the preamble is 2B (Core Spec v5.1 p2691), the result is not the same as 1M.

2. Suggest to use CONN_IND as the Core Spec v5.1 p2706.