### PR TITLE
porting: rm store_ram_init from nimble_port_run()

### DIFF
--- a/porting/nimble/src/nimble_port.c
+++ b/porting/nimble/src/nimble_port.c
@@ -32,7 +32,7 @@ void
 nimble_port_init(void)
 {
     void os_msys_init(void);
-    void ble_store_ram_init(void);
+
 #if NIMBLE_CFG_CONTROLLER
     void ble_hci_ram_init(void);
 #endif
@@ -43,9 +43,6 @@ nimble_port_init(void)
     os_msys_init();
 
     ble_hs_init();
-
-    /* XXX Need to have template for store */
-    ble_store_ram_init();
 
 #if NIMBLE_CFG_CONTROLLER
     hal_timer_init(5, NULL);


### PR DESCRIPTION
Please correct me if I'm wrong: to the best of my knowledge, the `ble_store_ram` module is never used, so no need to initialize it. At least a `git grep` did not return any calls to this module and all my GATT and IP-over-BLE examples run just fine without it...