### PR TITLE
NimBLE host: Change min/max macros to inline functions for C++

### DIFF
--- a/porting/nimble/include/os/os.h
+++ b/porting/nimble/include/os/os.h
@@ -24,14 +24,28 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
 
+inline int
+max(int a, int b)
+{
+    return((a) > (b) ? a : b);
+}
+
+inline int
+min(int a, int b)
+{
+    return((a) < (b) ? a : b);
+}
+
+#else
 #ifndef min
-#define min(a, b) ((a)<(b)?(a):(b))
+#define min(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
 #ifndef max
-#define max(a, b) ((a)>(b)?(a):(b))
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #endif
 
 #include "syscfg/syscfg.h"


### PR DESCRIPTION
In case of C++ project, the min/max macros defined in `porting/nimble/include/os/os.h` can cause compilation error if the C++ project also has min/max function definition in namespace/template. This issue happens because these min/max macros will simply replace the function definition in other part of code during preprocessing. The error seen for me is as below:
```
error: expected unqualified-id before 'const'
 inline const _T & min(const _T & a, const _T & b)
                       ^~~~~
/esp-idf/components/bt/host/nimble/nimble/porting/nimble/include/os/os.h:30:21: note: in definition of macro 'min'
 #define min(a, b) ((a)<(b)?(a):(b))
```  
Reference for solution: https://stackoverflow.com/a/51642531/6100298