### PR TITLE
npl/riot: Improve timer glue code

### DIFF
--- a/porting/npl/riot/include/nimble/nimble_npl_os.h
+++ b/porting/npl/riot/include/nimble/nimble_npl_os.h
@@ -100,7 +100,8 @@ ble_npl_eventq_get(struct ble_npl_eventq *evq, ble_npl_time_t tmo)
     } else if (tmo == BLE_NPL_TIME_FOREVER) {
         return (struct ble_npl_event *)event_wait(&evq->q);
     } else {
-        return (struct ble_npl_event *)event_wait_timeout(&evq->q, (tmo * 1000));
+        return (struct ble_npl_event *)event_wait_timeout(&evq->q,
+                                                          (tmo * US_PER_MS));
     }
 }
 
@@ -227,7 +228,7 @@ ble_npl_callout_set_arg(struct ble_npl_callout *co, void *arg)
 static inline uint32_t
 ble_npl_time_get(void)
 {
-    return xtimer_now_usec() / 1000;
+    return xtimer_now_usec64() / US_PER_MS;
 }
 
 static inline ble_npl_error_t
@@ -259,7 +260,7 @@ ble_npl_time_ticks_to_ms32(ble_npl_time_t ticks)
 static inline void
 ble_npl_time_delay(ble_npl_time_t ticks)
 {
-    xtimer_usleep(ticks * 1000);
+    xtimer_usleep(ticks * US_PER_MS);
 }
 
 static inline uint32_t

--- a/porting/npl/riot/include/nimble/nimble_npl_os.h
+++ b/porting/npl/riot/include/nimble/nimble_npl_os.h
@@ -51,7 +51,7 @@ struct ble_npl_eventq {
 
 struct ble_npl_callout {
     xtimer_t timer;
-    ble_npl_time_t target_ticks;
+    uint64_t target_us;
     struct ble_npl_event e;
     event_queue_t *q;
 };
@@ -100,8 +100,8 @@ ble_npl_eventq_get(struct ble_npl_eventq *evq, ble_npl_time_t tmo)
     } else if (tmo == BLE_NPL_TIME_FOREVER) {
         return (struct ble_npl_event *)event_wait(&evq->q);
     } else {
-        return (struct ble_npl_event *)event_wait_timeout(&evq->q,
-                                                          (tmo * US_PER_MS));
+        return (struct ble_npl_event *)event_wait_timeout64(&evq->q,
+                                                            tmo * US_PER_MS);
     }
 }
 
@@ -216,7 +216,7 @@ ble_npl_callout_is_active(struct ble_npl_callout *c)
 static inline ble_npl_time_t
 ble_npl_callout_get_ticks(struct ble_npl_callout *co)
 {
-    return co->target_ticks;
+    return (ble_npl_time_t)(co->target_us / US_PER_MS);
 }
 
 static inline void
@@ -225,10 +225,10 @@ ble_npl_callout_set_arg(struct ble_npl_callout *co, void *arg)
     co->e.arg = arg;
 }
 
-static inline uint32_t
+static inline ble_npl_time_t
 ble_npl_time_get(void)
 {
-    return xtimer_now_usec64() / US_PER_MS;
+    return (ble_npl_time_t)(xtimer_now_usec64() / US_PER_MS);
 }
 
 static inline ble_npl_error_t
@@ -260,7 +260,7 @@ ble_npl_time_ticks_to_ms32(ble_npl_time_t ticks)
 static inline void
 ble_npl_time_delay(ble_npl_time_t ticks)
 {
-    xtimer_usleep(ticks * US_PER_MS);
+    xtimer_usleep64(ticks * US_PER_MS);
 }
 
 static inline uint32_t

--- a/porting/npl/riot/src/npl_os_riot.c
+++ b/porting/npl/riot/src/npl_os_riot.c
@@ -39,7 +39,8 @@ ble_npl_sem_pend(struct ble_npl_sem *sem, ble_npl_time_t timeout)
     struct timespec abs;
     uint64_t time;
 
-    time = xtimer_now_usec64() + ble_npl_time_ticks_to_ms32(timeout) * US_PER_MS;
+    time = xtimer_now_usec64() +
+        (ble_npl_time_ticks_to_ms32(timeout) * US_PER_MS);
     abs.tv_sec = (time_t)(time / US_PER_SEC);
     abs.tv_nsec = (long)((time % US_PER_SEC) * NS_PER_US);
 
@@ -61,9 +62,12 @@ ble_npl_callout_init(struct ble_npl_callout *c, struct ble_npl_eventq *evq,
 ble_npl_error_t
 ble_npl_callout_reset(struct ble_npl_callout *c, ble_npl_time_t ticks)
 {
-    uint32_t now = xtimer_now_usec();
-    c->target_ticks = (ble_npl_time_t)((now / US_PER_MS) + ticks);
-    xtimer_set(&c->timer, ((ticks * US_PER_MS) - ((xtimer_now_usec() - now) / US_PER_MS)));
+    /* Use critical section to ensure matching target_us and xtimer value. */
+    uint32_t crit_state = ble_npl_hw_enter_critical();
+    uint64_t now = xtimer_now_usec64();
+    c->target_us = now  + ticks * US_PER_MS;
+    xtimer_set64(&c->timer, ticks * US_PER_MS);
+    ble_npl_hw_exit_critical(crit_state);
     return BLE_NPL_OK;
 }
 
@@ -71,6 +75,6 @@ uint32_t
 ble_npl_callout_remaining_ticks(struct ble_npl_callout *co,
                                 ble_npl_time_t time)
 {
-    uint32_t now = xtimer_now_usec();
-    return ((uint32_t)co->target_ticks) - (now / US_PER_MS);
+    uint64_t now = xtimer_now_usec64();
+    return (uint32_t)((co->target_us - now) / US_PER_MS);
 }

--- a/porting/npl/riot/src/npl_os_riot.c
+++ b/porting/npl/riot/src/npl_os_riot.c
@@ -39,9 +39,9 @@ ble_npl_sem_pend(struct ble_npl_sem *sem, ble_npl_time_t timeout)
     struct timespec abs;
     uint64_t time;
 
-    time = xtimer_now_usec64() + ble_npl_time_ticks_to_ms32(timeout) * 1000;
-    abs.tv_sec = (time_t)(time / 1000000);
-    abs.tv_nsec = (long)((time % 1000000) * 1000);
+    time = xtimer_now_usec64() + ble_npl_time_ticks_to_ms32(timeout) * US_PER_MS;
+    abs.tv_sec = (time_t)(time / US_PER_SEC);
+    abs.tv_nsec = (long)((time % US_PER_SEC) * NS_PER_US);
 
     rc = sem_timedwait(&sem->sem, &abs);
 
@@ -62,8 +62,8 @@ ble_npl_error_t
 ble_npl_callout_reset(struct ble_npl_callout *c, ble_npl_time_t ticks)
 {
     uint32_t now = xtimer_now_usec();
-    c->target_ticks = (ble_npl_time_t)((now / 1000) + ticks);
-    xtimer_set(&c->timer, ((ticks * 1000) - ((xtimer_now_usec() - now) / 1000)));
+    c->target_ticks = (ble_npl_time_t)((now / US_PER_MS) + ticks);
+    xtimer_set(&c->timer, ((ticks * US_PER_MS) - ((xtimer_now_usec() - now) / US_PER_MS)));
     return BLE_NPL_OK;
 }
 
@@ -72,5 +72,5 @@ ble_npl_callout_remaining_ticks(struct ble_npl_callout *co,
                                 ble_npl_time_t time)
 {
     uint32_t now = xtimer_now_usec();
-    return ((uint32_t)co->target_ticks) - (now / 1000);
+    return ((uint32_t)co->target_ticks) - (now / US_PER_MS);
 }


### PR DESCRIPTION
This PR modifies and cleans the RIOT NPL glue code. 

The first commit replaces the constants in the milllisecond-to-microsecond and microsecond-to-millisecond conversions to the RIOT defines for this to improve readability.
The second commit mitigates an incorrect `remaining_ticks` result when the RIOT microsecond timer overflows or when the Nimble thread is interrupted between setting the `target_ticks` and setting the timer.

@haukepetersen This might be of interest to you.