### PR TITLE
Set bleprph main task stack size to 512.

### DIFF
--- a/apps/bleprph/syscfg.yml
+++ b/apps/bleprph/syscfg.yml
@@ -58,7 +58,7 @@ syscfg.vals:
     CONFIG_MGMT: 1
 
     # OS main/default task
-    OS_MAIN_STACK_SIZE: 468
+    OS_MAIN_STACK_SIZE: 512
 
     # Lots of smaller mbufs are required for smp using typical BLE ATT MTU
     # values.


### PR DESCRIPTION
When using mcumgr's image management uploads on this app at least 502 words would be needed for stack. This is a similar problem to the one described on https://github.com/apache/mynewt-mcumgr/pull/59 so I came up with a value slightly higher than what was measured.  