### PR TITLE
nimble/store: Make it clear store/ram is deprecated

### DIFF
--- a/nimble/host/store/ram/syscfg.yml
+++ b/nimble/host/store/ram/syscfg.yml
@@ -20,4 +20,13 @@ syscfg.defs:
         description: >
             Sysinit stage for the RAM BLE store.
         value: 500
+    BLE_STORE_RAM_DEPRECATED_FLAG:
+        description: >
+            Package store/ram is deprecated and store/config shall be used with BLE_STORE_CONFIG_PERSIST set to 0
+        value: 0
+        deprecated: 1
+
+
+syscfg.vals:
+    BLE_STORE_RAM_DEPRECATED_FLAG: 1
 


### PR DESCRIPTION
With this patch when store/ram is used then new will warn about it:

2020/04/21 15:51:21.077 [WARNING] Use of deprecated setting BLE_STORE_RAM_DEPRECATED_FLAG in @apache-mynewt-nimble/nimble/host/store/ram: Package store/ram is deprecated and store/config shall be used with BLE_STORE_CONFIG_PERSIST set to 0