### PR TITLE
nimble/drivers: Fix loop condition in nrf51 driver

### DIFF
--- a/nimble/drivers/nrf51/src/ble_phy.c
+++ b/nimble/drivers/nrf51/src/ble_phy.c
@@ -238,7 +238,7 @@ ble_phy_rxpdu_copy(uint8_t *dptr, struct os_mbuf *rxpdu)
     om = rxpdu;
     dst = om->om_data;
 
-    while (om) {
+    while (true) {
         /*
          * Always copy blocks of length aligned to word size, only last mbuf
          * will have remaining non-word size bytes appended.


### PR DESCRIPTION
This condition was suggesting that loop can break while om is NULL but
this loop breaks only when copied enough bytes and om is expected to
have enough space.