### PR TITLE
nimble/ll: Fix TX time restrictions during phy transition

### DIFF
--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -2858,8 +2858,11 @@ ble_ll_ctrl_tx_done(struct os_mbuf *txpdu, struct ble_ll_conn_sm *connsm)
 #endif
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
     case BLE_LL_CTRL_PHY_REQ:
-        connsm->phy_tx_transition =
-                    ble_ll_ctrl_phy_tx_transition_get(connsm->phy_data.req_pref_tx_phys_mask);
+        if (connsm->conn_role == BLE_LL_CONN_ROLE_SLAVE) {
+            connsm->phy_tx_transition =
+                    ble_ll_ctrl_phy_tx_transition_get(
+                            connsm->phy_data.req_pref_tx_phys_mask);
+        }
         break;
     case BLE_LL_CTRL_PHY_UPDATE_IND:
         connsm->phy_tx_transition =


### PR DESCRIPTION
We do not need to restrict TX time after sending LL_PHY_REQ as a master,
this only applies to slave.

This makes LL/CON/CEN/BV-53-C pass instead of being inconclusive due to
data fragmentation done by IUT between LL_PHY_REQ and LL_PHU_UPDATE_IND.

Ref: Core 5.x, Vol. 6, Part B, section 5.1.10.1