### PR TITLE
NimBLE host: Modify `ble_gap_wl_set` to help remove all addresses from controller whitelist

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -2169,11 +2169,6 @@ ble_gap_wl_set(const ble_addr_t *addrs, uint8_t white_list_count)
 
     ble_hs_lock();
 
-    if (white_list_count == 0) {
-        rc = BLE_HS_EINVAL;
-        goto done;
-    }
-
     for (i = 0; i < white_list_count; i++) {
         if (addrs[i].type != BLE_ADDR_PUBLIC &&
             addrs[i].type != BLE_ADDR_RANDOM) {

--- a/nimble/host/test/src/ble_gap_test.c
+++ b/nimble/host/test/src/ble_gap_test.c
@@ -449,9 +449,10 @@ TEST_CASE_SELF(ble_gap_test_case_wl_bad_args)
 
     ble_gap_test_util_init();
 
-    /*** 0 white list entries. */
+    /*** 0 white list entries. This is acceptable now with the wl_set API
+     * change. */
     rc = ble_hs_test_util_wl_set(NULL, 0, 0, 0);
-    TEST_ASSERT(rc == BLE_HS_EINVAL);
+    TEST_ASSERT(rc == 0);
 
     /*** Invalid address type. */
     rc = ble_hs_test_util_wl_set(


### PR DESCRIPTION
In NimBLE host, we only have `ble_gap_wl_set` API. This API can be leveraged to add and remove addresses in whitelist. However, issue comes when `white_list_count = 0`. Instead of cluttering `ble_gap_wl_set` API with generic implementation, this PR adds API in host to remove addresses from whitelist.  

Edit: As per suggestion by @sjanc , I have removed addition of new API. The PR only modifies `ble_gap_wl_set` to clear complete whitelist stored in controller.