### PR TITLE
porting/npl/linux: support C library which didn't have PTHREAD_MUTEX_RECURSIVE_NP

### DIFF
--- a/porting/npl/linux/src/os_atomic.c
+++ b/porting/npl/linux/src/os_atomic.c
@@ -22,10 +22,19 @@
 
 #include "nimble/nimble_npl.h"
 
+#ifdef PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
 static pthread_mutex_t s_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+#else
+static pthread_mutex_t s_mutex = PTHREAD_MUTEX_INITIALIZER;
+static uint8_t s_mutex_inited = 0;
+#endif
 
 uint32_t ble_npl_hw_enter_critical(void)
 {
+    if( !s_mutex_inited ) {
+        pthread_mutexattr_settype(&s_mutex, PTHREAD_MUTEX_RECURSIVE);
+        s_mutex_inited = 1;
+    }
     pthread_mutex_lock(&s_mutex);
     return 0;
 }

--- a/porting/npl/linux/src/os_mutex.c
+++ b/porting/npl/linux/src/os_mutex.c
@@ -31,7 +31,11 @@ ble_npl_mutex_init(struct ble_npl_mutex *mu)
     }
 
     pthread_mutexattr_init(&mu->attr);
+    #ifdef PTHREAD_MUTEX_RECURSIVE_NP
     pthread_mutexattr_settype(&mu->attr, PTHREAD_MUTEX_RECURSIVE_NP);
+    #else
+    pthread_mutexattr_settype(&mu->attr, PTHREAD_MUTEX_RECURSIVE);    
+    #endif
     pthread_mutex_init(&mu->lock, &mu->attr);
 
     return BLE_NPL_OK;


### PR DESCRIPTION
porting/npl/linux: support C library (such as musl) which didn't have PTHREAD_MUTEX_RECURSIVE_NP defined