### PR TITLE
nimble/gatt: Fix GCC 10 build with no BLE_GATT_WRITE_RELIABLE

### DIFF
--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -698,12 +698,16 @@ ble_gattc_proc_free(struct ble_gattc_proc *proc)
 
         switch (proc->op) {
         case BLE_GATT_OP_WRITE_LONG:
-            os_mbuf_free_chain(proc->write_long.attr.om);
+            if (MYNEWT_VAL(BLE_GATT_WRITE_LONG)) {
+                os_mbuf_free_chain(proc->write_long.attr.om);
+            }
             break;
 
         case BLE_GATT_OP_WRITE_RELIABLE:
-            for (i = 0; i < proc->write_reliable.num_attrs; i++) {
-                os_mbuf_free_chain(proc->write_reliable.attrs[i].om);
+            if (MYNEWT_VAL(BLE_GATT_WRITE_RELIABLE)) {
+                for (i = 0; i < proc->write_reliable.num_attrs; i++) {
+                    os_mbuf_free_chain(proc->write_reliable.attrs[i].om);
+                }
             }
             break;
 


### PR DESCRIPTION
When BLE_GATT_WRITE_RELIABLE handling of BLE_GATT_OP_WRITE_RELIABLE
is not needed and is detected by gcc as:

Error: repos/apache-mynewt-nimble/nimble/host/src/ble_gattc.c: In function 'ble_gattc_proc_free':
repos/apache-mynewt-nimble/nimble/host/src/ble_gattc.c:709:66: error: array subscript 254 is outside the bounds of an interior zero-length array 'struct ble_gatt_attr[0]' [-Werror=zero-length-bounds]
  709 |                     os_mbuf_free_chain(proc->write_reliable.attrs[i].om);
      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
repos/apache-mynewt-nimble/nimble/host/src/ble_gattc.c:199:34: note: while referencing 'attrs'
  199 |             struct ble_gatt_attr attrs[MYNEWT_VAL(BLE_GATT_WRITE_MAX_ATTRS)];
      |                                  ^~~~~
cc1: all warnings being treated as errors

This change gets rid of offending code that is not needed when BLE_GATT_WRITE_LONG
or BLE_GATT_WRITE_RELIABLE are 0.