### PR TITLE
nimble/ll: Fix SyncInfo units when no offset is provided

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -3767,7 +3767,7 @@ cmd_sync_create(int argc, char **argv)
         return rc;
     }
 
-    params.sync_timeout = parse_arg_time_dflt("sync_timeout", 10000, 10, &rc);
+    params.sync_timeout = parse_arg_time_dflt("sync_timeout", 10000, 2000, &rc);
     if (rc != 0) {
         console_printf("invalid 'sync_timeout' parameter\n");
         return rc;

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -634,6 +634,7 @@ ble_ll_adv_put_syncinfo(struct ble_ll_adv_sm *advsm,
                 units |= 0x40;
             } else {
                 offset = 0;
+                units = 0x00;
             }
         }
 


### PR DESCRIPTION
If periodic advertising event is too far in future to be represented
in SyncInfo, offset is set to 0 and units should also not be set.