### PR TITLE
porting/npl/riot: add namespaced syscfg symlink

### DIFF
--- a/porting/npl/riot/include/npl_syscfg/npl_sycfg.h
+++ b/porting/npl/riot/include/npl_syscfg/npl_sycfg.h
@@ -1,0 +1,1 @@
+../syscfg/syscfg.h


### PR DESCRIPTION
This PR symlinks the autogenerated `syscfg` so that it can be included while overriding settings in a custom `syscfg.h`, it's used when building in RIOT for multiple packages based on mynewt, see RIOT-OS/RIOT#16348 and RIOT-OS/RIOT#15528. With the namespace, the header can be included individually and not the whole include dir.

@haukepetersen might be the right person to review this one!