### PR TITLE
Prevent storing of CCCD's if peer is not bonded.

### DIFF
--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1678,28 +1678,29 @@ ble_gatts_bonding_established(uint16_t conn_handle)
 
     conn = ble_hs_conn_find(conn_handle);
     BLE_HS_DBG_ASSERT(conn != NULL);
-    BLE_HS_DBG_ASSERT(conn->bhc_sec_state.bonded);
 
-    cccd_value.peer_addr = conn->bhc_peer_addr;
-    cccd_value.peer_addr.type =
-        ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);
-    gatt_srv = &conn->bhc_gatt_svr;
+    if(conn->bhc_sec_state.bonded) {
+        cccd_value.peer_addr = conn->bhc_peer_addr;
+        cccd_value.peer_addr.type =
+            ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);
+        gatt_srv = &conn->bhc_gatt_svr;
 
-    for (i = 0; i < gatt_srv->num_clt_cfgs; ++i) {
-        clt_cfg = &gatt_srv->clt_cfgs[i];
+        for (i = 0; i < gatt_srv->num_clt_cfgs; ++i) {
+            clt_cfg = &gatt_srv->clt_cfgs[i];
 
-        if (clt_cfg->flags != 0) {
-            cccd_value.chr_val_handle = clt_cfg->chr_val_handle;
-            cccd_value.flags = clt_cfg->flags;
-            cccd_value.value_changed = 0;
+            if (clt_cfg->flags != 0) {
+                cccd_value.chr_val_handle = clt_cfg->chr_val_handle;
+                cccd_value.flags = clt_cfg->flags;
+                cccd_value.value_changed = 0;
 
-            /* Store write use ble_hs_lock */
-            ble_hs_unlock();
-            ble_store_write_cccd(&cccd_value);
-            ble_hs_lock();
+                /* Store write use ble_hs_lock */
+                ble_hs_unlock();
+                ble_store_write_cccd(&cccd_value);
+                ble_hs_lock();
 
-            conn = ble_hs_conn_find(conn_handle);
-            BLE_HS_DBG_ASSERT(conn != NULL);
+                conn = ble_hs_conn_find(conn_handle);
+                BLE_HS_DBG_ASSERT(conn != NULL);
+            }
         }
     }
 

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1679,7 +1679,7 @@ ble_gatts_bonding_established(uint16_t conn_handle)
     conn = ble_hs_conn_find(conn_handle);
     BLE_HS_DBG_ASSERT(conn != NULL);
 
-    if(conn->bhc_sec_state.bonded) {
+    if (conn->bhc_sec_state.bonded) {
         cccd_value.peer_addr = conn->bhc_peer_addr;
         cccd_value.peer_addr.type =
             ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);


### PR DESCRIPTION
Currently a peer that we have paired with but not bonded will have it's
CCCD status stored. We should not store CCCD data unless bonded,
this will prevent that.

#788 