### PR TITLE
nimble/ll: Use true RNG instead of rand

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -574,6 +574,7 @@ void ble_ll_rand_sample(uint8_t rnum);
 int ble_ll_rand_data_get(uint8_t *buf, uint8_t len);
 void ble_ll_rand_prand_get(uint8_t *prand);
 int ble_ll_rand_start(void);
+int ble_ll_rand(void);
 
 static inline int
 ble_ll_get_addr_type(uint8_t txrxflag)

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1535,7 +1535,6 @@ ble_ll_init(void)
     uint64_t features;
     ble_addr_t addr;
     struct ble_ll_obj *lldata;
-    unsigned seed;
 
     /* Ensure this function only gets called by sysinit. */
     SYSINIT_ASSERT_ACTIVE();
@@ -1670,10 +1669,6 @@ ble_ll_init(void)
     ble_ll_rand_init();
     /* Start the random number generator */
     ble_ll_rand_start();
-    /* Use the random number generator to seed the STDLIBs pseudo-number
-     * generator */
-    ble_ll_rand_data_get((uint8_t *)&seed, sizeof(seed));
-    srand(seed);
 
     rc = stats_init_and_reg(STATS_HDR(ble_ll_stats),
                             STATS_SIZE_INIT_PARMS(ble_ll_stats, STATS_SIZE_32),

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -1379,7 +1379,7 @@ ble_ll_adv_aux_calculate(struct ble_ll_adv_sm *advsm,
                                            g_ble_ll_conn_params.num_used_chans,
                                            g_ble_ll_conn_params.master_chan_map);
 #else
-    aux->chan = ble_ll_utils_remapped_channel(rand() % BLE_PHY_NUM_DATA_CHANS,
+    aux->chan = ble_ll_utils_remapped_channel(ble_ll_rand() % BLE_PHY_NUM_DATA_CHANS,
                                               g_ble_ll_conn_params.master_chan_map);
 #endif
 
@@ -1856,7 +1856,7 @@ ble_ll_adv_update_did(struct ble_ll_adv_sm *advsm)
      * the previously used value.
      */
     do {
-        advsm->adi = (advsm->adi & 0xf000) | (rand() & 0x0fff);
+        advsm->adi = (advsm->adi & 0xf000) | (ble_ll_rand() & 0x0fff);
     } while (old_adi == advsm->adi);
 }
 #endif
@@ -2547,11 +2547,11 @@ ble_ll_adv_sm_start_periodic(struct ble_ll_adv_sm *advsm)
     advsm->periodic_num_used_chans = g_ble_ll_conn_params.num_used_chans;
     advsm->periodic_event_cntr = 0;
     /* for chaining we start with random counter as we share access addr */
-    advsm->periodic_chain_event_cntr = rand();
+    advsm->periodic_chain_event_cntr = ble_ll_rand();
     advsm->periodic_access_addr = ble_ll_utils_calc_access_addr();
     advsm->periodic_channel_id = ((advsm->periodic_access_addr & 0xffff0000) >> 16) ^
                                  (advsm->periodic_access_addr & 0x0000ffff);
-    advsm->periodic_crcinit = rand() & 0xffffff;
+    advsm->periodic_crcinit = ble_ll_rand() & 0xffffff;
 
     usecs = (uint32_t)advsm->periodic_adv_itvl_max * BLE_LL_ADV_PERIODIC_ITVL;
     ticks = os_cputime_usecs_to_ticks(usecs);
@@ -2740,7 +2740,7 @@ ble_ll_adv_sm_start(struct ble_ll_adv_sm *advsm)
      */
     earliest_start_time = ble_ll_rfmgmt_enable_now();
 
-    start_delay_us = rand() % (BLE_LL_ADV_DELAY_MS_MAX * 1000);
+    start_delay_us = ble_ll_rand() % (BLE_LL_ADV_DELAY_MS_MAX * 1000);
     advsm->adv_pdu_start_time = os_cputime_get32() +
                                 os_cputime_usecs_to_ticks(start_delay_us);
 

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1619,7 +1619,7 @@ ble_ll_conn_master_common_init(struct ble_ll_conn_sm *connsm)
     connsm->master_sca = BLE_LL_SCA_ENUM;
 
     /* Hop increment is a random value between 5 and 16. */
-    connsm->hop_inc = (rand() % 12) + 5;
+    connsm->hop_inc = (ble_ll_rand() % 12) + 5;
 
     /* Set channel map to map requested by host */
     connsm->num_used_chans = g_ble_ll_conn_params.num_used_chans;
@@ -1628,7 +1628,7 @@ ble_ll_conn_master_common_init(struct ble_ll_conn_sm *connsm)
 
     /*  Calculate random access address and crc initialization value */
     connsm->access_addr = ble_ll_utils_calc_access_addr();
-    connsm->crcinit = rand() & 0xffffff;
+    connsm->crcinit = ble_ll_rand() & 0xffffff;
 
     /* Set initial schedule callback */
     connsm->conn_sch.sched_cb = ble_ll_conn_event_start_cb;

--- a/nimble/controller/src/ble_ll_rand.c
+++ b/nimble/controller/src/ble_ll_rand.c
@@ -120,6 +120,18 @@ ble_ll_rand_data_get(uint8_t *buf, uint8_t len)
     return BLE_ERR_SUCCESS;
 }
 
+/* Simple wrapper to allow easy replacement of rand() */
+int
+ble_ll_rand(void)
+{
+    int data;
+
+    ble_ll_rand_data_get((uint8_t *)&data, sizeof(data));
+
+    /* rand returns signed integer but in range 0-RAND_MAX */
+    return data & RAND_MAX;
+}
+
 /**
  * Called to obtain a "prand" as defined in core V4.2 Vol 6 Part B 1.3.2.2
  *

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -293,7 +293,7 @@ ble_ll_scan_req_backoff(struct ble_ll_scan_sm *scansm, int success)
         STATS_INC(ble_ll_stats, scan_req_txf);
     }
 
-    scansm->backoff_count = rand() & (scansm->upper_limit - 1);
+    scansm->backoff_count = ble_ll_rand() & (scansm->upper_limit - 1);
     ++scansm->backoff_count;
     BLE_LL_ASSERT(scansm->backoff_count <= 256);
 }

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -1266,7 +1266,7 @@ ble_ll_sched_adv_reschedule(struct ble_ll_sched_item *sch, uint32_t *start,
     if (!rc) {
         sch->enqueued = 1;
         if (rand_ticks) {
-            sch->start_time += rand() % rand_ticks;
+            sch->start_time += ble_ll_rand() % rand_ticks;
         }
         sch->end_time = sch->start_time + duration;
         *start = sch->start_time;

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -50,8 +50,8 @@ ble_ll_utils_calc_access_addr(void)
     aa = 0;
     while (1) {
         /* Get two, 16-bit random numbers */
-        aa_low = rand() & 0xFFFF;
-        aa_high = rand() & 0xFFFF;
+        aa_low = ble_ll_rand() & 0xFFFF;
+        aa_high = ble_ll_rand() & 0xFFFF;
 
         /* All four bytes cannot be equal */
         if (aa_low == aa_high) {


### PR DESCRIPTION
Don't use stdlib pseudo rand in LL code. This also means LL code
will no longer seed stdlib srand() on init as this should be
application responsibility anyway.