### PR TITLE
host: Reset GAP server service/attribute counters on server reset

### DIFF
--- a/nimble/host/include/host/ble_hs.h
+++ b/nimble/host/include/host/ble_hs.h
@@ -283,7 +283,13 @@ struct ble_hs_cfg {
     void *store_status_arg;
 };
 
+extern uint16_t ble_hs_max_attrs;
+extern uint16_t ble_hs_max_services;
+extern uint16_t ble_hs_max_client_configs;
+
 extern struct ble_hs_cfg ble_hs_cfg;
+extern uint16_t ble_hs_gap_primary_svcs_count;
+extern uint16_t ble_hs_gap_primary_svcs_attrs_count;
 
 /**
  * @}

--- a/nimble/host/services/gap/src/ble_svc_gap.c
+++ b/nimble/host/services/gap/src/ble_svc_gap.c
@@ -296,6 +296,8 @@ ble_svc_gap_init(void)
 
 #if NIMBLE_BLE_CONNECT
     rc = ble_gatts_count_cfg(ble_svc_gap_defs);
+    ble_hs_gap_primary_svcs_count = ble_hs_max_services;
+    ble_hs_gap_primary_svcs_attrs_count = ble_hs_max_attrs;
     SYSINIT_PANIC_ASSERT(rc == 0);
 
     rc = ble_gatts_add_svcs(ble_svc_gap_defs);

--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -2671,6 +2671,11 @@ ble_att_svr_reset(void)
         ble_att_svr_entry_free(entry);
     }
 
+    /* All entries are freed - reset variables that kept track of their count */
+    ble_hs_max_services = ble_hs_gap_primary_svcs_count;
+    ble_hs_max_attrs = ble_hs_gap_primary_svcs_attrs_count;
+    ble_hs_max_client_configs = 0;
+
     /* Note: prep entries do not get freed here because it is assumed there are
      * no established connections.
      */

--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -87,6 +87,9 @@ uint16_t ble_hs_max_attrs;
 uint16_t ble_hs_max_services;
 uint16_t ble_hs_max_client_configs;
 
+uint16_t ble_hs_gap_primary_svcs_count;
+uint16_t ble_hs_gap_primary_svcs_attrs_count;
+
 #if MYNEWT_VAL(BLE_HS_DEBUG)
 static uint8_t ble_hs_dbg_mutex_locked;
 #endif

--- a/nimble/host/src/ble_hs_priv.h
+++ b/nimble/host/src/ble_hs_priv.h
@@ -98,10 +98,6 @@ extern uint8_t ble_hs_enabled_state;
 
 extern const uint8_t ble_hs_misc_null_addr[6];
 
-extern uint16_t ble_hs_max_attrs;
-extern uint16_t ble_hs_max_services;
-extern uint16_t ble_hs_max_client_configs;
-
 void ble_hs_process_rx_data_queue(void);
 int ble_hs_tx_data(struct os_mbuf *om);
 void ble_hs_wakeup_tx(void);


### PR DESCRIPTION
When `ble_gatts_reset` is called, nothing resets `ble_hs_max_services`,
`ble_hs_max_attrs` and `ble_hs_max_client_configs` to original values.
That leads to increasingly large allocs at next time
`ble_gatts_count_cfg` is called. Now, all mentioned variables
are being reset on server reset, which results in allocs of same
size each time.