### PR TITLE
npl/riot: rework to use RIOTs ztimer

### DIFF
--- a/porting/npl/riot/include/nimble/nimble_npl_os.h
+++ b/porting/npl/riot/include/nimble/nimble_npl_os.h
@@ -24,8 +24,8 @@
 #include <stdbool.h>
 #include "event/callback.h"
 #include "mutex.h"
-#include "semaphore.h"
-#include "xtimer.h"
+#include "sema.h"
+#include "ztimer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,8 +50,8 @@ struct ble_npl_eventq {
 };
 
 struct ble_npl_callout {
-    xtimer_t timer;
-    uint64_t target_us;
+    ztimer_t timer;
+    ble_npl_time_t ticks;
     struct ble_npl_event e;
     event_queue_t *q;
 };
@@ -61,7 +61,7 @@ struct ble_npl_mutex {
 };
 
 struct ble_npl_sem {
-    sem_t sem;
+    sema_t sem;
 };
 
 static inline bool
@@ -100,8 +100,9 @@ ble_npl_eventq_get(struct ble_npl_eventq *evq, ble_npl_time_t tmo)
     } else if (tmo == BLE_NPL_TIME_FOREVER) {
         return (struct ble_npl_event *)event_wait(&evq->q);
     } else {
-        return (struct ble_npl_event *)event_wait_timeout64(&evq->q,
-                                                            tmo * US_PER_MS);
+        return (struct ble_npl_event *)event_wait_timeout_ztimer(&evq->q,
+                                                                 ZTIMER_MSEC,
+                                                                 (uint32_t)tmo);
     }
 }
 
@@ -174,49 +175,39 @@ ble_npl_mutex_release(struct ble_npl_mutex *mu)
 static inline ble_npl_error_t
 ble_npl_sem_init(struct ble_npl_sem *sem, uint16_t tokens)
 {
-    int rc;
-
-    rc = sem_init(&sem->sem, 0, tokens);
-
-    return rc == 0 ? BLE_NPL_OK : BLE_NPL_ERROR;
+    sema_create(&sem->sem, (unsigned)tokens);
+    return BLE_NPL_OK;
 }
 
 static inline ble_npl_error_t
 ble_npl_sem_release(struct ble_npl_sem *sem)
 {
-    int rc;
-
-    rc = sem_post(&sem->sem);
-
-    return rc == 0 ? BLE_NPL_OK : BLE_NPL_ERROR;
+    int rc = sema_post(&sem->sem);
+    return (rc == 0) ? BLE_NPL_OK : BLE_NPL_ERROR;
 }
 
 static inline uint16_t
 ble_npl_sem_get_count(struct ble_npl_sem *sem)
 {
-    int val = 0;
-
-    sem_getvalue(&sem->sem, &val);
-
-    return (uint16_t)val;
+    return (uint16_t)sema_get_value(&sem->sem);
 }
 
 static inline void
 ble_npl_callout_stop(struct ble_npl_callout *co)
 {
-    xtimer_remove(&co->timer);
+    ztimer_remove(ZTIMER_MSEC, &co->timer);
 }
 
 static inline bool
 ble_npl_callout_is_active(struct ble_npl_callout *c)
 {
-    return (c->timer.offset || c->timer.long_offset);
+    return ztimer_is_set(ZTIMER_MSEC, &c->timer);
 }
 
 static inline ble_npl_time_t
 ble_npl_callout_get_ticks(struct ble_npl_callout *co)
 {
-    return (ble_npl_time_t)(co->target_us / US_PER_MS);
+    return co->ticks;
 }
 
 static inline void
@@ -228,7 +219,7 @@ ble_npl_callout_set_arg(struct ble_npl_callout *co, void *arg)
 static inline ble_npl_time_t
 ble_npl_time_get(void)
 {
-    return (ble_npl_time_t)(xtimer_now_usec64() / US_PER_MS);
+    return (ble_npl_time_t)ztimer_now(ZTIMER_MSEC);
 }
 
 static inline ble_npl_error_t
@@ -260,7 +251,7 @@ ble_npl_time_ticks_to_ms32(ble_npl_time_t ticks)
 static inline void
 ble_npl_time_delay(ble_npl_time_t ticks)
 {
-    xtimer_usleep64(ticks * US_PER_MS);
+    ztimer_sleep(ZTIMER_MSEC, (uint32_t)ticks);
 }
 
 static inline uint32_t


### PR DESCRIPTION
ztimer is a new high-level timer API in RIOT that was introcuced a
while ago to be the successor of xtimer. This commit reworks the
RIOT NPL implementation to use ztimer instead of xtimer. This
simplifies the NPL implementation and it allows for significant
energy savings.
For the xtimer switch the implemenation further switches from
RIOTs `posix_semaphore` module to the slimmer `sema` module, as the
prior indirectly pulls in xtimer as dependency.

When running the `examples/nimble_gatt` application from RIOTs examples for the `nrf52dk` and compiling it without STDIO (so UART is not enabled), the average power consumption drops **from 430µA down to 72µA** while maintaining a BLE connection to a smartphone using the default connection interval :-)