### PR TITLE
l2cap: Fix double disconnect issue

### DIFF
--- a/nimble/host/src/ble_l2cap_priv.h
+++ b/nimble/host/src/ble_l2cap_priv.h
@@ -62,6 +62,7 @@ typedef int ble_l2cap_rx_fn(struct ble_l2cap_chan *chan);
 
 struct ble_l2cap_chan {
     SLIST_ENTRY(ble_l2cap_chan) next;
+    bool disconnecting;
     uint16_t conn_handle;
     uint16_t dcid;
     uint16_t scid;

--- a/nimble/host/src/ble_l2cap_sig.c
+++ b/nimble/host/src/ble_l2cap_sig.c
@@ -1640,6 +1640,10 @@ ble_l2cap_sig_disconnect(struct ble_l2cap_chan *chan)
     struct ble_l2cap_sig_proc *proc;
     int rc;
 
+    if (chan->disconnecting) {
+        return 0;
+    }
+
     proc = ble_l2cap_sig_proc_alloc();
     if (proc == NULL) {
         return BLE_HS_ENOMEM;
@@ -1661,6 +1665,10 @@ ble_l2cap_sig_disconnect(struct ble_l2cap_chan *chan)
     req->scid = htole16(chan->scid);
 
     rc = ble_l2cap_sig_tx(proc->conn_handle, txom);
+    /* Mark channel as disconnecting */
+    if (rc == 0) {
+        chan->disconnecting = true;
+    }
 
 done:
     ble_l2cap_sig_process_status(proc, rc);


### PR DESCRIPTION
It might happen that we get into situation that host will try to
disconnect same channel couple times e.g when receiveing log of
corrupted packages.

This patch make sure that host will send l2cap disconnect command only
once.