### PR TITLE
Fix big-endian serialization issues

### DIFF
--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -1360,7 +1360,7 @@ done:
         *att_err = 0;
 
         /* Fill the response base. */
-        rsp->batp_length = htole16(sizeof(*data) + prev_attr_len);
+        rsp->batp_length = sizeof(*data) + prev_attr_len;
     }
 
     *out_txom = txom;

--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -447,8 +447,8 @@ ble_hs_hci_acl_hdr_prepend(struct os_mbuf *om, uint16_t handle,
     struct hci_data_hdr hci_hdr;
     struct os_mbuf *om2;
 
-    hci_hdr.hdh_handle_pb_bc =
-        ble_hs_hci_util_handle_pb_bc_join(handle, pb_flag, 0);
+    put_le16(&hci_hdr.hdh_handle_pb_bc,
+             ble_hs_hci_util_handle_pb_bc_join(handle, pb_flag, 0));
     put_le16(&hci_hdr.hdh_len, OS_MBUF_PKTHDR(om)->omp_len);
 
     om2 = os_mbuf_prepend(om, sizeof hci_hdr);


### PR DESCRIPTION
I have been porting NimBLE to a big endian system, and found two endianness issues: one missing cpu to le, and a `htole16` on a `uint8_t` value.

First PR related to #847.