### PR TITLE
ble_store_config: building error if BLE_STORE_CONFIG_PERSIST set to 0

### DIFF
--- a/nimble/host/store/config/src/ble_store_config.c
+++ b/nimble/host/store/config/src/ble_store_config.c
@@ -23,7 +23,9 @@
 #include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "host/ble_hs.h"
+#ifdef BLE_STORE_CONFIG_PERSIST
 #include "config/config.h"
+#endif
 #include "base64/base64.h"
 #include "store/config/ble_store_config.h"
 #include "ble_store_config_priv.h"


### PR DESCRIPTION
As apache-mynewt-core/sys/config is dependency of
BLE_STORE_CONFIG_PERSIST, it should only be included when
BLE_STORE_CONFIG_PERSIST is set to 1, preventing build errors.