### PR TITLE
dialog_cmac: update XCVR_TX_SCHED_DELAY

### DIFF
--- a/nimble/drivers/dialog_cmac/include/ble/xcvr.h
+++ b/nimble/drivers/dialog_cmac/include/ble/xcvr.h
@@ -24,7 +24,12 @@
 extern "C" {
 #endif
 
+#if ((MYNEWT_VAL(CMAC_MBOX_SIZE_S2C) > 128) || (MYNEWT_VAL(CMA_CMBOX_SIZE_C2S) > 128))
+#define XCVR_TX_SCHED_DELAY_USECS       (300)
+#else
 #define XCVR_TX_SCHED_DELAY_USECS       (250)
+#endif
+
 
 /*
  * Define HW whitelist size. This is the total possible whitelist size;


### PR DESCRIPTION
XCVR_TX_SCHED_DELAY is time the device needs to wake up before a
scheduled event occurs. With higher mbox size (1024), CMAC can take
longer to process the scheduled events. Scheduled events are processed
in an interrupt context and this parameter gives enough time to service
the scheduled event.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>