### PR TITLE
cmac/driver: Make CMAC2SYS IRQ priority configurable

### DIFF
--- a/nimble/transport/dialog_cmac/cmac_driver/src/cmac_host.c
+++ b/nimble/transport/dialog_cmac/cmac_driver/src/cmac_host.c
@@ -235,7 +235,7 @@ cmac_host_init(void)
 
     /* Setup CMAC2SYS interrupt */
     NVIC_SetVector(CMAC2SYS_IRQn, (uint32_t)cmac2sys_isr);
-    NVIC_SetPriority(CMAC2SYS_IRQn, 0);
+    NVIC_SetPriority(CMAC2SYS_IRQn, MYNEWT_VAL(CMAC_CMAC2SYS_IRQ_PRIORITY));
     NVIC_DisableIRQ(CMAC2SYS_IRQn);
 
     /* Enable Radio LDO */

--- a/nimble/transport/dialog_cmac/cmac_driver/syscfg.yml
+++ b/nimble/transport/dialog_cmac/cmac_driver/syscfg.yml
@@ -94,5 +94,11 @@ syscfg.defs:
             CMAC binary.
         value: 128K
 
+    CMAC_CMAC2SYS_IRQ_PRIORITY:
+        description: >
+            The priority of the CMAC2SYS IRQ. Default is 0, or highest
+            priority.
+        value: 0
+
 syscfg.restrictions.BLE_HOST:
     - TRNG


### PR DESCRIPTION
Allow the application to modify the CMAC2SYS IRQ priority.