### PR TITLE
Replace deprecated store/ram from nimble apps deps

### DIFF
--- a/apps/blecent/pkg.yml
+++ b/apps/blecent/pkg.yml
@@ -32,5 +32,5 @@ pkg.deps:
     - nimble/host/util
     - nimble/host/services/gap
     - nimble/host/services/gatt
-    - nimble/host/store/ram
+    - nimble/host/store/config
     - nimble/transport

--- a/apps/blecent/syscfg.yml
+++ b/apps/blecent/syscfg.yml
@@ -28,3 +28,6 @@ syscfg.vals:
     BLE_ROLE_CENTRAL: 1
     BLE_ROLE_OBSERVER: 1
     BLE_ROLE_PERIPHERAL: 0
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/blecsc/syscfg.yml
+++ b/apps/blecsc/syscfg.yml
@@ -36,3 +36,6 @@ syscfg.vals:
 
     # Set device appearance to Cycling Speed and Cadence Sensor
     BLE_SVC_GAP_APPEARANCE: BLE_SVC_GAP_APPEARANCE_CYC_SPEED_AND_CADENCE_SENSOR
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/blehr/syscfg.yml
+++ b/apps/blehr/syscfg.yml
@@ -33,3 +33,6 @@ syscfg.vals:
 
     # Set public device address.
     BLE_PUBLIC_DEV_ADDR: ((uint8_t[6]){0xcc, 0xbb, 0xaa, 0x33, 0x22, 0x11})
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/blemesh/pkg.yml
+++ b/apps/blemesh/pkg.yml
@@ -33,5 +33,5 @@ pkg.deps:
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt
-    - nimble/host/store/ram
+    - nimble/host/store/config
     - nimble/transport/ram

--- a/apps/blemesh/syscfg.yml
+++ b/apps/blemesh/syscfg.yml
@@ -37,3 +37,6 @@ syscfg.vals:
 
     BLE_MESH_SETTINGS: 0
     CONFIG_NFFS: 0
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/blemesh_light/pkg.yml
+++ b/apps/blemesh_light/pkg.yml
@@ -33,5 +33,5 @@ pkg.deps:
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt
-    - nimble/host/store/ram
+    - nimble/host/store/config
     - nimble/transport/ram

--- a/apps/blemesh_light/syscfg.yml
+++ b/apps/blemesh_light/syscfg.yml
@@ -55,6 +55,9 @@ syscfg.vals:
 
     USE_NEOPIXEL: 0
 
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0
+
 syscfg.vals.BLE_MESH_SHELL_MODELS:
     PWM_0: 1
     PWM_1: 1

--- a/apps/blemesh_shell/pkg.yml
+++ b/apps/blemesh_shell/pkg.yml
@@ -33,5 +33,5 @@ pkg.deps:
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt
-    - nimble/host/store/ram
+    - nimble/host/store/config
     - nimble/transport/ram

--- a/apps/blemesh_shell/syscfg.yml
+++ b/apps/blemesh_shell/syscfg.yml
@@ -55,3 +55,6 @@ syscfg.vals:
     BLE_MESH_CFG_CLI: 1
     BLE_MESH_SETTINGS: 0
     CONFIG_NFFS: 0
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/bleprph/syscfg.yml
+++ b/apps/bleprph/syscfg.yml
@@ -66,3 +66,6 @@ syscfg.vals:
     MSYS_1_BLOCK_SIZE: 110
 
     BLE_SVC_GAP_DEVICE_NAME: '"nimble-bleprph"'
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/blestress/pkg.yml
+++ b/apps/blestress/pkg.yml
@@ -35,5 +35,5 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host/util"
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
-    - "@apache-mynewt-nimble/nimble/host/store/ram"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
     - "@apache-mynewt-nimble/nimble/transport/ram"

--- a/apps/blestress/syscfg.yml
+++ b/apps/blestress/syscfg.yml
@@ -72,3 +72,6 @@ syscfg.vals:
 
     # Enable CODED PHY
     BLE_LL_CFG_FEAT_LE_CODED_PHY: 1
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/btshell/pkg.yml
+++ b/apps/btshell/pkg.yml
@@ -32,7 +32,7 @@ pkg.deps:
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt
-    - nimble/host/store/ram
+    - nimble/host/store/config
     - nimble/transport
 
 pkg.deps.BTSHELL_ANS:

--- a/apps/btshell/syscfg.yml
+++ b/apps/btshell/syscfg.yml
@@ -38,5 +38,8 @@ syscfg.vals:
     # SMP is not supported in this app, so disable smp-over-shell.
     SHELL_MGMT: 0
 
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0
+
 syscfg.vals.BLE_MESH:
     MSYS_1_BLOCK_COUNT: 16

--- a/apps/central/syscfg.yml
+++ b/apps/central/syscfg.yml
@@ -21,3 +21,6 @@ syscfg.vals:
     BLE_ROLE_CENTRAL: 1
     BLE_ROLE_OBSERVER: 1
     BLE_ROLE_PERIPHERAL: 0
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/ext_advertiser/syscfg.yml
+++ b/apps/ext_advertiser/syscfg.yml
@@ -43,3 +43,6 @@ syscfg.vals:
     # Since we advertise a lot of data (~4k in total) at the same time we need
     # to increase block count.
     MSYS_1_BLOCK_COUNT: 24
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/mesh_badge/syscfg.yml
+++ b/apps/mesh_badge/syscfg.yml
@@ -25,6 +25,9 @@ syscfg.vals:
     # Set log level to info (disable debug logging).
     LOG_LEVEL: 1
 
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0
+
     # Default task settings
     OS_MAIN_STACK_SIZE: 768
 

--- a/apps/peripheral/syscfg.yml
+++ b/apps/peripheral/syscfg.yml
@@ -21,3 +21,6 @@ syscfg.vals:
     BLE_ROLE_CENTRAL: 0
     BLE_ROLE_OBSERVER: 0
     BLE_ROLE_PERIPHERAL: 1
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/scanner/syscfg.yml
+++ b/apps/scanner/syscfg.yml
@@ -21,3 +21,6 @@ syscfg.vals:
     BLE_ROLE_CENTRAL: 0
     BLE_ROLE_OBSERVER: 1
     BLE_ROLE_PERIPHERAL: 0
+
+    # Whether to save data to sys/config, or just keep it in RAM.
+    BLE_STORE_CONFIG_PERSIST: 0


### PR DESCRIPTION
Replace store/ram with store/config in nimble apps dependencies.
Package store/ram is deprecated and store/config shall be used with
BLE_STORE_CONFIG_PERSIST set to 0.