### PR TITLE
nimble/host: Sync sending Host Number of Completed Packets command

### DIFF
--- a/nimble/host/src/ble_hs_flow.c
+++ b/nimble/host/src/ble_hs_flow.c
@@ -92,7 +92,7 @@ ble_hs_flow_tx_num_comp_pkts(void)
              * response from the controller, so don't use the normal blocking
              * HCI API when sending it.
              */
-            rc = ble_hs_hci_cmd_send_buf(
+            rc = ble_hs_hci_cmd_tx_no_rsp(
                 BLE_HCI_OP(BLE_HCI_OGF_CTLR_BASEBAND,
                            BLE_HCI_OCF_CB_HOST_NUM_COMP_PKTS),
                 buf, sizeof(buf));

--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -292,6 +292,20 @@ ble_hs_hci_wait_for_ack(void)
 }
 
 int
+ble_hs_hci_cmd_tx_no_rsp(uint16_t opcode, const void *cmd, uint8_t cmd_len)
+{
+    int rc;
+
+    ble_hs_hci_lock();
+
+    rc = ble_hs_hci_cmd_send_buf(opcode, cmd, cmd_len);
+
+    ble_hs_hci_unlock();
+
+    return rc;
+}
+
+int
 ble_hs_hci_cmd_tx(uint16_t opcode, const void *cmd, uint8_t cmd_len,
                   void *rsp, uint8_t rsp_len)
 {

--- a/nimble/host/src/ble_hs_hci_priv.h
+++ b/nimble/host/src/ble_hs_hci_priv.h
@@ -81,6 +81,8 @@ struct hci_periodic_adv_params
 
 extern uint16_t ble_hs_hci_avail_pkts;
 
+/* This function is not waiting for command status/complete HCI events */
+int ble_hs_hci_cmd_tx_no_rsp(uint16_t opcode, const void *cmd, uint8_t cmd_len);
 int ble_hs_hci_cmd_tx(uint16_t opcode, const void *cmd, uint8_t cmd_len,
                       void *rsp, uint8_t rsp_len);
 void ble_hs_hci_init(void);


### PR DESCRIPTION
Host Number of Completed Packets command is special as it doesn't
generate status event and thus is not send with ble_hs_hci_cmd_tx.

We should stil sync sending it with ble_hs_hci_cmd_tx() though to
avoid requesting more than one command buffer from HCI transport
(which may not be able to provide more).