### PR TITLE
nimble/phy/nrf: Fix checking for resolved addr

### DIFF
--- a/nimble/drivers/nrf51/src/ble_hw.c
+++ b/nimble/drivers/nrf51/src/ble_hw.c
@@ -474,13 +474,8 @@ ble_hw_resolv_list_size(void)
 int
 ble_hw_resolv_list_match(void)
 {
-    uint32_t index;
-
-    if (NRF_AAR->EVENTS_END) {
-        if (NRF_AAR->EVENTS_RESOLVED) {
-            index = NRF_AAR->STATUS;
-            return (int)index;
-        }
+    if (NRF_AAR->ENABLE && NRF_AAR->EVENTS_END && NRF_AAR->EVENTS_RESOLVED) {
+        return (int)NRF_AAR->STATUS;
     }
 
     return -1;

--- a/nimble/drivers/nrf52/src/ble_hw.c
+++ b/nimble/drivers/nrf52/src/ble_hw.c
@@ -474,13 +474,8 @@ ble_hw_resolv_list_size(void)
 int
 ble_hw_resolv_list_match(void)
 {
-    uint32_t index;
-
-    if (NRF_AAR->EVENTS_END) {
-        if (NRF_AAR->EVENTS_RESOLVED) {
-            index = NRF_AAR->STATUS;
-            return (int)index;
-        }
+    if (NRF_AAR->ENABLE && NRF_AAR->EVENTS_END && NRF_AAR->EVENTS_RESOLVED) {
+        return (int)NRF_AAR->STATUS;
     }
 
     return -1;

--- a/nimble/drivers/nrf5340/src/ble_hw.c
+++ b/nimble/drivers/nrf5340/src/ble_hw.c
@@ -461,13 +461,9 @@ ble_hw_resolv_list_size(void)
 int
 ble_hw_resolv_list_match(void)
 {
-    uint32_t index;
-
-    if (NRF_AAR_NS->EVENTS_END) {
-        if (NRF_AAR_NS->EVENTS_RESOLVED) {
-            index = NRF_AAR_NS->STATUS;
-            return (int)index;
-        }
+    if (NRF_AAR_NS->ENABLE && NRF_AAR_NS->EVENTS_END &&
+        NRF_AAR_NS->EVENTS_RESOLVED) {
+        return (int)NRF_AAR_NS->STATUS;
     }
 
     return -1;


### PR DESCRIPTION
We should check if NRF_AAR was enabled prior to checking its result
to avoid reading some uninitialied values if resolver was not enabled.