### PR TITLE
ll: Use macros to compare cputime

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -492,7 +492,7 @@ ble_ll_conn_is_lru(struct ble_ll_conn_sm *s1, struct ble_ll_conn_sm *s2)
     int rc;
 
     /* Set time that we last serviced the schedule */
-    if ((int32_t)(s1->last_scheduled - s2->last_scheduled) < 0) {
+    if (CPUTIME_LT(s1->last_scheduled, s2->last_scheduled)) {
         rc = 1;
     } else {
         rc = 0;
@@ -1157,10 +1157,10 @@ ble_ll_conn_tx_pdu(struct ble_ll_conn_sm *connsm)
         }
 
         ticks = os_cputime_usecs_to_ticks(ticks);
-        if ((int32_t)((os_cputime_get32() + ticks) - next_event_time) < 0) {
+        if (CPUTIME_LT(os_cputime_get32() + ticks, next_event_time)) {
             md = 1;
         }
-     }
+    }
 
     /* If we send an empty PDU we need to initialize the header */
 conn_tx_pdu:

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -305,7 +305,7 @@ ble_ll_scan_refresh_nrpa(struct ble_ll_scan_sm *scansm)
     ble_npl_time_t now;
 
     now = ble_npl_time_get();
-    if ((ble_npl_stime_t)(now - scansm->scan_nrpa_timer) >= 0) {
+    if (CPUTIME_GEQ(now, scansm->scan_nrpa_timer)) {
         /* Generate new NRPA */
         ble_ll_rand_data_get(scansm->scan_nrpa, BLE_DEV_ADDR_LEN);
         scansm->scan_nrpa[5] &= ~0xc0;

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -83,14 +83,14 @@ ble_ll_sched_is_overlap(struct ble_ll_sched_item *s1,
     int rc;
 
     rc = 1;
-    if ((int32_t)(s1->start_time - s2->start_time) < 0) {
+    if (CPUTIME_LT(s1->start_time, s2->start_time)) {
         /* Make sure this event does not overlap current event */
-        if ((int32_t)(s1->end_time - s2->start_time) <= 0) {
+        if (CPUTIME_LEQ(s1->end_time, s2->start_time)) {
             rc = 0;
         }
     } else {
         /* Check for overlap */
-        if ((int32_t)(s1->start_time - s2->end_time) >= 0) {
+        if (CPUTIME_GEQ(s1->start_time, s2->end_time)) {
             rc = 0;
         }
     }
@@ -111,7 +111,7 @@ ble_ll_sched_overlaps_current(struct ble_ll_sched_item *sch)
     rc = 0;
     if (ble_ll_state_get() == BLE_LL_STATE_CONNECTION) {
         ce_end_time = ble_ll_conn_get_ce_end_time();
-        if ((int32_t)(ce_end_time - sch->start_time) > 0) {
+        if (CPUTIME_GT(ce_end_time, sch->start_time)) {
             rc = 1;
         }
     }
@@ -178,7 +178,7 @@ ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm *connsm)
     sch->end_time = connsm->ce_end_time;
 
     /* Better be past current time or we just leave */
-    if ((int32_t)(sch->start_time - os_cputime_get32()) < 0) {
+    if (CPUTIME_LT(sch->start_time, os_cputime_get32())) {
         return -1;
     }
 
@@ -216,7 +216,7 @@ ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm *connsm)
                 end_overlap = entry;
             }
         } else {
-            if ((int32_t)(sch->end_time - entry->start_time) <= 0) {
+            if (CPUTIME_LEQ(sch->end_time, entry->start_time)) {
                 rc = 0;
                 TAILQ_INSERT_BEFORE(entry, sch, link);
                 break;
@@ -468,7 +468,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
             sch->end_time = earliest_end;
 
             /* We can insert if before entry in list */
-            if ((int32_t)(sch->end_time - entry->start_time) <= 0) {
+            if (CPUTIME_LEQ(sch->end_time, entry->start_time)) {
                 if ((earliest_start - initial_start) <= itvl_t) {
                     rc = 0;
                     TAILQ_INSERT_BEFORE(entry, sch, link);
@@ -655,7 +655,7 @@ ble_ll_sched_master_new(struct ble_ll_conn_sm *connsm,
             sch->end_time = earliest_end;
 
             /* We can insert if before entry in list */
-            if ((int32_t)(sch->end_time - entry->start_time) <= 0) {
+            if (CPUTIME_LEQ(sch->end_time, entry->start_time)) {
                 if ((earliest_start - initial_start) <= itvl_t) {
                     rc = 0;
                     TAILQ_INSERT_BEFORE(entry, sch, link);
@@ -770,7 +770,7 @@ ble_ll_sched_slave_new(struct ble_ll_conn_sm *connsm)
         while (1) {
             next_sch = entry->link.tqe_next;
             /* Insert if event ends before next starts */
-            if ((int32_t)(sch->end_time - entry->start_time) <= 0) {
+            if (CPUTIME_LEQ(sch->end_time, entry->start_time)) {
                 rc = 0;
                 TAILQ_INSERT_BEFORE(entry, sch, link);
                 break;
@@ -1047,7 +1047,7 @@ ble_ll_sched_adv_new(struct ble_ll_sched_item *sch, ble_ll_sched_adv_new_cb cb,
         os_cputime_timer_stop(&g_ble_ll_sched_timer);
         TAILQ_FOREACH(entry, &g_ble_ll_sched_q, link) {
             /* We can insert if before entry in list */
-            if ((int32_t)(sch->end_time - entry->start_time) <= 0) {
+            if (CPUTIME_LEQ(sch->end_time, entry->start_time)) {
                 TAILQ_INSERT_BEFORE(entry, sch, link);
                 break;
             }
@@ -1111,7 +1111,7 @@ ble_ll_sched_periodic_adv(struct ble_ll_sched_item *sch, uint32_t *start,
         os_cputime_timer_stop(&g_ble_ll_sched_timer);
         TAILQ_FOREACH(entry, &g_ble_ll_sched_q, link) {
             /* We can insert if before entry in list */
-            if ((int32_t)(sch->end_time - entry->start_time) <= 0) {
+            if (CPUTIME_LEQ(sch->end_time, entry->start_time)) {
                 TAILQ_INSERT_BEFORE(entry, sch, link);
                 break;
             }
@@ -1200,7 +1200,7 @@ ble_ll_sched_adv_reschedule(struct ble_ll_sched_item *sch, uint32_t *start,
                     end_overlap = entry;
                 }
             } else {
-                if ((int32_t)(sch->end_time - entry->start_time) <= 0) {
+                if (CPUTIME_LEQ(sch->end_time, entry->start_time)) {
                     before = entry;
                     break;
                 }
@@ -1233,7 +1233,7 @@ ble_ll_sched_adv_reschedule(struct ble_ll_sched_item *sch, uint32_t *start,
             sch->end_time = sch->start_time + duration;
             while (1) {
                 next_sch = entry->link.tqe_next;
-                if ((int32_t)(sch->end_time - entry->start_time) <= 0) {
+                if (CPUTIME_LEQ(sch->end_time, entry->start_time)) {
                     rand_ticks = entry->start_time - sch->end_time;
                     before = entry;
                     TAILQ_INSERT_BEFORE(before, sch, link);
@@ -1580,7 +1580,7 @@ ble_ll_sched_scan_req_over_aux_ptr(uint32_t chan, uint8_t phy_mode)
     while (sch) {
         /* Let's check if there is no scheduled item which want to start within
          * given usecs.*/
-        if ((int32_t)(sch->start_time - now + os_cputime_usecs_to_ticks(usec_dur)) > 0) {
+        if (CPUTIME_GT(sch->start_time, now + os_cputime_usecs_to_ticks(usec_dur))) {
             /* We are fine. Have time for scan req */
             return 0;
         }
@@ -1670,7 +1670,7 @@ ble_ll_sched_aux_scan(struct ble_mbuf_hdr *ble_hdr,
     os_cputime_timer_stop(&g_ble_ll_sched_timer);
     TAILQ_FOREACH(entry, &g_ble_ll_sched_q, link) {
         /* We can insert if before entry in list */
-        if ((int32_t)(sch->end_time - entry->start_time) <= 0) {
+        if (CPUTIME_LEQ(sch->end_time, entry->start_time)) {
             rc = 0;
             TAILQ_INSERT_BEFORE(entry, sch, link);
             sch->enqueued = 1;


### PR DESCRIPTION
Time was compared with explicit logic operators and result was casted to
int32_t each time. Now CPUTIME_* macros are used.

This fulfills request in issue https://github.com/apache/mynewt-nimble/issues/356