### PR TITLE
nimble/host: Improve find conn by ble_addr_t

### DIFF
--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -327,6 +327,7 @@ ble_hs_conn_find_by_addr(const ble_addr_t *addr)
 #endif
 
     struct ble_hs_conn *conn;
+    struct ble_hs_conn_addrs addrs;
 
     BLE_HS_DBG_ASSERT(ble_hs_locked_by_cur_task());
 
@@ -341,6 +342,14 @@ ble_hs_conn_find_by_addr(const ble_addr_t *addr)
             }
         } else {
             if (ble_addr_cmp(&conn->bhc_peer_addr, addr) == 0) {
+                return conn;
+            }
+            if (conn->bhc_peer_addr.type < BLE_OWN_ADDR_RPA_PUBLIC_DEFAULT) {
+                continue;
+            }
+            /*If type 0x02 or 0x03 is used, let's double check if address is good */
+            ble_hs_conn_addrs(conn, &addrs);
+            if (ble_addr_cmp(&addrs.peer_id_addr, addr) == 0) {
                 return conn;
             }
         }


### PR DESCRIPTION
This function compares ble_addr_t and the problems starts when type 0x02
or 0x03 is used in conn

Usually it is user who should take care about the proper type, but
problem might happen when this function is called in the event of
storage overflow and we might end up with type > 0x01 in conn but we are
looking for ble_addr_t found in the storage where address is already
translated to Public or Random.

This patch fixes that.