### PR TITLE
l2cap: implement echo request-response procedure (l2cap ping)

### DIFF
--- a/nimble/host/include/host/ble_l2cap.h
+++ b/nimble/host/include/host/ble_l2cap.h
@@ -246,6 +246,8 @@ struct ble_l2cap_chan_info {
 
 typedef int ble_l2cap_event_fn(struct ble_l2cap_event *event, void *arg);
 
+typedef void ble_l2cap_ping_fn(uint16_t conn_handle, uint32_t rtt_ms,
+                               struct os_mbuf *om);
 
 uint16_t ble_l2cap_get_conn_handle(struct ble_l2cap_chan *chan);
 int ble_l2cap_create_server(uint16_t psm, uint16_t mtu,
@@ -258,6 +260,26 @@ int ble_l2cap_disconnect(struct ble_l2cap_chan *chan);
 int ble_l2cap_send(struct ble_l2cap_chan *chan, struct os_mbuf *sdu_tx);
 int ble_l2cap_recv_ready(struct ble_l2cap_chan *chan, struct os_mbuf *sdu_rx);
 int ble_l2cap_get_chan_info(struct ble_l2cap_chan *chan, struct ble_l2cap_chan_info *chan_info);
+
+/**
+ * Send an ECHO_REQ packet over the L2CAP signalling channel for the given
+ * connection
+ *
+ * @param conn_handle   Connection handle
+ * @param cb            Function called once the corresponding ECHO_RSP is
+ *                      received. May be NULL.
+ * @param data          User payload appended to the ECHO_REQ packet, may be
+ *                      NULL
+ * @param data_len      Length of @p data in bytes. Set to 0 to omit any user
+ *                      payload
+ *
+ * @return              0 on success
+ *                      BLE_HS_EBADDATA if given payload is invalid
+ *                      BLE_HS_ENOMEM if request packet cannot be allocated
+ *                      BLE_HS_ENOTCONN if not connected
+ */
+int ble_l2cap_ping(uint16_t conn_handle, ble_l2cap_ping_fn cb,
+                   const void *data, uint16_t data_len);
 
 #ifdef __cplusplus
 }

--- a/nimble/host/src/ble_l2cap.c
+++ b/nimble/host/src/ble_l2cap.c
@@ -179,6 +179,13 @@ ble_l2cap_get_chan_info(struct ble_l2cap_chan *chan, struct ble_l2cap_chan_info 
 }
 
 int
+ble_l2cap_ping(uint16_t conn_handle, ble_l2cap_ping_fn cb,
+               const void *data, uint16_t data_len)
+{
+    return ble_l2cap_sig_ping(conn_handle, cb, data, data_len);
+}
+
+int
 ble_l2cap_enhanced_connect(uint16_t conn_handle,
                                uint16_t psm, uint16_t mtu,
                                uint8_t num, struct os_mbuf *sdu_rx[],

--- a/nimble/host/src/ble_l2cap_sig_priv.h
+++ b/nimble/host/src/ble_l2cap_sig_priv.h
@@ -172,6 +172,8 @@ ble_l2cap_sig_coc_reconfig(uint16_t conn_handle, struct ble_l2cap_chan *chans[],
 }
 #endif
 
+int ble_l2cap_sig_ping(uint16_t conn_handle, ble_l2cap_ping_fn cb,
+                       const void *data, uint16_t data_len);
 void ble_l2cap_sig_conn_broken(uint16_t conn_handle, int reason);
 int32_t ble_l2cap_sig_timer(void);
 struct ble_l2cap_chan *ble_l2cap_sig_create_chan(uint16_t conn_handle);


### PR DESCRIPTION
For doing run-time link quality assessment I am in the need of the echo request-response procedure provided by the L2CAP signalling layer. As of now, this functionality is not exposed through any NimBLE APIs. This PR exposes this functionality by adding the `ble_l2cap_ping()` function to NimBLE's l2cap API.

The usage is straight forward, once a BLE connection is established, one has simply to call the `ble_l2cap_ping()`. By passing an optional callback function to that function, this callback is executed one the `ECHO_RSP` packet is received. Additionally, an optional user payload can be appended to the `ECHO_REQ` packet.

Regarding testing of this feature: so far I only integrated and tested it with RIOT by exposing it as a `ping` subcommand for the `nimble_netif` shell command (-> https://github.com/haukepetersen/RIOT/tree/add_nimble_scnetifping, https://github.com/RIOT-OS/RIOT/pull/16539):
```
2021-06-08 12:14:35,823 # ble ping 0
> 2021-06-08 12:14:35,920 # ECHO_RSP, rtt:95 size:0
2021-06-08 12:14:35,936 # ble ping 0
> 2021-06-08 12:14:36,070 # ECHO_RSP, rtt:132 size:0
ble ping 0 moinsen
2021-06-08 12:14:44,246 # ble ping 0 moinsen
> 2021-06-08 12:14:44,321 # ECHO_RSP, rtt:73 size:7
```

Should we also add this to some of the NimBLE examples/test applications to ensure the feature is properly picked up by the NimBLE testing?

