### PR TITLE
Allow BLE_ROLE_OBSERVER without BLE_ROLE_CENTRAL or BLE_EXT_ADV

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -998,7 +998,7 @@ ble_gap_update_next_exp(int32_t *out_ticks_from_now)
 
 }
 
-#if MYNEWT_VAL(BLE_ROLE_CENTRAL) || MYNEWT_VAL(BLE_ROLE_OBSERVER)
+#if NIMBLE_BLE_SCAN
 static void
 ble_gap_master_set_timer(uint32_t ticks_from_now)
 {

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -998,7 +998,7 @@ ble_gap_update_next_exp(int32_t *out_ticks_from_now)
 
 }
 
-#if MYNEWT_VAL(BLE_ROLE_CENTRAL)
+#if MYNEWT_VAL(BLE_ROLE_CENTRAL) || MYNEWT_VAL(BLE_ROLE_OBSERVER)
 static void
 ble_gap_master_set_timer(uint32_t ticks_from_now)
 {


### PR DESCRIPTION
If BLE_ROLE_OBSERVER is set, but neither BLE_ROLE_CENTRAL or BLE_EXT_ADV is set, the build fails with a missing ble_gap_master_set_timer. This adds BLE_ROLE_OBSERVER to the list for ble_gap_master_set_timer