### PR TITLE
mesh: add frags to bt_mesh_adv struct

### DIFF
--- a/nimble/host/mesh/src/adv.h
+++ b/nimble/host/mesh/src/adv.h
@@ -35,8 +35,8 @@ typedef void (*bt_mesh_adv_func_t)(struct os_mbuf *buf, uint16_t duration,
 				   int err, void *user_data);
 
 struct bt_mesh_adv {
-
-	struct net_buf *frags;
+	/** Fragments associated with this buffer. */
+	struct os_mbuf *frags;
 
 	const struct bt_mesh_send_cb *cb;
 	void *cb_data;

--- a/nimble/host/mesh/src/friend.c
+++ b/nimble/host/mesh/src/friend.c
@@ -1236,7 +1236,7 @@ static void friend_timeout(struct ble_npl_event *work)
 
 	/* Clear the flag we use for segment tracking */
 	BT_MESH_ADV(frnd->last)->flags &= ~NET_BUF_FRAGS;
-	BT_MESH_ADV(frnd->last)->frags = 0;
+	BT_MESH_ADV(frnd->last)->frags = NULL;
 
 	BT_DBG("Sending buf %p from Friend Queue of LPN 0x%04x",
 	       frnd->last, frnd->lpn);
@@ -1382,8 +1382,8 @@ static void friend_purge_old_ack(struct bt_mesh_friend *frnd, uint64_t *seq_auth
 
 			net_buf_slist_remove(&frnd->queue, prev, cur);
 			frnd->queue_size--;
-			BT_MESH_ADV(buf)->frags = 0;
-
+			/* Make sure old slist entry state doesn't remain */
+			BT_MESH_ADV(buf)->frags = NULL;
 			net_buf_unref(buf);
 			break;
 		}


### PR DESCRIPTION
bt_mesh_adv was lacking frags member. It was left out in few places or
wrongly interpreted as "flags", causing the typo.