### PR TITLE
host: fail pairing in SC only when peripheral doesn't support SC

### DIFF
--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -1886,6 +1886,9 @@ ble_sm_pair_rsp_rx(uint16_t conn_handle, struct os_mbuf **om,
         } else if (rsp->max_enc_key_size > BLE_SM_PAIR_KEY_SZ_MAX) {
             res->sm_err = BLE_SM_ERR_INVAL;
             res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_INVAL);
+        } else if (!ble_sm_verify_auth_requirements(rsp->authreq)) {
+            res->sm_err = BLE_SM_ERR_AUTHREQ;
+            res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_AUTHREQ);
         } else {
             ble_sm_pair_cfg(proc);
 


### PR DESCRIPTION
If we, as central, send pairing request  in SC only mode we can
receive pairing response with with SC pairing not supported flag
in AuthReq. In this case we should fail pairing with BLE_SM_ERR_AUTHREQ
error.

This is required to pass GAP/SEC/SEM/BV-28-C