### PR TITLE
nimble/ll: Optimize AUX_CONNECT_REQ tx

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -192,8 +192,9 @@ struct hci_ext_conn_params
 {
     uint16_t scan_itvl;
     uint16_t scan_window;
-    uint16_t conn_itvl_min;
-    uint16_t conn_itvl_max;
+    uint32_t conn_itvl;
+    uint16_t conn_itvl_ticks;
+    uint8_t conn_itvl_usecs;
     uint16_t conn_latency;
     uint16_t supervision_timeout;
     uint16_t min_ce_len;

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -707,6 +707,9 @@ ble_ll_ext_conn_create(const uint8_t *cmdbuf, uint8_t len)
         ble_ll_conn_itvl_to_ticks(conn_itvl_max, &hcc.params[1].conn_itvl_ticks,
                                   &hcc.params[1].conn_itvl_usecs);
 
+        if (!fallback_params) {
+            fallback_params = &hcc.params[1];
+        }
         params++;
     }
 #endif


### PR DESCRIPTION
Currently we initialize a lot of connsm settings prior to scheduling
1st connection event and this takes some time. However, we only need
connection interval, latency and supervision timeout to be initialized
in order to schedule event properly and send AUX_CONNECT_REQ, other
stuff can be done after tx has already started.

This is especially important on slower MCU like CMAC as with old code
it was barely possible to make tx within Tifs even on speed build.

New code saves ~15us on CMAC prior to tx so we have quite a good margin
to complete on time.Currently we initialize a lot of connsm settings prior to scheduling
1st connection event and this takes some time. However, we only need
connection interval, latency and supervision timeout to be initialized
in order to schedule event properly and send AUX_CONNECT_REQ, other
stuff can be done after tx has already started.

This is especially important on slower MCU like CMAC as with old code
it was barely possible to make tx within Tifs even on speed build.

New code saves ~15us on CMAC prior to tx so we have quite a good margin
to complete on time.