### PR TITLE
porting: fix "cast from pointer to integer of different size" error

### DIFF
--- a/porting/nimble/src/os_mbuf.c
+++ b/porting/nimble/src/os_mbuf.c
@@ -245,7 +245,7 @@ os_mbuf_get(struct os_mbuf_pool *omp, uint16_t leadingspace)
     struct os_mbuf *om;
 
     os_trace_api_u32x2(OS_TRACE_ID_MBUF_GET, (uint32_t)omp,
-                       (uint32_t)leadingspace);
+                       (uint32_t)(uintptr_t)leadingspace);
 
     if (leadingspace > omp->omp_databuf_len) {
         om = NULL;
@@ -265,7 +265,7 @@ os_mbuf_get(struct os_mbuf_pool *omp, uint16_t leadingspace)
     om->om_omp = omp;
 
 done:
-    os_trace_api_ret_u32(OS_TRACE_ID_MBUF_GET, (uint32_t)om);
+    os_trace_api_ret_u32(OS_TRACE_ID_MBUF_GET, (uint32_t)(uintptr_t)om);
     return om;
 }
 
@@ -276,7 +276,7 @@ os_mbuf_get_pkthdr(struct os_mbuf_pool *omp, uint8_t user_pkthdr_len)
     struct os_mbuf_pkthdr *pkthdr;
     struct os_mbuf *om;
 
-    os_trace_api_u32x2(OS_TRACE_ID_MBUF_GET_PKTHDR, (uint32_t)omp,
+    os_trace_api_u32x2(OS_TRACE_ID_MBUF_GET_PKTHDR, (uint32_t)(uintptr_t)omp,
                        (uint32_t)user_pkthdr_len);
 
     /* User packet header must fit inside mbuf */
@@ -298,7 +298,7 @@ os_mbuf_get_pkthdr(struct os_mbuf_pool *omp, uint8_t user_pkthdr_len)
     }
 
 done:
-    os_trace_api_ret_u32(OS_TRACE_ID_MBUF_GET_PKTHDR, (uint32_t)om);
+    os_trace_api_ret_u32(OS_TRACE_ID_MBUF_GET_PKTHDR, (uint32_t)(uintptr_t)om);
     return om;
 }
 
@@ -307,7 +307,7 @@ os_mbuf_free(struct os_mbuf *om)
 {
     int rc;
 
-    os_trace_api_u32(OS_TRACE_ID_MBUF_FREE, (uint32_t)om);
+    os_trace_api_u32(OS_TRACE_ID_MBUF_FREE, (uint32_t)(uintptr_t)om);
 
     if (om->om_omp != NULL) {
         rc = os_memblock_put(om->om_omp->omp_pool, om);
@@ -329,7 +329,7 @@ os_mbuf_free_chain(struct os_mbuf *om)
     struct os_mbuf *next;
     int rc;
 
-    os_trace_api_u32(OS_TRACE_ID_MBUF_FREE_CHAIN, (uint32_t)om);
+    os_trace_api_u32(OS_TRACE_ID_MBUF_FREE_CHAIN, (uint32_t)(uintptr_t)om);
 
     while (om != NULL) {
         next = SLIST_NEXT(om, om_next);

--- a/porting/nimble/src/os_mempool.c
+++ b/porting/nimble/src/os_mempool.c
@@ -333,7 +333,7 @@ os_memblock_get(struct os_mempool *mp)
     os_sr_t sr;
     struct os_memblock *block;
 
-    os_trace_api_u32(OS_TRACE_ID_MEMBLOCK_GET, (uint32_t)mp);
+    os_trace_api_u32(OS_TRACE_ID_MEMBLOCK_GET, (uint32_t)(uintptr_t)mp);
 
     /* Check to make sure they passed in a memory pool (or something) */
     block = NULL;
@@ -361,7 +361,7 @@ os_memblock_get(struct os_mempool *mp)
         }
     }
 
-    os_trace_api_ret_u32(OS_TRACE_ID_MEMBLOCK_GET, (uint32_t)block);
+    os_trace_api_ret_u32(OS_TRACE_ID_MEMBLOCK_GET, (uint32_t)(uintptr_t)block);
 
     return (void *)block;
 }
@@ -372,8 +372,8 @@ os_memblock_put_from_cb(struct os_mempool *mp, void *block_addr)
     os_sr_t sr;
     struct os_memblock *block;
 
-    os_trace_api_u32x2(OS_TRACE_ID_MEMBLOCK_PUT_FROM_CB, (uint32_t)mp,
-                       (uint32_t)block_addr);
+    os_trace_api_u32x2(OS_TRACE_ID_MEMBLOCK_PUT_FROM_CB, (uint32_t)(uintptr_t)mp,
+                       (uint32_t)(uintptr_t)block_addr);
 
     os_mempool_guard_check(mp, block_addr);
     os_mempool_poison(mp, block_addr);
@@ -405,8 +405,8 @@ os_memblock_put(struct os_mempool *mp, void *block_addr)
     struct os_memblock *block;
 #endif
 
-    os_trace_api_u32x2(OS_TRACE_ID_MEMBLOCK_PUT, (uint32_t)mp,
-                       (uint32_t)block_addr);
+    os_trace_api_u32x2(OS_TRACE_ID_MEMBLOCK_PUT, (uint32_t)(uintptr_t)mp,
+                       (uint32_t)(uintptr_t)block_addr);
 
     /* Make sure parameters are valid */
     if ((mp == NULL) || (block_addr == NULL)) {


### PR DESCRIPTION
Changed direct casting of pointer to uint32_t to (uint32_t)(uintptr_t).