### PR TITLE
apps/blestress - test 10 (L2CAP) fix

### DIFF
--- a/apps/blestress/src/rx_stress.c
+++ b/apps/blestress/src/rx_stress.c
@@ -1365,7 +1365,7 @@ rx_stress_start(int test_num)
         break;
     case 10:
         console_printf("Stress L2CAP send\033[0m\n");
-        rc = ble_l2cap_create_server(1, STRESS_COC_MTU,
+        rc = ble_l2cap_create_server(TEST_PSM, STRESS_COC_MTU,
                                      rx_stress_10_l2cap_event, NULL);
         assert(rc == 0);
         rx_stress_simple_adv(&rx_stress_adv_sets[10]);

--- a/apps/blestress/src/rx_stress.c
+++ b/apps/blestress/src/rx_stress.c
@@ -837,14 +837,6 @@ rx_stress_10_l2cap_event(struct ble_l2cap_event *event, void *arg)
     MODLOG_DFLT(INFO, "Data buf %s\n", data_buf ? "OK" : "NOK");
     assert(data_buf != NULL);
 
-    /* The first 2 bytes of data is the size of appended pattern data. */
-    rc = os_mbuf_append(data_buf, (uint8_t[]) {data_len >> 8, data_len},
-                        2);
-    if (rc) {
-        os_mbuf_free_chain(data_buf);
-        assert(0);
-    }
-
     /* Fill mbuf with the pattern */
     stress_fill_mbuf_with_pattern(data_buf, data_len);
 

--- a/apps/blestress/src/stress.c
+++ b/apps/blestress/src/stress.c
@@ -119,7 +119,7 @@ stress_fill_mbuf_with_pattern(struct os_mbuf *om, uint16_t len)
     rest = len % STRESS_PAT_LEN;
 
     for (i = 0; i < mul; ++i) {
-        rc = os_mbuf_append(om, &test_6_pattern[29], STRESS_PAT_LEN);
+        rc = os_mbuf_append(om, &test_6_pattern[0], STRESS_PAT_LEN);
 
         if (rc) {
             os_mbuf_free_chain(om);
@@ -127,7 +127,7 @@ stress_fill_mbuf_with_pattern(struct os_mbuf *om, uint16_t len)
         }
     }
 
-    rc = os_mbuf_append(om, &test_6_pattern[29], rest);
+    rc = os_mbuf_append(om, &test_6_pattern[0], rest);
 
     if (rc) {
         os_mbuf_free_chain(om);

--- a/apps/blestress/src/stress.h
+++ b/apps/blestress/src/stress.h
@@ -44,6 +44,8 @@ extern "C" {
 #define STRESS_FIND_SRV 1
 #define STRESS_FIND_CHR 2
 #define STRESS_FIND_DSC 3
+/* L2CAP PSM */
+#define TEST_PSM 0x80
 
 struct os_callout stress_timer_callout;
 struct stress_gatt_search_ctx;

--- a/apps/blestress/src/tx_stress.c
+++ b/apps/blestress/src/tx_stress.c
@@ -1127,7 +1127,7 @@ tx_stress_10_gap_event(struct ble_gap_event *event, void *arg)
             assert(sdu_rx != NULL);
 
             tx_stress_ctx->conn_handle = event->connect.conn_handle;
-            rc = ble_l2cap_connect(event->connect.conn_handle, 1,
+            rc = ble_l2cap_connect(event->connect.conn_handle, TEST_PSM,
                                    STRESS_COC_MTU, sdu_rx,
                                    tx_stress_10_l2cap_event, NULL);
             assert(rc == 0);


### PR DESCRIPTION
In this test L2CAP frames are badly send and/or formed. Changes contain:
- switch from PSM = 1 to PSM = 0x80 (128) - from dynamic range
- in `stress_fill_mbuf_with_pattern()` filling mbuf begins at start of pattern
  buffer, as the full length of that buffer if being copied
- removed appending length of pattern data, as that is performed either way
  by functions called by l2cap API