### PR TITLE
nimble/hs: Fix mbuf allocation for combined build

### DIFF
--- a/nimble/host/src/ble_hs_mbuf.c
+++ b/nimble/host/src/ble_hs_mbuf.c
@@ -29,7 +29,11 @@ ble_hs_mbuf_gen_pkt(uint16_t leading_space)
     struct os_mbuf *om;
     int rc;
 
+#if MYNEWT_VAL(BLE_CONTROLLER)
+    om = os_msys_get_pkthdr(0, sizeof(struct ble_mbuf_hdr));
+#else
     om = os_msys_get_pkthdr(0, 0);
+#endif
     if (om == NULL) {
         return NULL;
     }


### PR DESCRIPTION
In combined build we need to allocate mbufs with user header since LL
needs extra space to keep txinfo.

This works so far only because txinfo has 4 bytes and it overwrites
omp_next in packet header which is only used when mbuf is enqueued.
Once dequeued, we don't use so it's "ok" to overwrite it. However if
txinfo is extended with some extra data we will start overwriting
PDU data when writing to txinfo.