### PR TITLE
controller/ble_ll_scan: For callouts number of ticks should be used

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -3431,20 +3431,16 @@ ble_ll_set_ext_scan_params(const uint8_t *cmdbuf, uint8_t len)
 static void
 ble_ll_scan_duration_period_timers_restart(struct ble_ll_scan_sm *scansm)
 {
-    ble_npl_time_t now;
-
-    now = ble_npl_time_get();
-
     ble_npl_callout_stop(&scansm->duration_timer);
     ble_npl_callout_stop(&scansm->period_timer);
 
     if (scansm->duration_ticks) {
         ble_npl_callout_reset(&scansm->duration_timer,
-                                                now + scansm->duration_ticks);
+                              scansm->duration_ticks);
 
         if (scansm->period_ticks) {
             ble_npl_callout_reset(&scansm->period_timer,
-                                                    now + scansm->period_ticks);
+                                  scansm->period_ticks);
         }
     }
 }


### PR DESCRIPTION
- For callouts number of ticks are used, not an absolute value in the future.

*BEFORE*
```
001674 [ts=13078120us, mod=100 level=1] scan: completed scan procedure delta=1674
001676 [ts=13093744us, mod=100 level=1] scan: restarted scan procedure
004662 [ts=36421848us, mod=100 level=1] scan: completed scan procedure delta=2986
004664 [ts=36437472us, mod=100 level=1] scan: restarted scan procedure
010638 [ts=83109368us, mod=100 level=1] scan: completed scan procedure delta=5974
010640 [ts=83124992us, mod=100 level=1] scan: restarted scan procedure
022590 [ts=176484344us, mod=100 level=1] scan: completed scan procedure delta=11950
022592 [ts=176499968us, mod=100 level=1] scan: restarted scan procedure
```

*AFTER*
```
007634 [ts=59640584us, mod=100 level=1] scan: completed scan procedure, delta=1310
008946 [ts=69890568us, mod=100 level=1] scan: completed scan procedure, delta=1310
010258 [ts=80140616us, mod=100 level=1] scan: completed scan procedure, delta=1310
011570 [ts=90390600us, mod=100 level=1] scan: completed scan procedure, delta=1310
012882 [ts=100640584us, mod=100 level=1] scan: completed scan procedure, delta=1310
014194 [ts=110890568us, mod=100 level=1] scan: completed scan procedure, delta=1310
015506 [ts=121140616us, mod=100 level=1] scan: completed scan procedure, delta=1310
016818 [ts=131390600us, mod=100 level=1] scan: completed scan procedure, delta=1310
018130 [ts=141640584us, mod=100 level=1] scan: completed scan procedure, delta=1310
```