### PR TITLE
l2cap/coc: make ble_l2cap_coc_continue_tx() thread safe

### DIFF
--- a/nimble/host/src/ble_l2cap_coc.c
+++ b/nimble/host/src/ble_l2cap_coc.c
@@ -469,12 +469,12 @@ ble_l2cap_coc_continue_tx(struct ble_l2cap_chan *chan)
             txom = NULL;
             goto failed;
         } else {
-            tx->credits --;
+            tx->credits--;
             tx->data_offset += len - sdu_size_offset;
         }
 
         BLE_HS_LOG(DEBUG, "Sent %d bytes, credits=%d, to send %d bytes \n",
-                  len, tx->credits, OS_MBUF_PKTLEN(tx->sdu)- tx->data_offset );
+                  len, tx->credits, OS_MBUF_PKTLEN(tx->sdu)- tx->data_offset);
 
         if (tx->data_offset == OS_MBUF_PKTLEN(tx->sdu)) {
             BLE_HS_LOG(DEBUG, "Complete package sent\n");

--- a/nimble/host/src/ble_l2cap_coc.c
+++ b/nimble/host/src/ble_l2cap_coc.c
@@ -403,9 +403,12 @@ ble_l2cap_coc_continue_tx(struct ble_l2cap_chan *chan)
     uint16_t sdu_size_offset;
     int rc;
 
+    ble_hs_lock();
+
     /* If there is no data to send, just return success */
     tx = &chan->coc_tx;
     if (!tx->sdu) {
+        ble_hs_unlock();
         return 0;
     }
 
@@ -458,10 +461,8 @@ ble_l2cap_coc_continue_tx(struct ble_l2cap_chan *chan)
             goto failed;
         }
 
-        ble_hs_lock();
         conn = ble_hs_conn_find_assert(chan->conn_handle);
         rc = ble_l2cap_tx(conn, chan, txom);
-        ble_hs_unlock();
 
         if (rc) {
           /* txom is consumed by l2cap */
@@ -491,14 +492,18 @@ ble_l2cap_coc_continue_tx(struct ble_l2cap_chan *chan)
     if (tx->sdu) {
         /* Not complete SDU sent, wait for credits */
         tx->flags |= BLE_L2CAP_COC_FLAG_STALLED;
+        ble_hs_unlock();
         return BLE_HS_ESTALLED;
     }
 
+    ble_hs_unlock();
     return 0;
 
 failed:
     os_mbuf_free_chain(tx->sdu);
     tx->sdu = NULL;
+    ble_hs_unlock();
+
     os_mbuf_free_chain(txom);
     if (tx->flags & BLE_L2CAP_COC_FLAG_STALLED) {
         ble_l2cap_event_coc_unstalled(chan, rc);

--- a/nimble/host/src/ble_l2cap_coc.c
+++ b/nimble/host/src/ble_l2cap_coc.c
@@ -465,9 +465,9 @@ ble_l2cap_coc_continue_tx(struct ble_l2cap_chan *chan)
         rc = ble_l2cap_tx(conn, chan, txom);
 
         if (rc) {
-          /* txom is consumed by l2cap */
-          txom = NULL;
-          goto failed;
+            /* txom is consumed by l2cap */
+            txom = NULL;
+            goto failed;
         } else {
             tx->credits --;
             tx->data_offset += len - sdu_size_offset;
@@ -477,15 +477,15 @@ ble_l2cap_coc_continue_tx(struct ble_l2cap_chan *chan)
                   len, tx->credits, OS_MBUF_PKTLEN(tx->sdu)- tx->data_offset );
 
         if (tx->data_offset == OS_MBUF_PKTLEN(tx->sdu)) {
-                BLE_HS_LOG(DEBUG, "Complete package sent\n");
-                os_mbuf_free_chain(tx->sdu);
-                tx->sdu = 0;
-                tx->data_offset = 0;
-                if (tx->flags & BLE_L2CAP_COC_FLAG_STALLED) {
-                    ble_l2cap_event_coc_unstalled(chan, 0);
-                    tx->flags &= ~BLE_L2CAP_COC_FLAG_STALLED;
-                }
-                break;
+            BLE_HS_LOG(DEBUG, "Complete package sent\n");
+            os_mbuf_free_chain(tx->sdu);
+            tx->sdu = NULL;
+            tx->data_offset = 0;
+            if (tx->flags & BLE_L2CAP_COC_FLAG_STALLED) {
+                ble_l2cap_event_coc_unstalled(chan, 0);
+                tx->flags &= ~BLE_L2CAP_COC_FLAG_STALLED;
+            }
+            break;
         }
     }
 


### PR DESCRIPTION
When debugging my favorite L2CAP throughput issues (#818, #373), I sometimes noticed some packets being dropped. In these (mostly rare) cases `l2cap_send()` returned `BLE_HS_ENOMEM` even though there was sufficient space in the used `msys` mbuf pool. 

Looking into this, I found that in `ble_l2cap_coc_continue_tx()` the `chan->coc_tx->data_offset` value as well as the value for `OS_MBUF_PKTLEN(tx->sdu)` were corrupted, leading `os_mbuf_appendfrom()` fail.

See the commit description for my explanation for this:
```
ble_l2cap_coc_continue_tx() is executed in different tasks: it is
(i) called from ble_l2cap_coc_send() in one or more different task
contexts from user application(s) and (ii) called from
ble_l2cap_coc_le_credits_update() from the NimBLE host task.
Typically, the host task has a higher priority then the user tasks,
so that ble_l2cap_coc_continue_tx() can be interrupted by itself.
This leads to potentially inconsistent state for
`chan->coc_tx->credits` and `chan->coc_tx->data_offset`, consequently
leading to dropped packets.
This commit fixes this by putting all the code code working on these
variables into a critical section.
```

This solution feels a little bit brute force, but I could not think of anything else to make `ble_l2cap_coc_continue_tx()` thread safe. My initial idea was to put an event into the hosts event queue from `ble_l2cap_coc_send()`, instead of calling `ble_l2cap_coc_continue_tx()` directly. But then we would need to allocate an event for each l2cap channel. But more severe we would not be able to synchronously pass the return code of `ble_l2cap_coc_continue_tx()` to `ble_l2cap_coc_send()`. So it seemed to me locking the host for the duration of `ble_l2cap_coc_continue_tx()` is the easier path?!

