### PR TITLE
nimble/ll: Fix assert in extended scanner

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -3151,10 +3151,10 @@ ble_ll_scan_rx_pkt_in_on_aux(uint8_t pdu_type, struct os_mbuf *om,
             /* Data were truncated so stop scanning for subsequent auxes */
             aux_data->flags_ll |= BLE_LL_AUX_FLAG_SCAN_ERROR;
 
-            ble_ll_sched_rmv_elem(&aux_data->sch);
-
-            ble_ll_scan_aux_data_unref(aux_data->sch.cb_arg);
-            aux_data->sch.cb_arg = NULL;
+            if (ble_ll_sched_rmv_elem(&aux_data->sch) == 0) {
+                ble_ll_scan_aux_data_unref(aux_data->sch.cb_arg);
+                aux_data->sch.cb_arg = NULL;
+            }
         } else if ((rc == 0) && scansm->scan_filt_dups) {
             /* Complete data were send so we can update scan_dup list */
             ble_ll_scan_dup_update_ext(addrd->adv_addr_type, addrd->adv_addr,


### PR DESCRIPTION
It is possible that scheduler already fired and aux data is NULL so
we should unref it only if scheduler item was removed.

ble_ll_scan_aux_data_unref (aux_data=<optimized out>) at repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_scan.c:1079
1079        BLE_LL_ASSERT(aux_data);
(gdb) bt
 #0  ble_ll_scan_aux_data_unref (aux_data=<optimized out>) at repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_scan.c:1079
 #1  0x0001f732 in ble_ll_scan_rx_pkt_in_on_aux (pdu_type=<optimized out>, om=0x2000d6f8 <os_msys_1_data>, hdr=0x2000d710 <os_msys_1_data+24>, addrd=addrd@entry=0x20004ecc <g_ble_ll_stack+404>)
    at repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_scan.c:3156
 #2  0x0002010e in ble_ll_scan_rx_pkt_in (ptype=ptype@entry=7 '\a', om=om@entry=0x2000d6f8 <os_msys_1_data>, hdr=hdr@entry=0x2000d710 <os_msys_1_data+24>)
    at repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_scan.c:3198
 #3  0x0001299e in ble_ll_rx_pkt_in () at repos/apache-mynewt-nimble/nimble/controller/src/ble_ll.c:837
 #4  0x000129de in ble_ll_event_rx_pkt (ev=<optimized out>) at repos/apache-mynewt-nimble/nimble/controller/src/ble_ll.c:1164
 #5  0x00012830 in ble_npl_event_run (ev=<optimized out>) at repos/apache-mynewt-nimble/porting/npl/mynewt/include/nimble/nimble_npl_os.h:116
 #6  ble_ll_task (arg=<optimized out>) at repos/apache-mynewt-nimble/nimble/controller/src/ble_ll.c:1214
 #7  0x00038e9c in nrf52_clock_hfxo_release () at repos/apache-mynewt-core/hw/mcu/nordic/nrf52xxx/include/mcu/cortex_m4.h:37
 #8  0x00000000 in ?? ()