### PR TITLE
NuttX fixes

### DIFF
--- a/porting/examples/nuttx/ble.c
+++ b/porting/examples/nuttx/ble.c
@@ -97,6 +97,17 @@ static void
 app_ble_sync_cb(void)
 {
     int rc;
+    ble_addr_t addr;
+
+    /* generate new non-resolvable private address */
+
+    rc = ble_hs_id_gen_rnd(1, &addr);
+    assert(rc == 0);
+
+    /* set generated address */
+
+    rc = ble_hs_id_set_rnd(addr.val);
+    assert(rc == 0);
 
     rc = ble_hs_util_ensure_addr(0);
     assert(rc == 0);

--- a/porting/npl/nuttx/src/os_eventq.c
+++ b/porting/npl/nuttx/src/os_eventq.c
@@ -73,13 +73,18 @@ ble_npl_eventq_inited(const struct ble_npl_eventq *evq)
 void
 ble_npl_eventq_put(struct ble_npl_eventq *evq, struct ble_npl_event *ev)
 {
+    int ret;
+
     if (ev->ev_queued)
       {
         return;
       }
 
     ev->ev_queued = 1;
-    mq_send(evq->mq, (const char*)&ev, sizeof(ev), 0);
+    ret = mq_send(evq->mq, (const char*)&ev, sizeof(ev), 0);
+
+    DEBUGASSERT(ret == 0);
+    UNUSED(ret);
 }
 
 struct ble_npl_event *

--- a/porting/npl/nuttx/src/os_task.c
+++ b/porting/npl/nuttx/src/os_task.c
@@ -60,14 +60,21 @@ ble_npl_task_init(struct ble_npl_task *t, const char *name, ble_npl_task_func_t 
     if (err) return err;
     err = pthread_attr_getschedparam (&t->attr, &t->param);
     if (err) return err;
+#if CONFIG_RR_INTERVAL > 0
     err = pthread_attr_setschedpolicy(&t->attr, SCHED_RR);
     if (err) return err;
+#endif
     t->param.sched_priority = prio;
     err = pthread_attr_setschedparam (&t->attr, &t->param);
     if (err) return err;
 
     t->name = name;
     err = pthread_create(&t->handle, &t->attr, func, arg);
+
+    if (err == ENOMEM)
+      {
+        err = OS_ENOMEM;
+      }
 
     return err;
 }


### PR DESCRIPTION
This introduces a fix for NuttX callout mechanism. SIGEV_THREAD is not entirely the same as in Linux and requires an own thread to work correctly (see commit message). This also adds random address generation to NuttX example so that it can work out of the box with chips which do not normally have a public address set.