### PR TITLE
nimble/ll: Allow to fine tune scheduler when scanning

### DIFF
--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -47,11 +47,6 @@ extern "C" {
 #define BLE_LL_SCHED_DIRECT_ADV_MAX_USECS   (502)
 #define BLE_LL_SCHED_MAX_ADV_PDU_USECS      (376)
 
-/* We don't know how big aux packet will be. It depends on adv packet len which
- * can be up to 257. For now we fix it to 128 bytes, but we can optimize it.
- */
-#define BLE_LL_SCHED_AUX_PTR_DFLT_BYTES_NUM  (128)
-
 /*
  * This is the offset from the start of the scheduled item until the actual
  * tx/rx should occur, in ticks.

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -854,6 +854,7 @@ ble_ll_sched_sync_reschedule(struct ble_ll_sched_item *sch,
     uint32_t window_ticks;
     uint32_t start_time;
     uint32_t end_time;
+    uint32_t dur;
     int rc = 0;
     os_sr_t sr;
 
@@ -871,11 +872,9 @@ ble_ll_sched_sync_reschedule(struct ble_ll_sched_item *sch,
         start_time_rem_usecs -= 31;
     }
 
-    /* TODO For now assume max sync packet, make expected data size
-     * configurable
-     */
-    end_time = start_time + os_cputime_usecs_to_ticks(
-                                        ble_ll_pdu_tx_time_get(257, phy_mode));
+    dur = ble_ll_pdu_tx_time_get(MYNEWT_VAL(BLE_LL_SCHED_SCAN_SYNC_PDU_LEN),
+                                 phy_mode);
+    end_time = start_time + os_cputime_usecs_to_ticks(dur);
 
     start_time -= g_ble_ll_sched_offset_ticks;
 
@@ -963,10 +962,8 @@ ble_ll_sched_sync(struct ble_ll_sched_item *sch,
         start_time_rem_usecs -= 31;
     }
 
-    /* TODO For now assume max sync packet, make expected data size
-     * configurable
-     */
-    dur = ble_ll_pdu_tx_time_get(257, phy_mode);
+    dur = ble_ll_pdu_tx_time_get(MYNEWT_VAL(BLE_LL_SCHED_SCAN_SYNC_PDU_LEN),
+                                  phy_mode);
     end_time = start_time + os_cputime_usecs_to_ticks(dur);
 
     start_time -= g_ble_ll_sched_offset_ticks;
@@ -1645,7 +1642,8 @@ ble_ll_sched_aux_scan(struct ble_mbuf_hdr *ble_hdr,
      */
     phy_mode = ble_ll_phy_to_phy_mode(aux_scan->aux_phy,
                                       BLE_HCI_LE_PHY_CODED_ANY);
-    dur = ble_ll_pdu_tx_time_get(BLE_LL_SCHED_AUX_PTR_DFLT_BYTES_NUM, phy_mode);
+    dur = ble_ll_pdu_tx_time_get(MYNEWT_VAL(BLE_LL_SCHED_SCAN_AUX_PDU_LEN),
+                                 phy_mode);
     end_time = start_time + os_cputime_usecs_to_ticks(dur);
 
     sch->start_time = start_time;

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -361,6 +361,31 @@ syscfg.defs:
             when scheduling extended or periodic advertising event. This extends
             T_MAFS.
         value: 0
+    BLE_LL_SCHED_SCAN_AUX_PDU_LEN:
+        description: >
+            This is expected PDU len for AUX_ADV_IND and subsequent
+            AUX_CHAIN_IND. When scheduling scan scheduler will reserve time for
+            receiving this amount of time. Setting this to high value improves
+            reception of large PDUs but results in wasting scheduler space when
+            receiving small PDUs only. On the other hand too low value can
+            result in not being able to scan whole PDU due to being preempted
+            by next scheduled item. By default size matching legacy ADV_IND PDU
+            payload is used: ExtHeader (Flags, AdvA, ADI) + 31 bytes of data.
+        range: 1..257
+        value: 41
+
+    BLE_LL_SCHED_SCAN_SYNC_PDU_LEN:
+        description: >
+            This is expected PDU len for AUX_SYNC_IND and subsequent
+            AUX_CHAIN_IND. When scheduling scan scheduler will reserve time for
+            receiving this amount of time. Setting this to high value improves
+            reception of large PDUs but results in wasting scheduler space when
+            receiving small PDUs only. On the other hand too low value can
+            result in not being able to scan whole PDU due to being preempted
+            by next scheduled item. By default size matching PDU with legacy
+            data size is used: ExtHeader + 31 bytes of data.
+        range: 1..257
+        value: 32
 
 # deprecated settings (to be defunct/removed eventually)
     BLE_LL_DIRECT_TEST_MODE:


### PR DESCRIPTION
This allows to tune expected PDUs length when scheduling for auxilary
or sync PDUs.