### PR TITLE
nimble/ll: Add restriction when enabling periodic advertising

### DIFF
--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -243,6 +243,8 @@ syscfg.defs:
             This option is used to enable/disable support for Periodic
             Advertising Feature.
         value: MYNEWT_VAL(BLE_PERIODIC_ADV)
+        restrictions:
+            - 'BLE_LL_CFG_FEAT_LL_EXT_ADV if 1'
 
     BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_CNT:
         description: >

--- a/nimble/syscfg.yml
+++ b/nimble/syscfg.yml
@@ -59,10 +59,14 @@ syscfg.defs:
         description: >
             This enables periodic advertising feature.
         value: 0
+        restrictions:
+            - 'BLE_EXT_ADV if 1'
     BLE_PERIODIC_ADV_SYNC_TRANSFER:
         description: >
             This enables Periodic Advertising Sync Transfer Feature.
         value: 0
+        restrictions:
+            - 'BLE_PERIODIC_ADV if 1'
 
     BLE_EXT_ADV_MAX_SIZE:
         description: >


### PR DESCRIPTION
Periodic advertising requires extended advertising to be enabled.