### PR TITLE
bttester: add another characteristic requiring authentication

### DIFF
--- a/apps/bttester/src/gatt.c
+++ b/apps/bttester/src/gatt.c
@@ -202,6 +202,14 @@ static const struct ble_gatt_svc_def gatt_svr_svcs[] = {
 				 BLE_GATT_CHR_F_WRITE |
 				 BLE_GATT_CHR_F_WRITE_AUTHEN,
 		}, {
+			.uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE_AUTHEN),
+			.access_cb = gatt_svr_read_write_auth_test,
+			.flags = BLE_GATT_CHR_F_READ_AUTHEN |
+				 BLE_GATT_CHR_F_READ |
+				 BLE_GATT_CHR_F_WRITE_AUTHEN |
+				 BLE_GATT_CHR_F_WRITE |
+				 BLE_GATT_CHR_F_WRITE_AUTHEN,
+		}, {
 			.uuid = PTS_UUID_DECLARE(PTS_CHR_RELIABLE_WRITE),
 			.access_cb = gatt_svr_rel_write_test,
 			.flags = BLE_GATT_CHR_F_WRITE |


### PR DESCRIPTION
This characteristic is required by GATT/SR/GAR/BI-21-C
(it requires two characteristics requiring authentication for
reading)