### PR TITLE
nimble/hs: Fix flow control

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -673,7 +673,7 @@ ble_hs_rx_data(struct os_mbuf *om, void *arg)
     /* If flow control is enabled, mark this packet with its corresponding
      * connection handle.
      */
-    ble_hs_flow_fill_acl_usrhdr(om);
+    ble_hs_flow_track_data_mbuf(om);
 
     rc = ble_mqueue_put(&ble_hs_rx_q, ble_hs_evq, om);
     if (rc != 0) {

--- a/nimble/host/src/ble_hs_flow_priv.h
+++ b/nimble/host/src/ble_hs_flow_priv.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 void ble_hs_flow_connection_broken(uint16_t conn_handle);
-void ble_hs_flow_fill_acl_usrhdr(struct os_mbuf *om);
+void ble_hs_flow_track_data_mbuf(struct os_mbuf *om);
 int ble_hs_flow_startup(void);
 
 #ifdef __cplusplus

--- a/nimble/transport/emspi/src/ble_hci_emspi.c
+++ b/nimble/transport/emspi/src/ble_hci_emspi.c
@@ -295,15 +295,7 @@ done:
 static struct os_mbuf *
 ble_hci_trans_acl_buf_alloc(void)
 {
-    uint8_t usrhdr_len;
-
-#if MYNEWT_VAL(BLE_HS_FLOW_CTRL)
-    usrhdr_len = BLE_MBUF_HS_HDR_LEN;
-#else
-    usrhdr_len = 0;
-#endif
-
-    return os_mbuf_get_pkthdr(&ble_hci_emspi_acl_mbuf_pool, usrhdr_len);
+    return os_mbuf_get_pkthdr(&ble_hci_emspi_acl_mbuf_pool, 0);
 }
 
 /**

--- a/nimble/transport/uart/src/ble_hci_uart.c
+++ b/nimble/transport/uart/src/ble_hci_uart.c
@@ -195,8 +195,6 @@ ble_hci_trans_acl_buf_alloc(void)
 
 #if MYNEWT_VAL(BLE_CONTROLLER)
     usrhdr_len = sizeof(struct ble_mbuf_hdr);
-#elif MYNEWT_VAL(BLE_HS_FLOW_CTRL)
-    usrhdr_len = BLE_MBUF_HS_HDR_LEN;
 #else
     usrhdr_len = 0;
 #endif


### PR DESCRIPTION
Current implementation of hs flow control uses mbuf user header to
associate mbuf with a connection handle. This unfortunately does not
work well in most cases.

One major problem is that host can reassemble data. This is done by
os_mbuf_concat() which strips packet header from 2nd mbuf and this
means we basically lose connection handle information.

While this problem can be worked around by some extra mbuf counting,
another way to lose connection handle information is to basically pass
received buffer to application. For example, OIC uses user header for
own purposes so it will either overwrite connection handle information
(if our user header is large enough for OIC) or strip our packet header
if it decides to use own mbuf for packet header.

So it's better not to rely on user header to track store connection
handle information. This patch uses a simple private array to store
connection handle for each mbuf - array is indexed by mbuf index in a
mempool. This is a bit of a hack since index of an mbuf in a mempool
has to be calculated using mempool buffer address and block size, but
I do not really see any simple alternative here.