### PR TITLE
WIP: use port dependent macros instead of FreeRTOS functions

### DIFF
--- a/porting/npl/freertos/include/nimble/nimble_npl_os.h
+++ b/porting/npl/freertos/include/nimble/nimble_npl_os.h
@@ -281,15 +281,20 @@ ble_npl_hw_set_isr(int irqn, void (*addr)(void))
 static inline uint32_t
 ble_npl_hw_enter_critical(void)
 {
-    vPortEnterCritical();
+    portENTER_CRITICAL();
     return 0;
 }
 
 static inline void
 ble_npl_hw_exit_critical(uint32_t ctx)
 {
-    vPortExitCritical();
+    portEXIT_CRITICAL();
+}
 
+static inline bool
+ble_npl_hw_is_in_critical(uint32_t ctx)
+{
+    return portIS_IN_CRITIAL();
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Management of critical section is done through a combination of the FreeRTOS
API and port dependent configuration.

Most of the time the port uses critical section management exposed by FreeRTOS by
defining as such

```C
extern void vPortEnterCritical(void);
#define portENTER_CRITICAL()     vPortEnterCritical();
...
```

Moreover FreeRTOS does not expose an API for critical section detection
as it is port dependent. This will rely on the macro `portIS_IN_CRITICAL` that
a port should implement when using nimble in conjunction with FreeRTOS.