### PR TITLE
nimble/host: Fix error return in `ble_store_util_bonded_peers`

### DIFF
--- a/nimble/host/src/ble_store_util.c
+++ b/nimble/host/src/ble_store_util.c
@@ -91,9 +91,6 @@ ble_store_util_bonded_peers(ble_addr_t *out_peer_id_addrs, int *out_num_peers,
     if (rc != 0) {
         return rc;
     }
-    if (set.status != 0) {
-        return set.status;
-    }
 
     *out_num_peers = set.num_peers;
     return 0;


### PR DESCRIPTION
Issue:

- When storage capacity of bonds is over, `ble_gap_unpair_oldest_peer` is called to make space for new bond. Then `ble_store_util_bonded_peers --> ble_store_iterate` are called. The callback `ble_store_util_iter_unique_peer` sets `set->status = BLE_HS_ENOMEM` when `max_peers` indicated by caller to `ble_store_util_bonded_peers` are iterated over in `ble_store_iterate`.   
- When `max_peer`(input parameter to API) is less than stored bonds, `ble_store_util_bonded_peers` returns `BLE_HS_ENOMEM` status code unnecessarily. It results in not freeing space for new bond when `ble_gap_unpair_oldest_peer` is called.

Solution:
- `ble_store_util_bonded_peers` should not return error depending upon `set.status`. 