### PR TITLE
NimBLE host: Make set Packet Length API public

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -1802,6 +1802,22 @@ int ble_gap_update_params(uint16_t conn_handle,
                           const struct ble_gap_upd_params *params);
 
 /**
+ * Configure LE Data Length in controller (OGF = 0x08, OCF = 0x0022).
+ *
+ * @param conn_handle      Connection handle.
+ * @param tx_octets        The preferred value of payload octets that the Controller
+ *                         should use for a new connection (Range
+ *                         0x001B-0x00FB).
+ * @param tx_time          The preferred maximum number of microseconds that the local Controller
+ *                         should use to transmit a single link layer packet
+ *                         (Range 0x0148-0x4290).
+ *
+ * @return                 0 on success,
+ *                         other error code on failure.
+ */
+int ble_gap_set_data_len(uint16_t conn_handle, uint16_t tx_octets, uint16_t tx_time);
+
+/**
  * Initiates the GAP security procedure.
  *
  * Depending on connection role and stored security information this function

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -5445,6 +5445,11 @@ done:
 #endif
 }
 
+int ble_gap_set_data_len(uint16_t conn_handle, uint16_t tx_octets, uint16_t tx_time)
+{
+    return ble_hs_hci_util_set_data_len(conn_handle, tx_octets, tx_time);
+}
+
 /*****************************************************************************
  * $security                                                                 *
  *****************************************************************************/


### PR DESCRIPTION
This PR makes API setting packet length (OGF = 0x08, OCF = 0x0022) in controller from host public. 