### PR TITLE
nimble/porting: Explicitly NULL terminate string buffer after using strncpy.

### DIFF
--- a/porting/nimble/src/os_mempool.c
+++ b/porting/nimble/src/os_mempool.c
@@ -336,7 +336,8 @@ os_mempool_info_get_next(struct os_mempool *mp, struct os_mempool_info *omi)
     omi->omi_num_blocks = cur->mp_num_blocks;
     omi->omi_num_free = cur->mp_num_free;
     omi->omi_min_free = cur->mp_min_free;
-    strncpy(omi->omi_name, cur->name, sizeof(omi->omi_name));
+    strncpy(omi->omi_name, cur->name, sizeof(omi->omi_name) - 1);
+    omi->omi_name[sizeof(omi->omi_name) - 1] = '\0';
 
     return (cur);
 }


### PR DESCRIPTION
os_mempool.c: Using `strncpy`, buffer will not be `NULL` terminated if size of source string is same as the buffer size. Hence relpace `strncpy` with `strlcpy`.