### PR TITLE
nimble/host: Fix for BLE_HS_DBG_ASSERT in adv_set_fields

### DIFF
--- a/nimble/host/src/ble_hs_adv.c
+++ b/nimble/host/src/ble_hs_adv.c
@@ -235,10 +235,10 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
 
     uint8_t type;
     int8_t tx_pwr_lvl;
+    uint8_t dst_len_local;
     int rc;
 
-    BLE_HS_DBG_ASSERT(dst_len);
-    *dst_len = 0;
+    dst_len_local = 0;
 
     /*** 0x01 - Flags. */
     /* The application has two options concerning the flags field:
@@ -250,7 +250,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
      */
     if (adv_fields->flags != 0) {
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_FLAGS, 1,
-                                      &adv_fields->flags, dst, dst_len,
+                                      &adv_fields->flags, dst, &dst_len_local,
                                       max_len, om);
 
         if (rc != 0) {
@@ -267,7 +267,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         }
 
         rc = ble_hs_adv_set_array_uuid16(type, adv_fields->num_uuids16,
-                                         adv_fields->uuids16, dst, dst_len,
+                                         adv_fields->uuids16, dst, &dst_len_local,
                                          max_len, om);
         if (rc != 0) {
             return rc;
@@ -283,7 +283,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         }
 
         rc = ble_hs_adv_set_array_uuid32(type, adv_fields->num_uuids32,
-                                         adv_fields->uuids32, dst, dst_len,
+                                         adv_fields->uuids32, dst, &dst_len_local,
                                          max_len, om);
         if (rc != 0) {
             return rc;
@@ -299,7 +299,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         }
 
         rc = ble_hs_adv_set_array_uuid128(type, adv_fields->num_uuids128,
-                                          adv_fields->uuids128, dst, dst_len,
+                                          adv_fields->uuids128, dst, &dst_len_local,
                                           max_len, om);
         if (rc != 0) {
             return rc;
@@ -315,7 +315,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         }
 
         rc = ble_hs_adv_set_flat_mbuf(type, adv_fields->name_len,
-                                      adv_fields->name, dst, dst_len, max_len,
+                                      adv_fields->name, dst, &dst_len_local, max_len,
                                       om);
         if (rc != 0) {
             return rc;
@@ -337,7 +337,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         }
 
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_TX_PWR_LVL, 1,
-                                      &tx_pwr_lvl, dst, dst_len, max_len, om);
+                                      &tx_pwr_lvl, dst, &dst_len_local, max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -348,7 +348,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_SLAVE_ITVL_RANGE,
                                       BLE_HS_ADV_SLAVE_ITVL_RANGE_LEN,
                                       adv_fields->slave_itvl_range, dst,
-                                      dst_len, max_len, om);
+                                      &dst_len_local, max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -358,7 +358,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
     if (adv_fields->svc_data_uuid16 != NULL && adv_fields->svc_data_uuid16_len) {
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_SVC_DATA_UUID16,
                                       adv_fields->svc_data_uuid16_len,
-                                      adv_fields->svc_data_uuid16, dst, dst_len,
+                                      adv_fields->svc_data_uuid16, dst, &dst_len_local,
                                       max_len, om);
         if (rc != 0) {
             return rc;
@@ -372,7 +372,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_PUBLIC_TGT_ADDR,
                                  BLE_HS_ADV_PUBLIC_TGT_ADDR_ENTRY_LEN *
                                      adv_fields->num_public_tgt_addrs,
-                                 adv_fields->public_tgt_addr, dst, dst_len,
+                                 adv_fields->public_tgt_addr, dst, &dst_len_local,
                                  max_len, om);
         if (rc != 0) {
             return rc;
@@ -383,7 +383,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
     if (adv_fields->appearance_is_present) {
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_APPEARANCE,
                                       BLE_HS_ADV_APPEARANCE_LEN,
-                                      &adv_fields->appearance, dst, dst_len,
+                                      &adv_fields->appearance, dst, &dst_len_local,
                                       max_len, om);
         if (rc != 0) {
             return rc;
@@ -393,7 +393,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
     /*** 0x1a - Advertising interval. */
     if (adv_fields->adv_itvl_is_present) {
         rc = ble_hs_adv_set_array16(BLE_HS_ADV_TYPE_ADV_ITVL, 1,
-                                    &adv_fields->adv_itvl, dst, dst_len,
+                                    &adv_fields->adv_itvl, dst, &dst_len_local,
                                     max_len, om);
         if (rc != 0) {
             return rc;
@@ -404,7 +404,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
     if (adv_fields->svc_data_uuid32 != NULL && adv_fields->svc_data_uuid32_len) {
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_SVC_DATA_UUID32,
                                      adv_fields->svc_data_uuid32_len,
-                                     adv_fields->svc_data_uuid32, dst, dst_len,
+                                     adv_fields->svc_data_uuid32, dst, &dst_len_local,
                                      max_len, om);
         if (rc != 0) {
             return rc;
@@ -416,7 +416,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_SVC_DATA_UUID128,
                                       adv_fields->svc_data_uuid128_len,
                                       adv_fields->svc_data_uuid128, dst,
-                                      dst_len, max_len, om);
+                                      &dst_len_local, max_len, om);
         if (rc != 0) {
             return rc;
         }
@@ -425,7 +425,7 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
     /*** 0x24 - URI. */
     if (adv_fields->uri != NULL && adv_fields->uri_len) {
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_URI, adv_fields->uri_len,
-                                      adv_fields->uri, dst, dst_len, max_len,
+                                      adv_fields->uri, dst, &dst_len_local, max_len,
                                       om);
         if (rc != 0) {
             return rc;
@@ -437,10 +437,14 @@ adv_set_fields(const struct ble_hs_adv_fields *adv_fields,
         rc = ble_hs_adv_set_flat_mbuf(BLE_HS_ADV_TYPE_MFG_DATA,
                                       adv_fields->mfg_data_len,
                                       adv_fields->mfg_data,
-                                      dst, dst_len, max_len, om);
+                                      dst, &dst_len_local, max_len, om);
         if (rc != 0) {
             return rc;
         }
+    }
+
+    if (dst_len) {
+        *dst_len = dst_len_local;
     }
 
     return 0;


### PR DESCRIPTION
This is regression after
95833796 nimble/host: Fix checking dst_len in adv_set_fields

Function ble_hs_adv_set_fields_mbuf() does not use dst_len which
triggers the BLE_HS_DBG_ASSERT

For that reason, we have now local variable in the adv_set_fields which
is later copied to dst_len if needed.