### PR TITLE
porting/nimble/hal_timer: fix NVIC setup

### DIFF
--- a/porting/nimble/src/hal_timer.c
+++ b/porting/nimble/src/hal_timer.c
@@ -538,8 +538,14 @@ hal_timer_init(int timer_num, void *cfg)
 
     /* Disable IRQ, set priority and set vector in table */
     NVIC_DisableIRQ(irq_num);
+#ifndef RIOT_VERSION
     NVIC_SetPriority(irq_num, (1 << __NVIC_PRIO_BITS) - 1);
+#endif
+#if MYNEWT
     NVIC_SetVector(irq_num, (uint32_t)irq_isr);
+#else
+    ble_npl_hw_set_isr(irq_num, irq_isr);
+#endif
 
     return 0;
 


### PR DESCRIPTION
Reverts some platform specific NVIC setup code that was removed in #872:

In commit ab53154 platform specific handling of the NVIC setup
for the timers priority and vectors were revertet. This leads
to problems on certain platforms, e.g. interrupt priority
related hard-faults on RIOT. This commit re-introduces the
platform specific setup.

I noticed this problem when trying to update the NimBLE version in RIOT to the latest master. At the same time 
@janosbrodbeck stumbled upon this problem when trying to test #920.