### PR TITLE
ll/rand: restructure rand initialization

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -581,7 +581,6 @@ int ble_ll_rand_init(void);
 void ble_ll_rand_sample(uint8_t rnum);
 int ble_ll_rand_data_get(uint8_t *buf, uint8_t len);
 void ble_ll_rand_prand_get(uint8_t *prand);
-int ble_ll_rand_start(void);
 uint32_t ble_ll_rand(void);
 
 static inline int

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1687,8 +1687,6 @@ ble_ll_init(void)
 
     /* Initialize random number generation */
     ble_ll_rand_init();
-    /* Start the random number generator */
-    ble_ll_rand_start();
 
     rc = stats_init_and_reg(STATS_HDR(ble_ll_stats),
                             STATS_SIZE_INIT_PARMS(ble_ll_stats, STATS_SIZE_32),

--- a/nimble/controller/src/ble_ll_rand.c
+++ b/nimble/controller/src/ble_ll_rand.c
@@ -47,6 +47,8 @@ struct ble_ll_rnum_data
 struct ble_ll_rnum_data g_ble_ll_rnum_data;
 uint8_t g_ble_ll_rnum_buf[MYNEWT_VAL(BLE_LL_RNG_BUFSIZE)];
 
+static unsigned short xsubi[3];
+
 #define IS_RNUM_BUF_END(x)  \
     (x == &g_ble_ll_rnum_buf[MYNEWT_VAL(BLE_LL_RNG_BUFSIZE) - 1])
 
@@ -127,14 +129,6 @@ ble_ll_rand_data_get(uint8_t *buf, uint8_t len)
 uint32_t
 ble_ll_rand(void)
 {
-    static unsigned short xsubi[3];
-    static bool init = true;
-
-    if (init) {
-        init = false;
-        ble_ll_rand_data_get((uint8_t *)xsubi, sizeof(xsubi));
-    }
-
     return (uint32_t) jrand48(xsubi);
 }
 
@@ -165,25 +159,6 @@ ble_ll_rand_prand_get(uint8_t *prand)
 }
 
 /**
- * Start the generation of random numbers
- *
- * @return int
- */
-int
-ble_ll_rand_start(void)
-{
-#if MYNEWT_VAL(TRNG)
-    /* Nothing to do - this is handled by driver */
-#else
-    /* Start the generation of numbers if we are not full */
-    if (g_ble_ll_rnum_data.rnd_size < MYNEWT_VAL(BLE_LL_RNG_BUFSIZE)) {
-        ble_hw_rng_start();
-    }
-#endif
-    return 0;
-}
-
-/**
  * Initialize LL random number generation. Should be called only once on
  * initialization.
  *
@@ -198,6 +173,19 @@ ble_ll_rand_init(void)
     g_ble_ll_rnum_data.rnd_in = g_ble_ll_rnum_buf;
     g_ble_ll_rnum_data.rnd_out = g_ble_ll_rnum_buf;
     ble_hw_rng_init(ble_ll_rand_sample, 1);
+
+    /* Start the generation of numbers if we are not full */
+    if (g_ble_ll_rnum_data.rnd_size < MYNEWT_VAL(BLE_LL_RNG_BUFSIZE)) {
+        ble_hw_rng_start();
+    }
+
+    /* Seed the pseudo random number generator (jrand48) */
+    ble_ll_rand_data_get((uint8_t *)xsubi, sizeof(xsubi));
+    /* We need to trigger jrand48 once discarding its output, as the initial
+     * call to jrand48 causes dynamic memory allocation by the libc. We do not
+     * want this to happen in interrupt context, which can happen if we wait for
+     * the first actual call to ble_ll_rand(). */
+    ble_ll_rand();
 #endif
     return 0;
 }


### PR DESCRIPTION
This one took me some time to track down :-) Under certain situations, NimBLE on RIOT hard-faulted on nRF boards. This happend maybe every 5th or so time a board was rebootet, mainly showing for RIOTs `nimble_scanner` example application. It turned out, that the late initialization of the pseudo random number generator as introduced in #883 has caused this:
- the first ever call to `jrand48()` causes a memory allocation (`malloc`) inside the libc code
- as `ble_ll_rand()` is partly called from interrupt context, this could trigger the late initialization in the interrupt context, leading to a `malloc` to be executed in interrupt context
- end of last year, a thread-safe malloc wrapper was introduced to RIOT, which does not allow for `malloc` calls from interrupt context, triggering a failed assertion (see https://github.com/RIOT-OS/RIOT/pull/15606)
- this leads to kind of a race condition for the `nimble_scanner` example: if the first call to `ble_ll_rand()` is coming from thread context, everything is fine, if its by chance coming from interrupt context, the node hard-faults due to a failed assertion.

In this PR I propose a pretty simple fix: why don't we simplify the `ble_ll_rand()` initialization per se and merge all three initialization steps into the `ble_ll_rand_init()` function?! This saves a little RAM (no static `init` var), makes the code more concise and prevents the error described above. I don't really see a drawback, as the split between `ble_ll_rand_init()` and `ble_ll_rand_start()` seems rather arbitrary to me, both are called exactly once and right after each other from the controllers init code anyway...