### PR TITLE
nimble/ble_gap: adv_enable_tx preprocessor directives corrections

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -930,7 +930,7 @@ ble_gap_master_ticks_until_exp(void)
     return 0;
 }
 
-#if !MYNEWT_VAL(BLE_EXT_ADV)
+#if NIMBLE_BLE_ADVERTISE && !MYNEWT_VAL(BLE_EXT_ADV)
 static uint32_t
 ble_gap_slave_ticks_until_exp(void)
 {
@@ -1941,7 +1941,7 @@ ble_gap_master_timer(void)
     return BLE_HS_FOREVER;
 }
 
-#if !MYNEWT_VAL(BLE_EXT_ADV)
+#if NIMBLE_BLE_ADVERTISE && !MYNEWT_VAL(BLE_EXT_ADV)
 static int32_t
 ble_gap_slave_timer(void)
 {
@@ -2040,7 +2040,7 @@ ble_gap_timer(void)
 
     min_ticks = min(master_ticks, update_ticks);
 
-#if !MYNEWT_VAL(BLE_EXT_ADV)
+#if NIMBLE_BLE_ADVERTISE && !MYNEWT_VAL(BLE_EXT_ADV)
     min_ticks = min(min_ticks, ble_gap_slave_timer());
 #endif
 


### PR DESCRIPTION
There wher compilation errors for blecent if NIMBLE_BLE_ADVERTISE was
not set. Appropriate preprocessor if conditions where added.

This fixes https://github.com/apache/mynewt-nimble/issues/833