### PR TITLE
nimble/porting: Make os_mbuf/os_mpool work on 64-bit.

### DIFF
--- a/porting/nimble/include/os/os_mempool.h
+++ b/porting/nimble/include/os/os_mempool.h
@@ -66,7 +66,7 @@ struct os_mempool {
     /** Bitmap of OS_MEMPOOL_F_[...] values. */
     uint8_t mp_flags;
     /** Address of memory buffer used by pool */
-    uint32_t mp_membuf_addr;
+    uintptr_t mp_membuf_addr;
     STAILQ_ENTRY(os_mempool) mp_list;
     SLIST_HEAD(,os_memblock);
     /** Name for memory block */

--- a/porting/nimble/src/os_mbuf.c
+++ b/porting/nimble/src/os_mbuf.c
@@ -244,7 +244,7 @@ os_mbuf_get(struct os_mbuf_pool *omp, uint16_t leadingspace)
 {
     struct os_mbuf *om;
 
-    os_trace_api_u32x2(OS_TRACE_ID_MBUF_GET, (uint32_t)omp,
+    os_trace_api_u32x2(OS_TRACE_ID_MBUF_GET, (uint32_t)(uintptr_t)omp,
                        (uint32_t)(uintptr_t)leadingspace);
 
     if (leadingspace > omp->omp_databuf_len) {

--- a/porting/nimble/src/os_mempool.c
+++ b/porting/nimble/src/os_mempool.c
@@ -38,7 +38,8 @@
 #define OS_MEMPOOL_TRUE_BLOCK_SIZE(mp) OS_MEM_TRUE_BLOCK_SIZE(mp->mp_block_size)
 #endif
 
-STAILQ_HEAD(, os_mempool) g_os_mempool_list;
+STAILQ_HEAD(, os_mempool) g_os_mempool_list =
+    STAILQ_HEAD_INITIALIZER(g_os_mempool_list);
 
 #if MYNEWT_VAL(OS_MEMPOOL_POISON)
 static uint32_t os_mem_poison = 0xde7ec7ed;
@@ -467,10 +468,4 @@ os_mempool_info_get_next(struct os_mempool *mp, struct os_mempool_info *omi)
     strncat(omi->omi_name, cur->name, sizeof(omi->omi_name) - 1);
 
     return (cur);
-}
-
-void
-os_mempool_module_init(void)
-{
-    STAILQ_INIT(&g_os_mempool_list);
 }

--- a/porting/nimble/src/os_msys_init.c
+++ b/porting/nimble/src/os_msys_init.c
@@ -27,7 +27,7 @@ static STAILQ_HEAD(, os_mbuf_pool) g_msys_pool_list =
 
 #if MYNEWT_VAL(MSYS_1_BLOCK_COUNT) > 0
 #define SYSINIT_MSYS_1_MEMBLOCK_SIZE                \
-    OS_ALIGN(MYNEWT_VAL(MSYS_1_BLOCK_SIZE), 4)
+    OS_ALIGN(MYNEWT_VAL(MSYS_1_BLOCK_SIZE), OS_ALIGNMENT)
 #define SYSINIT_MSYS_1_MEMPOOL_SIZE                 \
     OS_MEMPOOL_SIZE(MYNEWT_VAL(MSYS_1_BLOCK_COUNT),  \
                     SYSINIT_MSYS_1_MEMBLOCK_SIZE)
@@ -38,7 +38,7 @@ static struct os_mempool os_msys_1_mempool;
 
 #if MYNEWT_VAL(MSYS_2_BLOCK_COUNT) > 0
 #define SYSINIT_MSYS_2_MEMBLOCK_SIZE                \
-    OS_ALIGN(MYNEWT_VAL(MSYS_2_BLOCK_SIZE), 4)
+    OS_ALIGN(MYNEWT_VAL(MSYS_2_BLOCK_SIZE), OS_ALIGNMENT)
 #define SYSINIT_MSYS_2_MEMPOOL_SIZE                 \
     OS_MEMPOOL_SIZE(MYNEWT_VAL(MSYS_2_BLOCK_COUNT),  \
                     SYSINIT_MSYS_2_MEMBLOCK_SIZE)


### PR DESCRIPTION
We're using NimBLE in [MicroPython](https://github.com/micropython/micropython) and do much of our testing on (64-bit) Linux. @dpgeorge

Similar to #96 (@turon). Please see commit messages for details.

@KKopyscinski / @sjanc should I try and get this fixed in mynewt-core instead?