### PR TITLE
Make connection update process timeout variable

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -88,7 +88,7 @@
 #define BLE_GAP_CANCEL_RETRY_TIMEOUT_MS         100 /* ms */
 
 #define BLE_GAP_UPDATE_TIMEOUT_MS(itvl, latency) \
-            (6 * ((itvl) * BLE_HCI_CONN_ITVL / 1000) * ((latency) + 1))
+    (6 * ((itvl) * BLE_HCI_CONN_ITVL / 1000) * ((latency) + 1))
 
 #if MYNEWT_VAL(BLE_ROLE_CENTRAL)
 static const struct ble_gap_conn_params ble_gap_conn_params_dflt = {
@@ -1185,7 +1185,7 @@ ble_gap_rx_update_complete(const struct ble_hci_ev_le_subev_conn_upd_complete *e
             entry = ble_gap_update_entry_find(conn_handle, NULL);
             if (entry != NULL && !(conn->bhc_flags & BLE_HS_CONN_F_MASTER)) {
                 ble_gap_update_to_l2cap(&entry->params, &l2cap_params);
-                
+
                 timeout = BLE_GAP_UPDATE_TIMEOUT_MS(conn->bhc_itvl,
                                                     conn->bhc_latency);
 


### PR DESCRIPTION
This is a fix for #780, an issue I submitted earlier today.  

I am connecting as a central to a remote peripheral using a connection interval of 120, latency of 90, and timeout of 3000.  Due to the hard-coded 40 second timeout, it is impossible to perform a connection parameter update on this connection.  Trying to do so results in a timeout followed by a disconnect 100% of the time.

My attempt to fix the problem is to compute the timeout based on the current connection parameters instead of just hard-coding a constant value.  