### PR TITLE
ctype: Fix undefined behavior in ctype.h usage

### DIFF
--- a/apps/btshell/src/parse.c
+++ b/apps/btshell/src/parse.c
@@ -301,7 +301,7 @@ parse_time_us(const char *str, int *out_status)
     uint32_t val_mult = 1;
     uint32_t val_us;
 
-    while (isdigit(*str)) {
+    while (isdigit((unsigned char)*str)) {
         val *= 10;
         val += *str - '0';
         str++;
@@ -309,7 +309,7 @@ parse_time_us(const char *str, int *out_status)
 
     if (*str == '.') {
         str++;
-        while (isdigit(*str)) {
+        while (isdigit((unsigned char)*str)) {
             val *= 10;
             val += *str - '0';
             val_div *= 10;


### PR DESCRIPTION
When parse.c is build against newlib nano
following error shows up:
iparse.c:304:20: error: array subscript has type 'char' [-Werror=char-subscripts]

This can be easily fixed with casting to unsigned type first.