### PR TITLE
add deprecation message for ble store package

### DIFF
--- a/nimble/host/store/ram/include/store/ram/ble_store_ram.h
+++ b/nimble/host/store/ram/include/store/ram/ble_store_ram.h
@@ -17,6 +17,11 @@
  * under the License.
  */
 
+/* This package has been deprecated and you should
+ * use the store/config package. For a RAM-only BLE store,
+ * use store/config and set BLE_STORE_CONFIG_PERSIST to 0.
+ */
+
 #ifndef H_BLE_STORE_RAM_
 #define H_BLE_STORE_RAM_
 

--- a/nimble/host/store/ram/src/ble_store_ram.c
+++ b/nimble/host/store/ram/src/ble_store_ram.c
@@ -23,6 +23,11 @@
  * contents are lost when the application terminates.
  */
 
+/* This package has been deprecated and you should
+ * use the store/config package. For a RAM-only BLE store,
+ * use store/config and set BLE_STORE_CONFIG_PERSIST to 0.
+ */
+
 #include <inttypes.h>
 #include <string.h>
 


### PR DESCRIPTION
While the message is available in the package description it is not in the sources
so anyone using Nimble as a library without reading the newt metadata would miss
this information for sure.