### PR TITLE
apps/bttester: implement NRPA rotation

### DIFF
--- a/apps/bttester/syscfg.yml
+++ b/apps/bttester/syscfg.yml
@@ -75,6 +75,10 @@ syscfg.defs:
         description: Maximum MTU size the application can handle
         value: 230
 
+    BTTESTER_NRPA_TIMEOUT:
+        description: NRPA rotation timeout in seconds
+        value: 5
+
 syscfg.vals:
     OS_MAIN_STACK_SIZE: 512
     SHELL_TASK: 0


### PR DESCRIPTION
As per CORE v5.3, Vol 3, Part C 10.7.1 NRPA should also rotate, same
as RPA is doing right now. For time beeing let's implement this in
tester application, before it's implemented in host.

This affects GAP/BROB/BCST/BV-04-C