### PR TITLE
ble_store_config: Remove unneeded include

### DIFF
--- a/nimble/host/store/config/src/ble_store_config.c
+++ b/nimble/host/store/config/src/ble_store_config.c
@@ -23,7 +23,6 @@
 #include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "host/ble_hs.h"
-#include "config/config.h"
 #include "base64/base64.h"
 #include "store/config/ble_store_config.h"
 #include "ble_store_config_priv.h"


### PR DESCRIPTION
sys/config is conditionally included in pkg.yml yet
ble_store_config.c tried to included "config/config.h" always.

ble_store_config.c does not used content of config.h anyway
so include is removed.