### PR TITLE
nimble/ll: Fix network privacy when initiating

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -3409,6 +3409,12 @@ ble_ll_init_rx_isr_end(uint8_t *rxbuf, uint8_t crcok,
              */
             memcpy(init_addr, rl->rl_local_rpa, BLE_DEV_ADDR_LEN);
         }
+    } else if (!ble_ll_is_rpa(adv_addr, adv_addr_type)) {
+        /* undirected with ID address, assure privacy if on RL */
+        rl = ble_ll_resolv_list_find(adv_addr, adv_addr_type);
+        if (rl && (rl->rl_priv_mode == BLE_HCI_PRIVACY_NETWORK)) {
+            goto init_rx_isr_exit;
+        }
     }
 #endif
 


### PR DESCRIPTION
If remote is using ID address and IRK for that peer is on resolving
list and network privacy is enabled we should not be connecting to
that peer.

This was affecting LL/CON/INI/BV-24-C qualification test case.