### PR TITLE
mesh: don't free mbuf in bt_mesh_adv_create_from_pool

### DIFF
--- a/nimble/host/mesh/src/adv.c
+++ b/nimble/host/mesh/src/adv.c
@@ -232,7 +232,6 @@ struct os_mbuf *bt_mesh_adv_create_from_pool(struct os_mbuf_pool *pool,
 	adv->ref_cnt = 1;
 	ble_npl_event_set_arg(&adv->ev, buf);
 
-	os_mbuf_free_chain(buf);
 	return buf;
 }
 


### PR DESCRIPTION
Coverity caught that freeing of buf in this function was unreachable;
it's correct, as this buf shouldn't be freed at all.