### PR TITLE
porting: Fix mempool initialization

### DIFF
--- a/porting/examples/linux/main.c
+++ b/porting/examples/linux/main.c
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
         ble_hci_sock_set_device(atoi(argv[1]));
     }
 
-    ble_hci_sock_init();
     nimble_port_init();
+    ble_hci_sock_init();
 
     /* This example provides GATT Alert service */
     ble_svc_gap_init();

--- a/porting/examples/linux_blemesh/main.c
+++ b/porting/examples/linux_blemesh/main.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[])
         ble_hci_sock_set_device(atoi(argv[1]));
     }
 
-    ble_hci_sock_init();
     nimble_port_init();
+    ble_hci_sock_init();
 
     ble_svc_gap_init();
     ble_svc_gatt_init();

--- a/porting/examples/nuttx/main.c
+++ b/porting/examples/nuttx/main.c
@@ -71,10 +71,11 @@ int main(int argc, char *argv[])
         ble_hci_sock_set_device(atoi(argv[1]));
     }
 
-    printf("hci init\n");
-    ble_hci_sock_init();
     printf("port init\n");
     nimble_port_init();
+
+    printf("hci init\n");
+    ble_hci_sock_init();
 
     /* This example provides GATT Alert service */
     printf("gap init\n");

--- a/porting/nimble/src/nimble_port.c
+++ b/porting/nimble/src/nimble_port.c
@@ -30,6 +30,7 @@
 static struct ble_npl_eventq g_eventq_dflt;
 
 extern void os_msys_init(void);
+extern void os_mempool_module_init(void);
 
 void
 nimble_port_init(void)
@@ -37,6 +38,7 @@ nimble_port_init(void)
     /* Initialize default event queue */
     ble_npl_eventq_init(&g_eventq_dflt);
     /* Initialize the global memory pool */
+    os_mempool_module_init();
     os_msys_init();
     /* Initialize the host */
     ble_hs_init();


### PR DESCRIPTION
This fix crash on init due to changes in mmepool init after recent
sync with core.