### PR TITLE
Add unittest target

### DIFF
--- a/targets/unittest/pkg.yml
+++ b/targets/unittest/pkg.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+### Package: targets/unittest
+pkg.name: "targets/unittest"
+pkg.type: "target"
+pkg.description: "Used for unit tests by the \"newt test\" command."
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+
+pkg.deps: "@apache-mynewt-core/sys/sysinit"

--- a/targets/unittest/target.yml
+++ b/targets/unittest/target.yml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+### Target: targets/unittest
+target.bsp: "@apache-mynewt-core/hw/bsp/native"
+target.build_profile: "debug"
+target.compiler: "@apache-mynewt-core/compiler/sim"


### PR DESCRIPTION
A recent newt change removed final-atom support (https://github.com/apache/mynewt-newt/pull/381); this has a side-effect that results in the "unittest" target not being found if is not located in the repo where tests are being run (it does not search for "unittest" inside @apache-mynewt-core anymore). So add the same "unittest" target that already exists in @apache-mynewt-core repo here.