### PR TITLE
Remove notification for update process timeout.

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -1943,7 +1943,6 @@ ble_gap_update_timer(void)
         ble_hs_unlock();
 
         if (entry != NULL) {
-            ble_gap_update_notify(conn_handle, BLE_HS_ETIMEOUT);
             ble_gap_update_entry_free(entry);
         }
     } while (entry != NULL);


### PR DESCRIPTION
(This addresses issue #780, just like PR #781, which was closed due to some repo juggling on my end.)

From the original

> This is a fix for #780, an issue I submitted earlier today.  

>I am connecting as a central to a remote peripheral using a connection interval of 120, latency of 90, and timeout of 3000.  Due to the hard-coded 40 second timeout, it is impossible to perform a connection parameter update on this connection.  Trying to do so results in a timeout followed by a disconnect 100% of the time.

>My attempt to fix the problem is to compute the timeout based on the current connection parameters instead of just hard-coding a constant value.  

Based on @rymanluk's  comments to that PR, I have reduced the change to keeping the 40s timeout, but simply not posting an event should a timeout occur.
