### PR TITLE
host/l2cap: send command reject in L2CAP disc req for invalid CID

### DIFF
--- a/nimble/host/src/ble_l2cap_sig.c
+++ b/nimble/host/src/ble_l2cap_sig.c
@@ -1540,7 +1540,13 @@ ble_l2cap_sig_disc_req_rx(uint16_t conn_handle, struct ble_l2cap_sig_hdr *hdr,
      * is from peer perspective. It is source CID from nimble perspective
      */
     chan = ble_hs_conn_chan_find_by_scid(conn, le16toh(req->dcid));
-    if (!chan || (le16toh(req->scid) != chan->dcid)) {
+    if (!chan) {
+        os_mbuf_free_chain(txom);
+        ble_hs_unlock();
+        ble_l2cap_sig_reject_invalid_cid_tx(conn_handle, hdr->identifier, req->dcid, req->scid);
+        return 0;
+    }
+    if (le16toh(req->scid) != chan->dcid) {
         os_mbuf_free_chain(txom);
         ble_hs_unlock();
         return 0;

--- a/nimble/host/test/src/ble_hs_test_util.h
+++ b/nimble/host/test/src/ble_hs_test_util.h
@@ -162,6 +162,8 @@ int ble_hs_test_util_l2cap_rx_payload_flat(uint16_t conn_handle, uint16_t cid,
                                            const void *data, int len);
 uint8_t ble_hs_test_util_verify_tx_l2cap_sig(uint16_t opcode, void *cmd,
                                                  uint16_t cmd_size);
+uint8_t ble_hs_test_util_verify_tx_l2cap_discon_rej(uint16_t opcode, void *cmd,
+                                             uint16_t cmd_size);
 int ble_hs_test_util_inject_rx_l2cap_sig(uint16_t conn_handle, uint8_t opcode,
                                      uint8_t id, void *cmd, uint16_t cmd_size);
 void ble_hs_test_util_verify_tx_l2cap(struct os_mbuf *txom);


### PR DESCRIPTION
If ble_hs_conn_chan_find_by_scid fails to find channel, it means
that destination CID in L2CAP Disconnection Request is invalid.
Send L2CAP_COMMAND_REJECT_RSP with BLE_L2CAP_SIG_ERR_INVALID_CID
reason.

This is affecting L2CAP/LE/CFC/BV-23-C