### PR TITLE
nimble/host: Remove redundant check in connection latency

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -4634,8 +4634,7 @@ ble_gap_check_conn_params(uint8_t phy, const struct ble_gap_conn_params *params)
     }
 
     /* Check connection latency */
-    if ((params->latency < BLE_HCI_CONN_LATENCY_MIN) ||
-        (params->latency > BLE_HCI_CONN_LATENCY_MAX)) {
+    if (params->latency > BLE_HCI_CONN_LATENCY_MAX) {
         return BLE_ERR_INV_HCI_CMD_PARMS;
     }
 


### PR DESCRIPTION
## Fix redundant check when extended advertisement flag is enabled.

In `ble_gap.c`, as `params->latency` is of `unsigned uint16_t` type and `BLE_HCI_CONN_LATENCY_MIN` is `0`, the check `(params->latency < BLE_HCI_CONN_LATENCY_MIN)` will always be false and hence can be dropped.

This can give below warnings if custom compiler options are used while compiling the code.
```
warning: comparison is always false due to limited range of data type [-Wtype-limits]
```