### PR TITLE
nimble/host: Clear master and slave states on host reset

### DIFF
--- a/nimble/host/src/ble_gap_priv.h
+++ b/nimble/host/src/ble_gap_priv.h
@@ -136,6 +136,7 @@ void ble_gap_preempt(void);
 void ble_gap_preempt_done(void);
 
 int ble_gap_terminate_with_conn(struct ble_hs_conn *conn, uint8_t hci_reason);
+void ble_gap_reset_state(int reason);
 void ble_gap_conn_broken(uint16_t conn_handle, int reason);
 int32_t ble_gap_timer(void);
 

--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -361,7 +361,6 @@ ble_hs_sync(void)
 static int
 ble_hs_reset(void)
 {
-    uint16_t conn_handle;
     int rc;
 
     STATS_INC(ble_hs_stats, reset);
@@ -376,14 +375,8 @@ ble_hs_reset(void)
 
     ble_hs_clear_rx_queue();
 
-    while (1) {
-        conn_handle = ble_hs_atomic_first_conn_handle();
-        if (conn_handle == BLE_HS_CONN_HANDLE_NONE) {
-            break;
-        }
-
-        ble_gap_conn_broken(conn_handle, ble_hs_reset_reason);
-    }
+    /* Clear adverising and scanning states. */
+    ble_gap_reset_state(ble_hs_reset_reason);
 
     /* Clear configured addresses. */
     ble_hs_id_reset();


### PR DESCRIPTION
Added `ble_gap_reset_master_slave_states` to clear advertising and discovery states when `ble_hs_reset` is called. This PR addresses  #776 