### PR TITLE
apps/blestress: error correction

### DIFF
--- a/apps/blestress/src/rx_stress.c
+++ b/apps/blestress/src/rx_stress.c
@@ -844,8 +844,13 @@ rx_stress_10_l2cap_event(struct ble_l2cap_event *event, void *arg)
     rc = ble_l2cap_send(rx_stress_ctx->chan, data_buf);
     MODLOG_DFLT(INFO, "Return code=%d\n", rc);
     if (rc) {
-        MODLOG_DFLT(INFO, "L2CAP stalled - waiting\n");
-        stalled = true;
+        if (rc == BLE_HS_ESTALLED) {
+            MODLOG_DFLT(INFO, "L2CAP stalled - waiting\n");
+            stalled = true;
+        } else {
+            MODLOG_DFLT(INFO, "Sending data via L2CAP failed with error "
+                        "code %d\n", rc);
+        }
     }
 
     MODLOG_DFLT(INFO, " %d, %d\n", ++send_cnt, data_len);


### PR DESCRIPTION
Failed sending data via L2CAP in test 10 was always assumed to be
BLE_HS_ESTALLED error, and it's not always the case.