### PR TITLE
npl/riot: adapt to xtimer API change

### DIFF
--- a/porting/npl/riot/include/nimble/nimble_npl_os.h
+++ b/porting/npl/riot/include/nimble/nimble_npl_os.h
@@ -209,7 +209,7 @@ ble_npl_callout_stop(struct ble_npl_callout *co)
 static inline bool
 ble_npl_callout_is_active(struct ble_npl_callout *c)
 {
-    return (c->timer.target || c->timer.long_target);
+    return (c->timer.offset || c->timer.long_offset);
 }
 
 static inline ble_npl_time_t


### PR DESCRIPTION
The `xtimer` API in RIOT was recently changed (see https://github.com/RIOT-OS/RIOT/pull/9530). So far, this change was applied to nimble in RIOT using a patch in RIOTs package system. This PR upstreams that fix to NimBLE.