### PR TITLE
Rework `os_membuf_t` definition + add CHERI support

### DIFF
--- a/porting/nimble/include/os/os_mempool.h
+++ b/porting/nimble/include/os/os_mempool.h
@@ -147,13 +147,16 @@ struct os_mempool *os_mempool_info_get_next(struct os_mempool *,
  * is NOT in bytes! The size is the number of os_membuf_t elements required for
  * the memory pool.
  */
-#if (OS_CFG_ALIGNMENT == OS_CFG_ALIGN_4)
-#define OS_MEMPOOL_SIZE(n,blksize)      ((((blksize) + 3) / 4) * (n))
+#if (OS_ALIGNMENT == 4)
 typedef uint32_t os_membuf_t;
-#else
-#define OS_MEMPOOL_SIZE(n,blksize)      ((((blksize) + 7) / 8) * (n))
+#elif (OS_ALIGNMENT == 8)
 typedef uint64_t os_membuf_t;
-#endif
+#elif (OS_ALIGNMENT == 16)
+typedef __uint128_t os_membuf_t;
+#else
+#error "Unhandled `OS_ALIGNMENT` for `os_membuf_t`"
+#endif /* OS_ALIGNMENT == * */
+#define OS_MEMPOOL_SIZE(n,blksize)      ((((blksize) + ((OS_ALIGNMENT)-1)) / (OS_ALIGNMENT)) * (n))
 
 /** Calculates the number of bytes required to initialize a memory pool. */
 #define OS_MEMPOOL_BYTES(n,blksize)     \


### PR DESCRIPTION
Use `OS_ALIGNMENT` as everywhere else in the code, instead of `OS_CFG_ALIGNMENT`.
Also adds CHERI-support, which has 128-bit pointers.

I am not sure where `OS_CFG_ALIGNMENT`/`OS_CFG_ALIGN_4` were supposed to be defined (maybe some mynewt definitions?), but we have `OS_ALIGNMENT` for this.

Part of #847.