### PR TITLE
mesh: Check if ack is pending in trans_seg

### DIFF
--- a/nimble/host/mesh/src/transport.c
+++ b/nimble/host/mesh/src/transport.c
@@ -1413,8 +1413,9 @@ found_rx:
 	/* Reset the Incomplete Timer */
 	rx->last = k_uptime_get_32();
 
-	if (!k_delayed_work_remaining_get(&rx->ack) &&
-	    !bt_mesh_lpn_established()) {
+	if (!k_delayed_work_pending(&rx->ack) ||
+	    (!k_delayed_work_remaining_get(&rx->ack) &&
+	    !bt_mesh_lpn_established())) {
 		int32_t timeout = ack_timeout(rx);
 
 		k_delayed_work_submit(&rx->ack, K_MSEC(timeout));


### PR DESCRIPTION
Before scheduling ack it was checked if previous ack reached it's
timeout. If it did, it was assumed it was sent, where in fact,
timeout could be not reached and work could be canceled. Now,
check if work is pending at all, and if not, schedule next one.

This affects MESH/NODE/TNPT/BV-11-C