### PR TITLE
controller/phy: mark ununsed var in ble_phy.h

### DIFF
--- a/nimble/controller/include/controller/ble_phy.h
+++ b/nimble/controller/include/controller/ble_phy.h
@@ -225,6 +225,8 @@ static inline int ble_ll_phy_to_phy_mode(int phy, int phy_options)
     if (phy == BLE_PHY_CODED && phy_options == BLE_HCI_LE_PHY_CODED_S2_PREF) {
         phy_mode = BLE_PHY_MODE_CODED_500KBPS;
     }
+#else
+    (void)phy_options;
 #endif
 
     return phy_mode;


### PR DESCRIPTION
My compiler was angry at me for that one little unused parameter...

Fixing this one line did also enable me to build NimBLE with RIOTs default gcc configuration (removing the `#   CFLAGS += -Wno-unused-but-set-variable` from the packages Makefile).