### PR TITLE
cmac: Update initialization and calibration routines

### DIFF
--- a/nimble/drivers/dialog_cmac/src/ble_phy.c
+++ b/nimble/drivers/dialog_cmac/src/ble_phy.c
@@ -1198,7 +1198,6 @@ ble_phy_init(void)
 #endif
 
     ble_rf_init();
-    ble_rf_calibrate_once();
 
     /*
      * 9_0_EQ_X can be linked to start RX/TX so we'll use this one for

--- a/nimble/drivers/dialog_cmac/src/ble_rf_priv.h
+++ b/nimble/drivers/dialog_cmac/src/ble_rf_priv.h
@@ -28,7 +28,6 @@ bool ble_rf_is_enabled(void);
 void ble_rf_configure(void);
 
 void ble_rf_calibrate(void);
-void ble_rf_calibrate_once(void);
 
 void ble_rf_setup_tx(uint8_t rf_chan, uint8_t mode);
 void ble_rf_setup_rx(uint8_t rf_chan, uint8_t mode);

--- a/nimble/transport/dialog_cmac/cmac_driver/include/cmac_driver/cmac_host.h
+++ b/nimble/transport/dialog_cmac/cmac_driver/include/cmac_driver/cmac_host.h
@@ -26,6 +26,7 @@ extern "C" {
 
 void cmac_host_init(void);
 void cmac_host_signal2cmac(void);
+void cmac_host_rf_calibrate(void);
 
 #ifdef __cplusplus
 }

--- a/nimble/transport/dialog_cmac/cmac_driver/src/cmac_host.c
+++ b/nimble/transport/dialog_cmac/cmac_driver/src/cmac_host.c
@@ -184,6 +184,16 @@ cmac_host_print_trim(const char *name, const uint32_t *tv, unsigned len)
 #endif
 
 void
+cmac_host_rf_calibrate(void)
+{
+    cmac_shared_lock();
+    g_cmac_shared_data->pending_ops |= CMAC_PENDING_OP_RF_CAL;
+    cmac_shared_unlock();
+
+    cmac_host_signal2cmac();
+}
+
+void
 cmac_host_init(void)
 {
     struct trng_dev *trng;


### PR DESCRIPTION
Make sure we initialize RF part only once, that is we only need to read
trim values, TX power configuration and do full calibration once after
boot.

Partial calibration is done on host request in idle time when RF is not
used.