### PR TITLE
npl/riot: simplify ble_npl_hw_is_in_critical()

### DIFF
--- a/porting/npl/riot/include/nimble/nimble_npl_os.h
+++ b/porting/npl/riot/include/nimble/nimble_npl_os.h
@@ -38,8 +38,6 @@ extern "C" {
 typedef uint32_t ble_npl_time_t;
 typedef int32_t ble_npl_stime_t;
 
-extern volatile int ble_npl_in_critical;
-
 struct ble_npl_event {
     event_callback_t e;
     void *arg;
@@ -257,27 +255,19 @@ ble_npl_time_delay(ble_npl_time_t ticks)
 static inline uint32_t
 ble_npl_hw_enter_critical(void)
 {
-    uint32_t ctx = irq_disable();
-    ++ble_npl_in_critical;
-    return ctx;
+    return (uint32_t)irq_disable();
 }
 
 static inline void
 ble_npl_hw_exit_critical(uint32_t ctx)
 {
-    --ble_npl_in_critical;
     irq_restore((unsigned)ctx);
 }
 
 static inline bool
 ble_npl_hw_is_in_critical(void)
 {
-    /*
-     * XXX Currently RIOT does not support an API for finding out if interrupts
-     *     are currently disabled, hence in a critical section in this context.
-     *     So for now, we use this global variable to keep this state for us.
-    -*/
-    return (ble_npl_in_critical > 0);
+    return (bool)!irq_is_enabled();
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Recently the RIOT IRQ API was extended to support irq_is_enabled(), so time to switch away from the hacked implementation of ble_npl_hw_is_in_critical().