### PR TITLE
targets: Add blehci over USB for pca10056

### DIFF
--- a/targets/nordic_pca10056-blehci-usb/pkg.yml
+++ b/targets/nordic_pca10056-blehci-usb/pkg.yml
@@ -1,0 +1,9 @@
+pkg.name: "targets/nordic_pca10056-blehci-usb"
+pkg.type: target
+pkg.description: 
+pkg.author: 
+pkg.homepage:
+
+pkg.deps:
+    - "@apache-mynewt-core/hw/usb/tinyusb"
+    - "@apache-mynewt-core/hw/usb/tinyusb/std_descriptors"

--- a/targets/nordic_pca10056-blehci-usb/syscfg.yml
+++ b/targets/nordic_pca10056-blehci-usb/syscfg.yml
@@ -1,0 +1,6 @@
+syscfg.vals:
+    BLE_HCI_TRANSPORT: usb
+    USBD_BTH: 1
+
+    USBD_PID: 0xC01A
+    USBD_VID: 0xC0CA

--- a/targets/nordic_pca10056-blehci-usb/target.yml
+++ b/targets/nordic_pca10056-blehci-usb/target.yml
@@ -1,0 +1,3 @@
+target.app: "@apache-mynewt-nimble/apps/blehci"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
+target.build_profile: debug


### PR DESCRIPTION
Target to use nimble controller on Linux with USB.

Target uses some randomly selected USB VID/PID and BT address.

TinyUSB repository must be in project.yml

```
repository.tinyusb:
    type: github
    vers: 0.7.0
    user: hathach
    repo: tinyusb
```