### PR TITLE
apps/blestress - compilation error

### DIFF
--- a/apps/blestress/src/stress.c
+++ b/apps/blestress/src/stress.c
@@ -19,6 +19,8 @@
 
 #include "stress.h"
 
+static struct os_callout stress_timer_callout;
+
 void
 com_stress_print_report(const struct com_stress_test_ctx *test_ctxs)
 {
@@ -176,6 +178,7 @@ void
 stress_start_timer(uint32_t timeout_ms, os_event_fn *ev_cb)
 {
     int rc;
+
     os_callout_stop(&stress_timer_callout);
 
     os_callout_init(&stress_timer_callout, os_eventq_dflt_get(), ev_cb, NULL);

--- a/apps/blestress/src/stress.h
+++ b/apps/blestress/src/stress.h
@@ -45,7 +45,6 @@ extern "C" {
 #define STRESS_FIND_CHR 2
 #define STRESS_FIND_DSC 3
 
-struct os_callout stress_timer_callout;
 struct stress_gatt_search_ctx;
 typedef void stress_gatt_disc_end_fn(struct stress_gatt_search_ctx *search_ctx);
 


### PR DESCRIPTION
Building the app returned error: multiple definition of `stress_timer_callout'. Moving the it's declaration to stress.c fixes the issue - this structure is only used there.