### PR TITLE
transport/cmac: Fix race on LL event write

### DIFF
--- a/nimble/transport/dialog_cmac/src/ble_hci_cmac_ll.c
+++ b/nimble/transport/dialog_cmac/src/ble_hci_cmac_ll.c
@@ -92,11 +92,16 @@ int
 ble_hci_trans_ll_evt_tx(uint8_t *evt)
 {
     uint8_t pkt_type = BLE_HCI_TRANS_H4_PKT_TYPE_EVT;
+    os_sr_t sr;
+
+    OS_ENTER_CRITICAL(sr);
 
     cmac_mbox_write(&pkt_type, sizeof(pkt_type));
     cmac_mbox_write(evt, evt[1] + 2);
 
     ble_hci_trans_buf_free(evt);
+
+    OS_EXIT_CRITICAL(sr);
 
     return 0;
 }


### PR DESCRIPTION
HCI commands are processed in LL task context and thus CS/CC events are
written to mbox in the same context. This can lead to following race:
- CS/CC is written to mbox
- interrupt in handled on CMAC *before* command buffer is freed
- M33 reads CS/CC and writes next command to mbox
- CMAC reads new command

This triggers an assert in code because we do not have free buffer for
new command because we were busy handling interrupts and did not free
it yet.

To fix this we should write and free in critical section.