### PR TITLE
nimble/test: Fix LE SC tests

### DIFF
--- a/nimble/host/src/ble_sm_alg.c
+++ b/nimble/host/src/ble_sm_alg.c
@@ -494,6 +494,10 @@ ble_sm_alg_gen_key_pair(uint8_t *pub, uint8_t *priv)
     return 0;
 }
 
+#if MYNEWT_VAL(SELFTEST)
+/* Unit tests rely on custom RNG function not being set */
+#define ble_sm_alg_rand NULL
+#else
 /* used by uECC to get random data */
 static int
 ble_sm_alg_rand(uint8_t *dst, unsigned int size)
@@ -519,6 +523,7 @@ ble_sm_alg_rand(uint8_t *dst, unsigned int size)
 
     return 1;
 }
+#endif
 
 void
 ble_sm_alg_ecc_init(void)


### PR DESCRIPTION
Some LE SC tests depend on known initial values on crypto side.
With latest update to TinyCrypt provided prng function is used also
for initial seeding and thus tests were failing. To keep things simple
just don't initialize random source function when doign unit tests.