### PR TITLE
porting: cleanup porting_init()

### DIFF
--- a/porting/nimble/src/nimble_port.c
+++ b/porting/nimble/src/nimble_port.c
@@ -24,31 +24,28 @@
 #include "nimble/nimble_port.h"
 #if NIMBLE_CFG_CONTROLLER
 #include "controller/ble_ll.h"
+#include "transport/ram/ble_hci_ram.h"
 #endif
 
 static struct ble_npl_eventq g_eventq_dflt;
 
+extern void os_msys_init(void);
+
 void
 nimble_port_init(void)
 {
-    void os_msys_init(void);
-
-#if NIMBLE_CFG_CONTROLLER
-    void ble_hci_ram_init(void);
-#endif
-
     /* Initialize default event queue */
     ble_npl_eventq_init(&g_eventq_dflt);
-
+    /* Initialize the global memory pool */
     os_msys_init();
-
+    /* Initialize the host */
     ble_hs_init();
 
 #if NIMBLE_CFG_CONTROLLER
+    ble_hci_ram_init();
     hal_timer_init(5, NULL);
     os_cputime_init(32768);
     ble_ll_init();
-    ble_hci_ram_init();
 #endif
 }
 


### PR DESCRIPTION
- code simplification
- add some more comments
- call ble_hci_ram_init() before ble_ll_init() to make sure the
  buffers are intialized before they are potentially used