### PR TITLE
nimble/ll: Add common setting for SCA

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -69,6 +69,29 @@ extern "C" {
 /* Timing jitter as per spec is +/16 usecs */
 #define BLE_LL_JITTER_USECS         (16)
 
+
+#if MYNEWT_VAL(BLE_LL_SCA) < 0
+#error Invalid SCA value
+#elif MYNEWT_VAL(BLE_LL_SCA) <= 20
+#define BLE_LL_SCA_ENUM     7
+#elif MYNEWT_VAL(BLE_LL_SCA) <= 30
+#define BLE_LL_SCA_ENUM     6
+#elif MYNEWT_VAL(BLE_LL_SCA) <= 50
+#define BLE_LL_SCA_ENUM     5
+#elif MYNEWT_VAL(BLE_LL_SCA) <= 75
+#define BLE_LL_SCA_ENUM     4
+#elif MYNEWT_VAL(BLE_LL_SCA) <= 100
+#define BLE_LL_SCA_ENUM     3
+#elif MYNEWT_VAL(BLE_LL_SCA) <= 150
+#define BLE_LL_SCA_ENUM     2
+#elif MYNEWT_VAL(BLE_LL_SCA) <= 250
+#define BLE_LL_SCA_ENUM     1
+#elif MYNEWT_VAL(BLE_LL_SCA) <= 500
+#define BLE_LL_SCA_ENUM     0
+#else
+#error Invalid SCA value
+#endif
+
 /* Packet queue header definition */
 STAILQ_HEAD(ble_ll_pkt_q, os_mbuf_pkthdr);
 

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -4022,7 +4022,7 @@ ble_ll_adv_periodic_send_sync_ind(struct ble_ll_adv_sm *advsm,
 
     /* SID, AType, SCA */
     sync_ind[24] = (advsm->adi >> 12);
-    sync_ind[24] |= !!(advsm->flags & BLE_LL_ADV_SM_FLAG_TX_ADD) << 4 ;
+    sync_ind[24] |= !!(advsm->flags & BLE_LL_ADV_SM_FLAG_TX_ADD) << 4;
     sync_ind[24] |= BLE_LL_SCA_ENUM << 5;
 
     /* PHY */

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -686,7 +686,7 @@ ble_ll_adv_put_syncinfo(struct ble_ll_adv_sm *advsm,
     dptr[8] = advsm->periodic_chanmap[4] & 0x1f;
 
     /* SCA (3 bits) */
-    dptr[8] |= MYNEWT_VAL(BLE_LL_MASTER_SCA) << 5;
+    dptr[8] |= BLE_LL_SCA_ENUM << 5;
 
     /* AA (4 bytes) */
     put_le32(&dptr[9], advsm->periodic_access_addr);
@@ -4023,7 +4023,7 @@ ble_ll_adv_periodic_send_sync_ind(struct ble_ll_adv_sm *advsm,
     /* SID, AType, SCA */
     sync_ind[24] = (advsm->adi >> 12);
     sync_ind[24] |= !!(advsm->flags & BLE_LL_ADV_SM_FLAG_TX_ADD) << 4 ;
-    sync_ind[24] |= MYNEWT_VAL(BLE_LL_MASTER_SCA) << 5;
+    sync_ind[24] |= BLE_LL_SCA_ENUM << 5;
 
     /* PHY */
     sync_ind[25] = (0x01 << (advsm->sec_phy - 1));

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1450,7 +1450,7 @@ ble_ll_conn_master_common_init(struct ble_ll_conn_sm *connsm)
      */
     connsm->tx_win_size = BLE_LL_CONN_TX_WIN_MIN + 1;
     connsm->tx_win_off = 0;
-    connsm->master_sca = MYNEWT_VAL(BLE_LL_MASTER_SCA);
+    connsm->master_sca = BLE_LL_SCA_ENUM;
 
     /* Hop increment is a random value between 5 and 16. */
     connsm->hop_inc = (rand() % 12) + 5;

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -2091,7 +2091,7 @@ ble_ll_sync_send_sync_ind(struct ble_ll_sync_sm *syncsm,
     if (syncsm->flags & BLE_LL_SYNC_SM_FLAG_ADDR_RESOLVED) {
         sync_ind[24] |= 1 << 4;
     } else {
-        sync_ind[24] |= (syncsm->adv_addr_type == BLE_ADDR_RANDOM) << 4 ;
+        sync_ind[24] |= (syncsm->adv_addr_type == BLE_ADDR_RANDOM) << 4;
     }
 
     sync_ind[24] |= BLE_LL_SCA_ENUM << 5;

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -2094,7 +2094,7 @@ ble_ll_sync_send_sync_ind(struct ble_ll_sync_sm *syncsm,
         sync_ind[24] |= (syncsm->adv_addr_type == BLE_ADDR_RANDOM) << 4 ;
     }
 
-    sync_ind[24] |= MYNEWT_VAL(BLE_LL_MASTER_SCA) << 5;
+    sync_ind[24] |= BLE_LL_SCA_ENUM << 5;
 
     /* PHY */
     sync_ind[25] = (0x01 << (ble_ll_sync_phy_mode_to_hci(syncsm->phy_mode) - 1));

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -292,8 +292,7 @@ ble_ll_utils_calc_window_widening(uint32_t anchor_point,
     time_since_last_anchor = (int32_t)(anchor_point - last_anchor_point);
     if (time_since_last_anchor > 0) {
         delta_msec = os_cputime_ticks_to_usecs(time_since_last_anchor) / 1000;
-        total_sca_ppm = g_ble_sca_ppm_tbl[master_sca] +
-                                          MYNEWT_VAL(BLE_LL_OUR_SCA);
+        total_sca_ppm = g_ble_sca_ppm_tbl[master_sca] + MYNEWT_VAL(BLE_LL_SCA);
         window_widening = (total_sca_ppm * delta_msec) / 1000;
     }
 

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -38,35 +38,10 @@ syscfg.defs:
         type: 'task_priority'
         value: 0
 
-    # Sleep clock accuracy (sca). This is the amount of drift in the system
-    # during when the device is sleeping (in parts per million).
-    #
-    # NOTE: 'the' master sca is an enumerated value based on the sca. Rather
-    # than have a piece of code calculate this value, the developer must set
-    # this value based on the value of the SCA using the following table:
-    #
-    #  SCA between 251 and 500 ppm (inclusive); master sca = 0
-    #  SCA between 151 and 250 ppm (inclusive); master sca = 1
-    #  SCA between 101 and 150 ppm (inclusive); master sca = 2
-    #  SCA between 76 and 100 ppm (inclusive); master sca = 3
-    #  SCA between 51 and 75 ppm (inclusive); master sca = 4
-    #  SCA between 31 and 50 ppm (inclusive); master sca = 5
-    #  SCA between 21 and 30 ppm (inclusive); master sca = 6
-    #  SCA between 0 and 20 ppm (inclusive); master sca = 7
-    #
-    #  For example:
-    #      if your clock drift is 101 ppm, your master should be set to 2.
-    #      if your clock drift is 20, your master sca should be set to 7.
-    #
-    #  The values provided below are merely meant to be an example and should
-    #  be replaced by values appropriate for your platform.
-    BLE_LL_OUR_SCA:
-        description: 'The system clock accuracy of the device.'
-        value: '60'    # in ppm
-
-    BLE_LL_MASTER_SCA:
-        description: 'Enumerated value based on our sca'
-        value: '4'
+    BLE_LL_SCA:
+        description: Sleep clock accuracy of our device (in ppm)
+        value: MYNEWT_VAL(BLE_LL_OUR_SCA)
+        range: 0..500
 
     BLE_LL_TX_PWR_DBM:
         description: 'Transmit power level.'
@@ -404,6 +379,10 @@ syscfg.defs:
         description: use BLE_LL_RFMGMT_ENABLE_TIME instead
         value: 0
         deprecated: 1
+    BLE_LL_OUR_SCA:
+        description: use BLE_LL_SCA instead
+        value: 60
+        deprecated: 1
 
 # defunct settings (to be removed eventually)
     BLE_DEVICE:
@@ -417,6 +396,10 @@ syscfg.defs:
     BLE_NUM_COMP_PKT_RATE:
         description: Superseded by BLE_LL_NUM_COMP_PKT_ITVL_MS
         value: '(2 * OS_TICKS_PER_SEC)'
+        defunct: 1
+    BLE_LL_MASTER_SCA:
+        description: use BLE_LL_SCA instead
+        value: 4
         defunct: 1
 
 

--- a/porting/npl/riot/include/syscfg/syscfg.h
+++ b/porting/npl/riot/include/syscfg/syscfg.h
@@ -980,6 +980,11 @@
 #define MYNEWT_VAL_BLE_LL_RNG_BUFSIZE (32)
 #endif
 
+/* Value copied from BLE_LL_OUR_SCA */
+#ifndef MYNEWT_VAL_BLE_LL_SCA
+#define MYNEWT_VAL_BLE_LL_SCA (60)
+#endif
+
 #ifndef MYNEWT_VAL_BLE_LL_SCHED_AUX_CHAIN_MAFS_DELAY
 #define MYNEWT_VAL_BLE_LL_SCHED_AUX_CHAIN_MAFS_DELAY (0)
 #endif


### PR DESCRIPTION
Currently we have two separate SCA settings: actual SCA as ppm value and
enumerated one based on ranges of SCA value. This means user needs to
update both values and they ideally should be in sync.

To make our life easier, we can just have single BLE_LL_SCA setting to
provide ppm value and enumerated one can be easily determined at build
time.