### PR TITLE
ble_gap: fix warning about implicit cast form pointer to int

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -745,7 +745,7 @@ ble_gap_has_client(struct ble_gap_master_state *out_state)
         return 0;
     }
 
-    return out_state->cb;
+    return out_state->cb != NULL;
 }
 
 static void


### PR DESCRIPTION
This solves the following warning:

returning 'int (*)(struct ble_gap_event *, void *)' from a function with return type '_Bool8' {aka 'unsigned char'} makes integer from pointer without a cast [-Werror=int-conversion]

which was found when building nimBLE as part of NuttX