### PR TITLE
Removed an illogical check from npl_freertos_callout_reset

### DIFF
--- a/porting/npl/freertos/src/npl_os_freertos.c
+++ b/porting/npl/freertos/src/npl_os_freertos.c
@@ -279,10 +279,6 @@ npl_freertos_callout_reset(struct ble_npl_callout *co, ble_npl_time_t ticks)
 {
     BaseType_t woken1, woken2, woken3;
 
-    if (ticks < 0) {
-        return BLE_NPL_INVALID_PARAM;
-    }
-
     if (ticks == 0) {
         ticks = 1;
     }


### PR DESCRIPTION
Because `ble_npl_time_t` is `uint32_t`, checking if it is negative doesn't make sense and the check can be removed.