### PR TITLE
porting/nimble/src/nimble_port: riot initializes timers

### DIFF
--- a/porting/nimble/src/nimble_port.c
+++ b/porting/nimble/src/nimble_port.c
@@ -45,8 +45,10 @@ nimble_port_init(void)
 
 #if NIMBLE_CFG_CONTROLLER
     ble_hci_ram_init();
+#ifndef RIOT_VERSION
     hal_timer_init(5, NULL);
     os_cputime_init(32768);
+#endif
     ble_ll_init();
 #endif
 }


### PR DESCRIPTION
This PR allows RIOT to take care of initializing the timers. This is used when compiled in conjunction with other 'mynewt' based packages like Decawave `uwb-core`, see https://github.com/RIOT-OS/RIOT/pull/16348 and https://github.com/RIOT-OS/RIOT/issues/15528.

@haukepetersen might be the right person to review this one!