### PR TITLE
nimble/ll: Refactor and cleanup initiator code

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -216,7 +216,6 @@ extern STATS_SECT_DECL(ble_ll_stats) ble_ll_stats;
 #define BLE_LL_STATE_STANDBY        (0)
 #define BLE_LL_STATE_ADV            (1)
 #define BLE_LL_STATE_SCANNING       (2)
-#define BLE_LL_STATE_INITIATING     (3)
 #define BLE_LL_STATE_CONNECTION     (4)
 #define BLE_LL_STATE_DTM            (5)
 #define BLE_LL_STATE_SYNC           (6)

--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -205,7 +205,6 @@ struct ble_ll_conn_sm
     uint16_t rem_max_rx_time;
     uint16_t eff_max_tx_time;
     uint16_t eff_max_rx_time;
-    uint8_t max_tx_octets_phy_mode[BLE_PHY_NUM_MODE];
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
     uint16_t host_req_max_tx_time;
 #endif

--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -45,16 +45,6 @@ extern "C" {
 /* Channel map size */
 #define BLE_LL_CONN_CHMAP_LEN           (5)
 
-/* Definitions for source clock accuracy */
-#define BLE_MASTER_SCA_251_500_PPM      (0)
-#define BLE_MASTER_SCA_151_250_PPM      (1)
-#define BLE_MASTER_SCA_101_150_PPM      (2)
-#define BLE_MASTER_SCA_76_100_PPM       (3)
-#define BLE_MASTER_SCA_51_75_PPM        (4)
-#define BLE_MASTER_SCA_31_50_PPM        (5)
-#define BLE_MASTER_SCA_21_30_PPM        (6)
-#define BLE_MASTER_SCA_0_20_PPM         (7)
-
 /* Definition for RSSI when the RSSI is unknown */
 #define BLE_LL_CONN_UNKNOWN_RSSI        (127)
 

--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -188,29 +188,6 @@ struct hci_conn_update
     uint16_t max_ce_len;
 };
 
-struct hci_ext_conn_params
-{
-    uint16_t scan_itvl;
-    uint16_t scan_window;
-    uint32_t conn_itvl;
-    uint16_t conn_itvl_ticks;
-    uint8_t conn_itvl_usecs;
-    uint16_t conn_latency;
-    uint16_t supervision_timeout;
-    uint16_t min_ce_len;
-    uint16_t max_ce_len;
-};
-
-struct hci_ext_create_conn
-{
-    uint8_t filter_policy;
-    uint8_t own_addr_type;
-    uint8_t peer_addr_type;
-    uint8_t peer_addr[BLE_DEV_ADDR_LEN];
-    uint8_t init_phy_mask;
-    struct hci_ext_conn_params params[3];
-};
-
 /* Connection state machine */
 struct ble_ll_conn_sm
 {
@@ -378,10 +355,6 @@ struct ble_ll_conn_sm
 
     /* XXX: for now, just store them all */
     struct ble_ll_conn_params conn_cp;
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    struct hci_ext_create_conn initial_params;
-#endif
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
     uint8_t  sync_transfer_mode;

--- a/nimble/controller/include/controller/ble_ll_scan.h
+++ b/nimble/controller/include/controller/ble_ll_scan.h
@@ -197,10 +197,11 @@ int ble_ll_scan_can_chg_whitelist(void);
 int ble_ll_scan_enabled(void);
 
 /* Initialize the scanner when we start initiating */
-struct hci_create_conn;
+struct ble_ll_conn_create_scan;
+struct ble_ll_conn_create_params;
 int
-ble_ll_scan_initiator_start(struct hci_create_conn *hcc,
-                            struct ble_ll_conn_sm *connsm);
+ble_ll_scan_initiator_start(struct ble_ll_conn_sm *connsm, uint8_t ext,
+                            struct ble_ll_conn_create_scan *cc_scan);
 
 /* Returns storage for PDU data (for SCAN_REQ or CONNECT_IND) */
 struct ble_ll_scan_pdu_data *ble_ll_scan_get_pdu_data(void);
@@ -227,12 +228,6 @@ void ble_ll_scan_wfr_timer_exp(void);
 void ble_ll_scan_interrupted(struct ble_ll_scan_sm *scansm);
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-/* Initialize the extended scanner when we start initiating */
-struct hci_ext_create_conn;
-int
-ble_ll_scan_ext_initiator_start(struct hci_ext_create_conn *hcc,
-                                struct ble_ll_conn_sm *connsm);
-
 /* Called to parse extended advertising*/
 void ble_ll_scan_end_adv_evt(struct ble_ll_aux_data *aux_data);
 #endif

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -67,7 +67,6 @@ extern uint8_t g_ble_ll_sched_offset_ticks;
 #define BLE_LL_SCHED_TYPE_ADV       (1)
 #define BLE_LL_SCHED_TYPE_SCAN      (2)
 #define BLE_LL_SCHED_TYPE_CONN      (3)
-#define BLE_LL_SCHED_TYPE_AUX_SCAN  (4)
 #define BLE_LL_SCHED_TYPE_DTM       (5)
 #define BLE_LL_SCHED_TYPE_PERIODIC  (6)
 #define BLE_LL_SCHED_TYPE_SYNC      (7)

--- a/nimble/controller/include/controller/ble_phy.h
+++ b/nimble/controller/include/controller/ble_phy.h
@@ -202,6 +202,11 @@ void ble_phy_resolv_list_disable(void);
 #define BLE_PHY_MASK_2M             (BLE_HCI_LE_PHY_2M_PREF_MASK)
 #define BLE_PHY_MASK_CODED          (BLE_HCI_LE_PHY_CODED_PREF_MASK)
 
+/* PHY indices (for a zero-based array) */
+#define BLE_PHY_IDX_1M              (0)
+#define BLE_PHY_IDX_2M              (1)
+#define BLE_PHY_IDX_CODED           (2)
+
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY) || MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY))
 uint32_t ble_phy_mode_pdu_start_off(int phy);
 void ble_phy_mode_set(uint8_t tx_phy_mode, uint8_t rx_phy_mode);

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -677,9 +677,6 @@ ble_ll_wfr_timer_exp(void *arg)
         case BLE_LL_STATE_SCANNING:
             ble_ll_scan_wfr_timer_exp();
             break;
-        case BLE_LL_STATE_INITIATING:
-            ble_ll_conn_init_wfr_timer_exp();
-            break;
 #if MYNEWT_VAL(BLE_LL_DTM)
         case BLE_LL_STATE_DTM:
             ble_ll_dtm_wfr_timer_exp();
@@ -842,9 +839,6 @@ ble_ll_rx_pkt_in(void)
         case BLE_LL_STATE_SCANNING:
             ble_ll_scan_rx_pkt_in(pdu_type, m, ble_hdr);
             break;
-        case BLE_LL_STATE_INITIATING:
-            ble_ll_init_rx_pkt_in(pdu_type, rxbuf, ble_hdr);
-            break;
 #if MYNEWT_VAL(BLE_LL_DTM)
         case BLE_LL_STATE_DTM:
             ble_ll_dtm_rx_pkt_in(m, ble_hdr);
@@ -979,9 +973,6 @@ ble_ll_rx_start(uint8_t *rxbuf, uint8_t chan, struct ble_mbuf_hdr *rxhdr)
         break;
     case BLE_LL_STATE_ADV:
         rc = ble_ll_adv_rx_isr_start(pdu_type);
-        break;
-    case BLE_LL_STATE_INITIATING:
-        rc = ble_ll_init_rx_isr_start(pdu_type, rxhdr);
         break;
     case BLE_LL_STATE_SCANNING:
         rc = ble_ll_scan_rx_isr_start(pdu_type, &rxhdr->rxinfo.flags);
@@ -1121,9 +1112,6 @@ ble_ll_rx_end(uint8_t *rxbuf, struct ble_mbuf_hdr *rxhdr)
             }
         }
         rc = ble_ll_scan_rx_isr_end(rxpdu, crcok);
-        break;
-    case BLE_LL_STATE_INITIATING:
-        rc = ble_ll_init_rx_isr_end(rxbuf, crcok, rxhdr);
         break;
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
     case BLE_LL_STATE_SCAN_AUX:

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -577,7 +577,7 @@ ble_ll_set_random_addr(const uint8_t *cmdbuf, uint8_t len, bool hci_adv_ext)
      * Test specification extends this also to initiating.
      */
 
-    if (g_ble_ll_conn_create_sm || ble_ll_scan_enabled() ||
+    if (g_ble_ll_conn_create_sm.connsm || ble_ll_scan_enabled() ||
                                 (!hci_adv_ext && ble_ll_adv_enabled())) {
         return BLE_ERR_CMD_DISALLOWED;
     }

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -674,64 +674,6 @@ ble_ll_conn_wfr_timer_exp(void)
     STATS_INC(ble_ll_conn_stats, wfr_expirations);
 }
 
-void
-ble_ll_conn_reset_pending_aux_conn_rsp(void)
-{
-#if !MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    return;
-#endif
-    struct ble_ll_conn_sm *connsm;
-
-    connsm = g_ble_ll_conn_create_sm;
-    if (!connsm) {
-        return;
-    }
-
-    if (CONN_F_AUX_CONN_REQ(connsm)) {
-        STATS_INC(ble_ll_stats, aux_conn_rsp_err);
-        CONN_F_CONN_REQ_TXD(connsm) = 0;
-        CONN_F_AUX_CONN_REQ(connsm) = 0;
-        ble_ll_sched_rmv_elem(&connsm->conn_sch);
-        return;
-    }
-
-    return;
-}
-
-bool
-ble_ll_conn_init_pending_aux_conn_rsp(void)
-{
-#if !MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    return false;
-#endif
-    struct ble_ll_conn_sm *connsm;
-
-    connsm = g_ble_ll_conn_create_sm;
-    if (!connsm) {
-        return false;
-    }
-
-    return CONN_F_AUX_CONN_REQ(connsm);
-}
-
-void
-ble_ll_conn_init_wfr_timer_exp(void)
-{
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    struct ble_ll_conn_sm *connsm;
-
-    connsm = g_ble_ll_conn_create_sm;
-    if (!connsm) {
-        return;
-    }
-
-    ble_ll_conn_reset_pending_aux_conn_rsp();
-    connsm->inita_identity_used = 0;
-
-    ble_ll_scan_interrupted(connsm->scansm);
-
-#endif
-}
 /**
  * Callback for slave when it transmits a data pdu and the connection event
  * ends after the transmission.
@@ -1764,6 +1706,13 @@ void
 ble_ll_conn_ext_set_params(struct ble_ll_conn_sm *connsm,
                            struct hci_ext_conn_params *hcc_params, int phy)
 {
+    connsm->slave_latency = hcc_params->conn_latency;
+    connsm->supervision_tmo = hcc_params->supervision_timeout;
+
+    connsm->conn_itvl = hcc_params->conn_itvl;
+    connsm->conn_itvl_ticks = hcc_params->conn_itvl_ticks;
+    connsm->conn_itvl_usecs = hcc_params->conn_itvl_usecs;
+
     /* Check the min/max CE lengths are less than connection interval */
     if (hcc_params->min_ce_len > (connsm->conn_itvl * 2)) {
         connsm->min_ce_len = connsm->conn_itvl * 2;
@@ -1833,7 +1782,6 @@ ble_ll_conn_sm_new(struct ble_ll_conn_sm *connsm)
     connsm->sub_vers_nr = 0;
     connsm->reject_reason = BLE_ERR_SUCCESS;
     connsm->conn_rssi = BLE_LL_CONN_UNKNOWN_RSSI;
-    connsm->rpa_index = -1;
     connsm->inita_identity_used = 0;
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
@@ -2667,8 +2615,8 @@ ble_ll_conn_event_end(struct ble_npl_event *ev)
 
  * @param txoffset      The tx window offset for this connection
  */
-static void
-ble_ll_conn_connect_ind_prepare(struct ble_ll_conn_sm *connsm,
+void
+ble_ll_conn_prepare_connect_ind(struct ble_ll_conn_sm *connsm,
                                 struct ble_ll_scan_pdu_data *pdu_data,
                                 uint8_t adva_type, uint8_t *adva,
                                 uint8_t inita_type, uint8_t *inita,
@@ -2753,110 +2701,8 @@ ble_ll_conn_connect_ind_prepare(struct ble_ll_conn_sm *connsm,
     pdu_data->hdr_byte = hdr;
 }
 
-/* Returns true if the address matches the connection peer address having in
- * mind privacy mode
- */
-static int
-ble_ll_conn_is_peer_adv(uint8_t addr_type, uint8_t *adva, int index)
-{
-    int rc;
-    uint8_t *peer_addr = NULL;
-    struct ble_ll_conn_sm *connsm;
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
-    struct ble_ll_resolv_entry *rl;
-#endif
-
-    /* XXX: Deal with different types of random addresses here! */
-    connsm = g_ble_ll_conn_create_sm;
-    if (!connsm) {
-        return 0;
-    }
-
-    switch (connsm->peer_addr_type) {
-    /* Fall-through intentional */
-    case BLE_HCI_CONN_PEER_ADDR_PUBLIC:
-    case BLE_HCI_CONN_PEER_ADDR_RANDOM:
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
-        if (ble_ll_addr_is_id(adva, addr_type)) {
-                /* Peer uses its identity address. Let's verify privacy mode.
-                 *
-                 * Note: Core Spec 5.0 Vol 6, Part B
-                 * If the Host has added the peer device to the resolving list
-                 * with an all-zero peer IRK, the Controller shall only accept
-                 * the peer's identity address.
-                 */
-            if (ble_ll_resolv_enabled()) {
-                rl = ble_ll_resolv_list_find(adva, addr_type);
-                if (rl && (rl->rl_priv_mode == BLE_HCI_PRIVACY_NETWORK) &&
-                    rl->rl_has_peer) {
-                    return 0;
-                }
-            }
-        }
-
-        /* Check if peer uses RPA. If so and it match, use it as controller
-         * supports privacy mode
-         */
-        if ((index >= 0) &&
-                (g_ble_ll_resolv_list[index].rl_addr_type == connsm->peer_addr_type)) {
-            peer_addr = g_ble_ll_resolv_list[index].rl_identity_addr;
-        }
-#endif
-        /*
-         * If we are here it means we don't know the device, lets
-         * check if type is what we are looking for and later
-         * if address matches
-         */
-        if ((connsm->peer_addr_type == addr_type) && !peer_addr) {
-            peer_addr = adva;
-        }
-
-        break;
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
-    case BLE_HCI_CONN_PEER_ADDR_PUBLIC_IDENT:
-        if ((index < 0) ||
-            (g_ble_ll_resolv_list[index].rl_addr_type != 0)) {
-            return 0;
-        }
-        peer_addr = g_ble_ll_resolv_list[index].rl_identity_addr;
-        break;
-    case BLE_HCI_CONN_PEER_ADDR_RANDOM_IDENT:
-        if ((index < 0) ||
-            (g_ble_ll_resolv_list[index].rl_addr_type != 1)) {
-            return 0;
-        }
-        peer_addr = g_ble_ll_resolv_list[index].rl_identity_addr;
-        break;
-#endif
-    default:
-        peer_addr = NULL;
-        break;
-    }
-
-    rc = 0;
-    if (peer_addr) {
-        if (!memcmp(peer_addr, connsm->peer_addr, BLE_DEV_ADDR_LEN)) {
-            rc = 1;
-        }
-    }
-
-    return rc;
-}
-
-static void
-ble_ll_conn_connect_ind_txend_to_standby(void *arg)
-{
-    ble_ll_state_set(BLE_LL_STATE_STANDBY);
-}
-
-static void
-ble_ll_conn_connect_ind_txend_to_init(void *arg)
-{
-    ble_ll_state_set(BLE_LL_STATE_INITIATING);
-}
-
-static uint8_t
-ble_ll_conn_connect_ind_tx_pducb(uint8_t *dptr, void *pducb_arg, uint8_t *hdr_byte)
+uint8_t
+ble_ll_conn_tx_connect_ind_pducb(uint8_t *dptr, void *pducb_arg, uint8_t *hdr_byte)
 {
     struct ble_ll_conn_sm *connsm;
     struct ble_ll_scan_pdu_data *pdu_data;
@@ -2891,30 +2737,6 @@ ble_ll_conn_connect_ind_tx_pducb(uint8_t *dptr, void *pducb_arg, uint8_t *hdr_by
 }
 
 /**
- * Send a connection requestion to an advertiser
- *
- * Context: Interrupt
- *
- * @param addr_type Address type of advertiser
- * @param adva Address of advertiser
- */
-int
-ble_ll_conn_connect_ind_send(struct ble_ll_conn_sm *connsm, uint8_t end_trans)
-{
-    int rc;
-
-    if (end_trans == BLE_PHY_TRANSITION_NONE) {
-        ble_phy_set_txend_cb(ble_ll_conn_connect_ind_txend_to_standby, NULL);
-    } else {
-        ble_phy_set_txend_cb(ble_ll_conn_connect_ind_txend_to_init, NULL);
-    }
-
-    rc = ble_phy_tx(ble_ll_conn_connect_ind_tx_pducb, connsm, end_trans);
-
-    return rc;
-}
-
-/**
  * Called when a schedule item overlaps the currently running connection
  * event. This generally should not happen, but if it does we stop the
  * current connection event to let the schedule item run.
@@ -2933,595 +2755,141 @@ ble_ll_conn_event_halt(void)
     }
 }
 
-/**
- * Process a received PDU while in the initiating state.
- *
- * Context: Link Layer task.
- *
- * @param pdu_type
- * @param rxbuf
- * @param ble_hdr
- */
-void
-ble_ll_init_rx_pkt_in(uint8_t pdu_type, uint8_t *rxbuf,
-                      struct ble_mbuf_hdr *ble_hdr)
-{
-    uint8_t addr_type;
-    uint8_t *addr;
-    uint8_t *adv_addr;
-    uint8_t *inita;
-    uint8_t inita_type;
-    struct ble_ll_conn_sm *connsm;
-    int ext_adv_mode = -1;
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    struct ble_ll_aux_data *aux_data = NULL;
-
-     if (ble_hdr->rxinfo.user_data) {
-         /* aux_data just a local helper, no need to ref
-          * as ble_hdr->rxinfo.user_data is unref in the end of this function
-          */
-         aux_data = ble_hdr->rxinfo.user_data;
-     }
-#endif
-
-    /* Get the connection state machine we are trying to create */
-    connsm = g_ble_ll_conn_create_sm;
-    if (!connsm) {
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-        if (aux_data) {
-            ble_ll_scan_aux_data_unref(ble_hdr->rxinfo.user_data);
-            ble_hdr->rxinfo.user_data = NULL;
-        }
-#endif
-        return;
-    }
-
-    if (!BLE_MBUF_HDR_CRC_OK(ble_hdr)) {
-        goto scan_continue;
-    }
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    if (BLE_MBUF_HDR_AUX_INVALID(ble_hdr)) {
-        goto scan_continue;
-    }
-
-    if (pdu_type == BLE_ADV_PDU_TYPE_ADV_EXT_IND) {
-        if (BLE_MBUF_HDR_WAIT_AUX(ble_hdr)) {
-            /* Just continue scanning. We are waiting for AUX */
-            if (!ble_ll_sched_aux_scan(ble_hdr, connsm->scansm, aux_data)) {
-                /* ref for aux ptr in the scheduler */
-                ble_ll_scan_aux_data_unref(ble_hdr->rxinfo.user_data);
-                ble_hdr->rxinfo.user_data = NULL;
-                ble_ll_scan_chk_resume();
-                return;
-            }
-            goto scan_continue;
-        }
-    }
-
-    if (CONN_F_AUX_CONN_REQ(connsm)) {
-        if (pdu_type != BLE_ADV_PDU_TYPE_AUX_CONNECT_RSP) {
-            /* Wait for connection response, in this point of time aux is NULL */
-            BLE_LL_ASSERT(ble_hdr->rxinfo.user_data == NULL);
-            return;
-        }
-    }
-#endif
-
-    /* If we have sent a connect request, we need to enter CONNECTION state */
-    if (connsm && CONN_F_CONN_REQ_TXD(connsm)) {
-        /* Set address of advertiser to which we are connecting. */
-
-        if (ble_ll_scan_adv_decode_addr(pdu_type, rxbuf, ble_hdr,
-                                        &adv_addr, &addr_type,
-                                        &inita, &inita_type, &ext_adv_mode)) {
-            /* Something got wrong, keep trying to connect */
-            goto scan_continue;
-        }
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
-        /*
-         * Did we resolve this address? If so, set correct peer address
-         * and peer address type.
-         */
-        if (connsm->rpa_index >= 0) {
-            addr_type = g_ble_ll_resolv_list[connsm->rpa_index].rl_addr_type + 2;
-            addr = g_ble_ll_resolv_list[connsm->rpa_index].rl_identity_addr;
-        } else {
-            addr = adv_addr;
-        }
-#else
-        addr = adv_addr;
-#endif
-
-        if (connsm->rpa_index >= 0) {
-            connsm->peer_addr_type = addr_type;
-            memcpy(connsm->peer_addr, addr, BLE_DEV_ADDR_LEN);
-
-            ble_ll_scan_set_peer_rpa(adv_addr);
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
-            /* Update resolving list with current peer RPA */
-            ble_ll_resolv_set_peer_rpa(connsm->rpa_index, rxbuf + BLE_LL_PDU_HDR_LEN);
-            if (ble_ll_is_rpa(inita, inita_type)) {
-                ble_ll_resolv_set_local_rpa(connsm->rpa_index, inita);
-            }
-
-#endif
-        } else if (ble_ll_scan_whitelist_enabled()) {
-            /* if WL is used we need to store peer addr also if it was not
-             * resolved
-             */
-            connsm->peer_addr_type = addr_type;
-            memcpy(connsm->peer_addr, addr, BLE_DEV_ADDR_LEN);
-        }
-
-        /* Connection has been created. Stop scanning */
-        g_ble_ll_conn_create_sm = NULL;
-        ble_ll_scan_sm_stop(0);
-
-        /* For AUX Connect CSA2 is mandatory. Otherwise we need to check bit
-         * mask
-         */
-        if (ble_hdr->rxinfo.channel < BLE_PHY_NUM_DATA_CHANS) {
-            ble_ll_conn_set_csa(connsm, 1);
-        } else {
-            ble_ll_conn_set_csa(connsm, rxbuf[0] & BLE_ADV_PDU_HDR_CHSEL_MASK);
-        }
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-#if (BLE_LL_BT5_PHY_SUPPORTED == 1)
-        /* Lets take last used phy */
-        ble_ll_conn_init_phy(connsm, ble_hdr->rxinfo.phy);
-#endif
-        if (aux_data) {
-            ble_ll_scan_aux_data_unref(ble_hdr->rxinfo.user_data);
-            ble_hdr->rxinfo.user_data = NULL;
-        }
-#endif
-        ble_ll_conn_created(connsm, NULL);
-        return;
-    }
-
-scan_continue:
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    /* Drop last reference and keep continue to connect */
-    if (aux_data) {
-        ble_ll_scan_aux_data_unref(ble_hdr->rxinfo.user_data);
-        ble_hdr->rxinfo.user_data = NULL;
-    }
-#endif
-    ble_ll_scan_chk_resume();
-}
-
-/**
- * Called when a receive PDU has started and we are in the initiating state.
- *
- * Context: Interrupt
- *
- * @param pdu_type
- * @param ble_hdr
- *
- * @return int
- *  0: we will not attempt to reply to this frame
- *  1: we may send a response to this frame.
- */
 int
-ble_ll_init_rx_isr_start(uint8_t pdu_type, struct ble_mbuf_hdr *ble_hdr)
+ble_ll_conn_send_connect_req(struct os_mbuf *rxpdu,
+                             struct ble_ll_scan_addr_data *addrd,
+                             uint8_t ext)
 {
     struct ble_ll_conn_sm *connsm;
+    struct ble_mbuf_hdr *rxhdr;
+    int8_t rpa_index;
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+    struct hci_ext_conn_params *ecp;
+    uint8_t phy;
+#endif
+    int rc;
 
     connsm = g_ble_ll_conn_create_sm;
-    if (!connsm) {
-        return 0;
-    }
-
-    if ((pdu_type == BLE_ADV_PDU_TYPE_ADV_IND) ||
-        (pdu_type == BLE_ADV_PDU_TYPE_ADV_DIRECT_IND ||
-         pdu_type == BLE_ADV_PDU_TYPE_AUX_CONNECT_RSP)) {
-        return 1;
-    }
+    rxhdr = BLE_MBUF_HDR_PTR(rxpdu);
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    if (pdu_type == BLE_ADV_PDU_TYPE_ADV_EXT_IND &&
-                                                connsm->scansm->ext_scanning) {
-        if (connsm->scansm->cur_aux_data) {
-            STATS_INC(ble_ll_stats, aux_received);
-        }
-
-        ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_EXT_ADV;
-        return 1;
+    if (ext) {
+#if BLE_LL_BT5_PHY_SUPPORTED
+        phy = rxhdr->rxinfo.phy;
+#else
+        phy = BLE_PHY_1M;
+#endif
+        ecp = &connsm->initial_params.params[phy - 1];
+        ble_ll_conn_ext_set_params(connsm, ecp, phy);
     }
 #endif
+
+    if (ble_ll_sched_master_new(connsm, rxhdr, 0)) {
+        return -1;
+    }
+
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
+    rpa_index = addrd->rpa_index;
+#else
+    rpa_index = -1;
+#endif
+    ble_ll_conn_prepare_connect_ind(connsm, ble_ll_scan_get_pdu_data(),
+                                    addrd->adva_type, addrd->adva,
+                                    addrd->targeta_type, addrd->targeta,
+                                    rpa_index, rxhdr->rxinfo.channel);
+
+    ble_phy_set_txend_cb(NULL, NULL);
+    rc = ble_phy_tx(ble_ll_conn_tx_connect_ind_pducb, connsm,
+                    ext ? BLE_PHY_TRANSITION_TX_RX : BLE_PHY_TRANSITION_NONE);
+    if (rc) {
+        ble_ll_conn_send_connect_req_cancel();
+        return -1;
+    }
 
     return 0;
 }
 
-/**
- * Called when a receive PDU has ended and we are in the initiating state.
- *
- * Context: Interrupt
- *
- * @param rxpdu
- * @param crcok
- * @param ble_hdr
- *
- * @return int
- *       < 0: Disable the phy after reception.
- *      == 0: Success. Do not disable the PHY.
- *       > 0: Do not disable PHY as that has already been done.
- */
-int
-ble_ll_init_rx_isr_end(uint8_t *rxbuf, uint8_t crcok,
-                       struct ble_mbuf_hdr *ble_hdr)
+void
+ble_ll_conn_send_connect_req_cancel(void)
 {
-    int rc;
-    int resolved;
-    int chk_wl;
-    int index;
-    uint8_t pdu_type;
-    uint8_t adv_addr_type;
-    uint8_t peer_addr_type;
-    uint8_t *adv_addr = NULL;
-    uint8_t *peer;
-    uint8_t *init_addr = NULL;
-    uint8_t init_addr_type;
-    uint8_t pyld_len;
-    uint8_t inita_is_rpa;
-    uint8_t conn_req_end_trans;
-    struct os_mbuf *rxpdu;
     struct ble_ll_conn_sm *connsm;
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
-    struct ble_ll_resolv_entry *rl;
-#endif
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    struct hci_ext_conn_params *hcp;
-    struct ble_ll_scan_sm *scansm;
-    uint8_t phy;
-#endif
-    int ext_adv_mode = -1;
 
-    /* Get connection state machine to use if connection to be established */
     connsm = g_ble_ll_conn_create_sm;
-    /* This could happen if connection init was cancelled while isr end was
-     * already pending
-     */
-    if (!connsm) {
-        ble_ll_state_set(BLE_LL_STATE_STANDBY);
-        return -1;
-    }
 
-    rc = -1;
-    pdu_type = rxbuf[0] & BLE_ADV_PDU_HDR_TYPE_MASK;
-    pyld_len = rxbuf[1];
+    ble_ll_sched_rmv_elem(&connsm->conn_sch);
+}
 
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    scansm = connsm->scansm;
-    if (scansm->cur_aux_data) {
-        ble_hdr->rxinfo.user_data = scansm->cur_aux_data;
-        scansm->cur_aux_data = NULL;
-    }
-#endif
+static void
+ble_ll_conn_master_start(uint8_t phy, uint8_t csa,
+                         struct ble_ll_scan_addr_data *addrd, uint8_t *targeta)
+{
+    struct ble_ll_conn_sm *connsm;
 
-    if (!crcok) {
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-        /* Invalid packet - make sure we do not wait for AUX_CONNECT_RSP */
-        ble_ll_conn_reset_pending_aux_conn_rsp();
-#endif
+    connsm = g_ble_ll_conn_create_sm;
+    g_ble_ll_conn_create_sm = NULL;
 
-        /* Ignore this packet */
-        goto init_rx_isr_exit;
-    }
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    /* If we sent AUX_CONNECT_REQ, we only expect AUX_CONNECT_RSP here */
-    if (CONN_F_AUX_CONN_REQ(connsm)) {
-        if (pdu_type != BLE_ADV_PDU_TYPE_AUX_CONNECT_RSP) {
-            STATS_INC(ble_ll_stats, aux_conn_rsp_err);
-            CONN_F_CONN_REQ_TXD(connsm) = 0;
-            CONN_F_AUX_CONN_REQ(connsm) = 0;
-            ble_ll_sched_rmv_elem(&connsm->conn_sch);
-        }
-        goto init_rx_isr_exit;
-    }
-#endif
-
-    inita_is_rpa = 0;
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    if (pdu_type == BLE_ADV_PDU_TYPE_ADV_EXT_IND) {
-        if (!scansm->ext_scanning) {
-            goto init_rx_isr_exit;
-        }
-
-        rc = ble_ll_scan_update_aux_data(ble_hdr, rxbuf, NULL);
-        if (rc < 0) {
-            /* No memory or broken packet */
-            ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_AUX_INVALID;
-            goto init_rx_isr_exit;
-        }
-    }
-#endif
-
-    /* Lets get addresses from advertising report*/
-    if (ble_ll_scan_adv_decode_addr(pdu_type, rxbuf, ble_hdr,
-                                    &adv_addr, &adv_addr_type,
-                                    &init_addr, &init_addr_type,
-                                    &ext_adv_mode)) {
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-        ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_AUX_INVALID;
-#endif
-        goto init_rx_isr_exit;
-    }
-
-    switch (pdu_type) {
-    case BLE_ADV_PDU_TYPE_ADV_IND:
-        break;
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    case BLE_ADV_PDU_TYPE_ADV_EXT_IND:
-        rc = -1;
-
-        /* If this is not connectable adv mode, lets skip it */
-        if (!(ext_adv_mode & BLE_LL_EXT_ADV_MODE_CONN)) {
-            goto init_rx_isr_exit;
-        }
-
-        if (!adv_addr) {
-            ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_AUX_PTR_WAIT;
-            goto init_rx_isr_exit;
-        }
-
-        if (!init_addr) {
-            break;
-        }
-        /* if there is direct address lets fall down and check it.*/
-        // no break
-#endif
-    case BLE_ADV_PDU_TYPE_ADV_DIRECT_IND:
-        inita_is_rpa = (uint8_t)ble_ll_is_rpa(init_addr, init_addr_type);
-        if (!inita_is_rpa) {
-
-            /* Resolving will be done later. Check if identity InitA matches */
-            if (!ble_ll_is_our_devaddr(init_addr, init_addr_type)) {
-                goto init_rx_isr_exit;
-            }
-        }
-#if !MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
-        else {
-            /* If privacy is off - reject RPA InitA*/
-            goto init_rx_isr_exit;
-        }
-#endif
-
-        break;
-    default:
-        goto init_rx_isr_exit;
-    }
-
-    /* Should we send a connect request? */
-    index = -1;
-    peer = adv_addr;
-    peer_addr_type = adv_addr_type;
-
-    resolved = 0;
-    chk_wl = ble_ll_scan_whitelist_enabled();
+    connsm->peer_addr_type = addrd->adv_addr_type;
+    memcpy(connsm->peer_addr, addrd->adv_addr, 6);
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
-    if (ble_ll_is_rpa(adv_addr, adv_addr_type) && ble_ll_resolv_enabled()) {
-        index = ble_hw_resolv_list_match();
-        if (index >= 0) {
-            rl = &g_ble_ll_resolv_list[index];
-
-            ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_RESOLVED;
-            connsm->rpa_index = index;
-            peer = rl->rl_identity_addr;
-            peer_addr_type = rl->rl_addr_type;
-            resolved = 1;
-
-            /* Assure privacy */
-            if ((rl->rl_priv_mode == BLE_HCI_PRIVACY_NETWORK) && init_addr &&
-                !inita_is_rpa && rl->rl_has_local) {
-                goto init_rx_isr_exit;
-            }
-
-            /*
-             * If the InitA is a RPA, we must see if it resolves based on the
-             * identity address of the resolved ADVA.
-             */
-            if (init_addr && inita_is_rpa) {
-                if (!ble_ll_resolv_rpa(init_addr,
-                                       g_ble_ll_resolv_list[index].rl_local_irk)) {
-                    goto init_rx_isr_exit;
-                }
-
-                /* Core Specification Vol 6, Part B, Section 6.4:
-                 * "The Link Layer should not set the InitA field to the same
-                 * value as the TargetA field in the received advertising PDU."
-                 *
-                 * We update the received PDU directly here, so ble_ll_init_rx_pkt_in
-                 * can process it as is.
-                 */
-                memcpy(init_addr, rl->rl_local_rpa, BLE_DEV_ADDR_LEN);
-            }
-
-        } else {
-            if (chk_wl) {
-                goto init_rx_isr_exit;
-            }
-
-            /* Could not resolved InitA */
-            if (init_addr && inita_is_rpa) {
-                goto init_rx_isr_exit;
-            }
-        }
-    } else if (init_addr) {
-
-        /* If resolving is off and InitA is RPA we reject advertising */
-        if (inita_is_rpa && !ble_ll_resolv_enabled()) {
-            goto init_rx_isr_exit;
-        }
-
-        /* Let's see if we have IRK with that peer.*/
-        rl = ble_ll_resolv_list_find(adv_addr, adv_addr_type);
-
-        /* Lets make sure privacy mode is correct together with InitA in case it
-         * is identity address
-         */
-        if (rl && !inita_is_rpa &&
-           (rl->rl_priv_mode == BLE_HCI_PRIVACY_NETWORK) &&
-           rl->rl_has_local) {
-            goto init_rx_isr_exit;
-        }
-
-        /*
-         * If the InitA is a RPA, we must see if it resolves based on the
-         * identity address of the resolved ADVA.
-         */
-        if (inita_is_rpa) {
-            if (!rl || !ble_ll_resolv_rpa(init_addr, rl->rl_local_irk)) {
-                goto init_rx_isr_exit;
-            }
-
-            /* Core Specification Vol 6, Part B, Section 6.4:
-             * "The Link Layer should not set the InitA field to the same
-             * value as the TargetA field in the received advertising PDU."
-             *
-             * We update the received PDU directly here, so ble_ll_init_rx_pkt_in
-             * can process it as is.
-             */
-            memcpy(init_addr, rl->rl_local_rpa, BLE_DEV_ADDR_LEN);
-        }
-    } else if (!ble_ll_is_rpa(adv_addr, adv_addr_type)) {
-        /* undirected with ID address, assure privacy if on RL */
-        rl = ble_ll_resolv_list_find(adv_addr, adv_addr_type);
-        if (rl && (rl->rl_priv_mode == BLE_HCI_PRIVACY_NETWORK) &&
-            rl->rl_has_peer) {
-            goto init_rx_isr_exit;
-        }
-    }
-#endif
-
-    /* Check filter policy */
-    if (chk_wl) {
-        if (!ble_ll_whitelist_match(peer, peer_addr_type, resolved)) {
-            goto init_rx_isr_exit;
-        }
+    if (addrd->adva_resolved) {
+        BLE_LL_ASSERT(addrd->rpa_index >= 0);
+        connsm->peer_addr_resolved = 1;
+        ble_ll_resolv_set_peer_rpa(addrd->rpa_index, addrd->adva);
+        ble_ll_scan_set_peer_rpa(addrd->adva);
     } else {
-        /* Must match the connection address */
-        if (!ble_ll_conn_is_peer_adv(adv_addr_type, adv_addr, index)) {
-            goto init_rx_isr_exit;
-        }
-    }
-    ble_hdr->rxinfo.flags |= BLE_MBUF_HDR_F_DEVMATCH;
-
-    /* For CONNECT_IND we don't go into RX state */
-    conn_req_end_trans = BLE_PHY_TRANSITION_NONE;
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    /* Check if we should send AUX_CONNECT_REQ and wait for AUX_CONNECT_RSP */
-    if (ble_hdr->rxinfo.channel < BLE_PHY_NUM_DATA_CHANS) {
-        conn_req_end_trans = BLE_PHY_TRANSITION_TX_RX;
+        connsm->peer_addr_resolved = 0;
     }
 
-    if (connsm->scansm->ext_scanning) {
-        phy = ble_hdr->rxinfo.phy;
-
-        hcp = &connsm->initial_params.params[phy - 1];
-
-        connsm->slave_latency = hcp->conn_latency;
-        connsm->supervision_tmo = hcp->supervision_timeout;
-
-        connsm->conn_itvl = hcp->conn_itvl;
-        connsm->conn_itvl_ticks = hcp->conn_itvl_ticks;
-        connsm->conn_itvl_usecs = hcp->conn_itvl_usecs;
+    if (addrd->targeta_resolved) {
+        BLE_LL_ASSERT(addrd->rpa_index >= 0);
+        BLE_LL_ASSERT(targeta);
+        ble_ll_resolv_set_local_rpa(addrd->rpa_index, targeta);
     }
 #endif
 
-    /* Schedule new connection */
-    if (ble_ll_sched_master_new(connsm, ble_hdr, pyld_len)) {
-        STATS_INC(ble_ll_conn_stats, cant_set_sched);
-        goto init_rx_isr_exit;
-    }
-
-    /* Prepare data for connect request */
-    ble_ll_conn_connect_ind_prepare(connsm,
-                                    ble_ll_scan_get_pdu_data(),
-                                    adv_addr_type, adv_addr,
-                                    init_addr_type, init_addr,
-                                    index, ble_hdr->rxinfo.channel);
-
-    /* Setup to transmit the connect request */
-    rc = ble_ll_conn_connect_ind_send(connsm, conn_req_end_trans);
-    if (rc) {
-        ble_ll_sched_rmv_elem(&connsm->conn_sch);
-        goto init_rx_isr_exit;
-    }
-
-    if (init_addr && !inita_is_rpa) {
-        connsm->inita_identity_used = 1;
-    }
-
-    CONN_F_CONN_REQ_TXD(connsm) = 1;
-
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-    if (ble_hdr->rxinfo.channel < BLE_PHY_NUM_DATA_CHANS) {
-        /* Lets wait for AUX_CONNECT_RSP */
-        CONN_F_AUX_CONN_REQ(connsm) = 1;
-        /* Keep aux data until we get scan response */
-        scansm->cur_aux_data = ble_hdr->rxinfo.user_data;
-        ble_hdr->rxinfo.user_data = NULL;
-        STATS_INC(ble_ll_stats, aux_conn_req_tx);
-    }
-
-    if (connsm->scansm->ext_scanning) {
-        phy = ble_hdr->rxinfo.phy;
-
-        /* Update connection state machine with appropriate parameters for
-         * certain PHY
-         */
-        ble_ll_conn_ext_set_params(connsm,
-                                   &connsm->initial_params.params[phy - 1],
-                                   phy);
-
-    }
+    ble_ll_conn_set_csa(connsm, csa);
+#if BLE_LL_BT5_PHY_SUPPORTED
+    ble_ll_conn_init_phy(connsm, phy);
 #endif
-
-    STATS_INC(ble_ll_conn_stats, conn_req_txd);
-
-init_rx_isr_exit:
-
-    /*
-     * We have to restart receive if we cant hand up pdu. We return 0 so that
-     * the phy does not get disabled.
-     */
-    rxpdu = ble_ll_rxpdu_alloc(pyld_len + BLE_LL_PDU_HDR_LEN);
-    if (rxpdu == NULL) {
-        /*
-         * XXX: possible allocate the PDU when we start initiating?
-         * I cannot say I like this solution, but if we cannot allocate a PDU
-         * to hand up to the LL, we need to remove the connection we just
-         * scheduled since the connection state machine will not get processed
-         * by link layer properly. For now, just remove it from the scheduler
-         */
-        if (CONN_F_CONN_REQ_TXD(connsm) == 1) {
-            CONN_F_CONN_REQ_TXD(connsm) = 0;
-            CONN_F_AUX_CONN_REQ(connsm) = 0;
-            ble_ll_sched_rmv_elem(&connsm->conn_sch);
-        }
-        ble_phy_restart_rx();
-        rc = 0;
-    } else {
-        ble_phy_rxpdu_copy(rxbuf, rxpdu);
-        ble_ll_rx_pdu_in(rxpdu);
-    }
-
-    if (rc) {
-        ble_ll_state_set(BLE_LL_STATE_STANDBY);
-    }
-
-    return rc;
+    ble_ll_conn_created(connsm, NULL);
 }
+
+void
+ble_ll_conn_created_on_legacy(struct os_mbuf *rxpdu,
+                              struct ble_ll_scan_addr_data *addrd,
+                              uint8_t *targeta)
+{
+    uint8_t *rxbuf;
+    uint8_t csa;
+
+    rxbuf = rxpdu->om_data;
+    csa = rxbuf[0] & BLE_ADV_PDU_HDR_CHSEL_MASK;
+
+    ble_ll_conn_master_start(BLE_PHY_1M, csa, addrd, targeta);
+}
+
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+void
+ble_ll_conn_created_on_aux(struct os_mbuf *rxpdu,
+                           struct ble_ll_scan_addr_data *addrd,
+                           uint8_t *targeta)
+{
+#if BLE_LL_BT5_PHY_SUPPORTED
+    struct ble_mbuf_hdr *rxhdr;
+#endif
+    uint8_t phy;
+
+#if BLE_LL_BT5_PHY_SUPPORTED
+    rxhdr = BLE_MBUF_HDR_PTR(rxpdu);
+    phy = rxhdr->rxinfo.phy;
+#else
+    phy = BLE_PHY_1M;
+#endif
+
+    ble_ll_conn_master_start(phy, 1, addrd, targeta);
+}
+#endif /* BLE_LL_CFG_FEAT_LL_EXT_ADV */
 
 /**
  * Function called when a timeout has occurred for a connection. There are

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -2080,7 +2080,6 @@ ble_ll_conn_next_event(struct ble_ll_conn_sm *connsm)
         connsm->anchor_point += connsm->conn_itvl_ticks;
         connsm->anchor_point_usecs += connsm->conn_itvl_usecs;
     } else {
-        uint32_t ticks;
         ticks = os_cputime_usecs_to_ticks(itvl);
         connsm->anchor_point += ticks;
         connsm->anchor_point_usecs += (itvl - os_cputime_ticks_to_usecs(ticks));

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -25,10 +25,8 @@
 #include "os/os.h"
 #include "os/os_cputime.h"
 #include "nimble/ble.h"
-#include "nimble/nimble_opt.h"
 #include "nimble/hci_common.h"
 #include "nimble/ble_hci_trans.h"
-#include "ble/xcvr.h"
 #include "controller/ble_ll.h"
 #include "controller/ble_ll_hci.h"
 #include "controller/ble_ll_scan.h"
@@ -40,7 +38,6 @@
 #include "controller/ble_ll_trace.h"
 #include "controller/ble_ll_rfmgmt.h"
 #include "controller/ble_phy.h"
-#include "controller/ble_hw.h"
 #include "controller/ble_ll_utils.h"
 #include "ble_ll_conn_priv.h"
 

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1591,23 +1591,6 @@ ble_ll_conn_master_init(struct ble_ll_conn_sm *connsm,
     connsm->max_ce_len = cc_params->max_ce_len;
 }
 
-static void
-ble_ll_update_max_tx_octets_phy_mode(struct ble_ll_conn_sm *connsm)
-{
-    uint32_t usecs;
-
-    usecs = connsm->eff_max_tx_time;
-
-    connsm->max_tx_octets_phy_mode[BLE_PHY_MODE_1M] =
-            ble_ll_pdu_max_tx_octets_get(usecs, BLE_PHY_MODE_1M);
-    connsm->max_tx_octets_phy_mode[BLE_PHY_MODE_2M] =
-            ble_ll_pdu_max_tx_octets_get(usecs, BLE_PHY_MODE_2M);
-    connsm->max_tx_octets_phy_mode[BLE_PHY_MODE_CODED_125KBPS] =
-            ble_ll_pdu_max_tx_octets_get(usecs, BLE_PHY_MODE_CODED_125KBPS);
-    connsm->max_tx_octets_phy_mode[BLE_PHY_MODE_CODED_500KBPS] =
-            ble_ll_pdu_max_tx_octets_get(usecs, BLE_PHY_MODE_CODED_500KBPS);
-}
-
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
 
 static void
@@ -1657,8 +1640,6 @@ ble_ll_conn_init_phy(struct ble_ll_conn_sm *connsm, int phy)
     connsm->rem_max_rx_octets = BLE_LL_CONN_SUPP_BYTES_MIN;
     connsm->eff_max_tx_octets = BLE_LL_CONN_SUPP_BYTES_MIN;
     connsm->eff_max_rx_octets = BLE_LL_CONN_SUPP_BYTES_MIN;
-
-    ble_ll_update_max_tx_octets_phy_mode(connsm);
 }
 
 #endif
@@ -1791,8 +1772,6 @@ ble_ll_conn_sm_new(struct ble_ll_conn_sm *connsm)
     connsm->host_req_max_tx_time = 0;
 #endif
 
-    ble_ll_update_max_tx_octets_phy_mode(connsm);
-
     /* Reset encryption data */
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION)
     memset(&connsm->enc_data, 0, sizeof(struct ble_ll_conn_enc_data));
@@ -1842,8 +1821,6 @@ ble_ll_conn_update_eff_data_len(struct ble_ll_conn_sm *connsm)
     if (eff_time != connsm->eff_max_tx_time) {
         connsm->eff_max_tx_time = eff_time;
         send_event = 1;
-
-        ble_ll_update_max_tx_octets_phy_mode(connsm);
     }
     eff_bytes = min(connsm->rem_max_tx_octets, connsm->max_rx_octets);
     if (eff_bytes != connsm->eff_max_rx_octets) {

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -23,7 +23,6 @@
 #include "syscfg/syscfg.h"
 #include "os/os.h"
 #include "nimble/ble.h"
-#include "nimble/nimble_opt.h"
 #include "nimble/hci_common.h"
 #include "nimble/ble_hci_trans.h"
 #include "controller/ble_ll.h"

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -435,23 +435,13 @@ ble_ll_conn_hci_create_check_scan(struct ble_ll_conn_create_scan *p)
 static int
 ble_ll_conn_hci_create_check_params(struct ble_ll_conn_create_params *cc_params)
 {
-    uint32_t supervision_tmo_us;
-    uint32_t conn_itvl_us;
+    int rc;
 
-    if ((cc_params->conn_itvl < BLE_HCI_CONN_ITVL_MIN) ||
-        (cc_params->conn_itvl > BLE_HCI_CONN_ITVL_MAX) ||
-        (cc_params->conn_latency > BLE_HCI_CONN_LATENCY_MAX) ||
-        (cc_params->supervision_timeout < BLE_HCI_CONN_SPVN_TIMEOUT_MIN) ||
-        (cc_params->supervision_timeout > BLE_HCI_CONN_SPVN_TIMEOUT_MAX)) {
-        return BLE_ERR_INV_HCI_CMD_PARMS;
-    }
-
-    /* Supervision timeout must be longer than (1 + latency) * interval * 2 */
-    supervision_tmo_us = cc_params->supervision_timeout *
-                         BLE_HCI_CONN_SPVN_TMO_UNITS * 1000;
-    conn_itvl_us = cc_params->conn_itvl * BLE_LL_CONN_ITVL_USECS;
-
-    if (supervision_tmo_us <= (1 + cc_params->conn_latency) * conn_itvl_us * 2) {
+    rc = ble_ll_conn_hci_chk_conn_params(cc_params->conn_itvl,
+                                         cc_params->conn_itvl,
+                                         cc_params->conn_latency,
+                                         cc_params->supervision_timeout);
+    if (rc) {
         return BLE_ERR_INV_HCI_CMD_PARMS;
     }
 

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -148,18 +148,10 @@ void ble_ll_conn_tx_pkt_in(struct os_mbuf *om, uint16_t handle, uint16_t len);
 int ble_ll_conn_rx_isr_start(struct ble_mbuf_hdr *rxhdr, uint32_t aa);
 int ble_ll_conn_rx_isr_end(uint8_t *rxbuf, struct ble_mbuf_hdr *rxhdr);
 void ble_ll_conn_rx_data_pdu(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *hdr);
-void ble_ll_init_rx_pkt_in(uint8_t pdu_type, uint8_t *rxbuf,
-                           struct ble_mbuf_hdr *ble_hdr);
-int ble_ll_init_rx_isr_start(uint8_t pdu_type, struct ble_mbuf_hdr *ble_hdr);
-int ble_ll_init_rx_isr_end(uint8_t *rxbuf, uint8_t crcok,
-                           struct ble_mbuf_hdr *ble_hdr);
 void ble_ll_conn_wfr_timer_exp(void);
-void ble_ll_conn_init_wfr_timer_exp(void);
 int ble_ll_conn_is_lru(struct ble_ll_conn_sm *s1, struct ble_ll_conn_sm *s2);
 uint32_t ble_ll_conn_get_ce_end_time(void);
 void ble_ll_conn_event_halt(void);
-void ble_ll_conn_reset_pending_aux_conn_rsp(void);
-bool ble_ll_conn_init_pending_aux_conn_rsp(void);
 /* HCI */
 void ble_ll_disconn_comp_event_send(struct ble_ll_conn_sm *connsm,
                                     uint8_t reason);

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -910,7 +910,7 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
         rc = ble_ll_hci_scan_set_enable(cmdbuf, len);
         break;
     case BLE_HCI_OCF_LE_CREATE_CONN:
-        rc = ble_ll_conn_create(cmdbuf, len);
+        rc = ble_ll_conn_hci_create(cmdbuf, len);
         break;
     case BLE_HCI_OCF_LE_CREATE_CONN_CANCEL:
         if (len == 0) {
@@ -1113,7 +1113,7 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
         rc = ble_ll_hci_ext_scan_set_enable(cmdbuf, len);
         break;
     case BLE_HCI_OCF_LE_EXT_CREATE_CONN:
-        rc = ble_ll_ext_conn_create(cmdbuf, len);
+        rc = ble_ll_conn_hci_ext_create(cmdbuf, len);
         break;
 #endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV)

--- a/nimble/controller/src/ble_ll_resolv.c
+++ b/nimble/controller/src/ble_ll_resolv.c
@@ -57,7 +57,7 @@ ble_ll_is_controller_busy(void)
 #endif
 
     return ble_ll_adv_enabled() || ble_ll_scan_enabled() ||
-           g_ble_ll_conn_create_sm;
+           g_ble_ll_conn_create_sm.connsm;
 }
 /**
  * Called to determine if a change is allowed to the resolving list at this

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -2439,14 +2439,19 @@ ble_ll_scan_rx_pkt_in_restore_addr_data(struct ble_mbuf_hdr *hdr,
     addrd->adv_addr_type = addrd->adva_type;
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
-    if (rxinfo->rpa_index >= 0) {
+    addrd->rpa_index = rxinfo->rpa_index;
+
+    if (hdr->rxinfo.flags & BLE_MBUF_HDR_F_RESOLVED) {
+        BLE_LL_ASSERT(rxinfo->rpa_index >= 0);
         rl = &g_ble_ll_resolv_list[rxinfo->rpa_index];
         addrd->adv_addr = rl->rl_identity_addr;
         addrd->adv_addr_type = rl->rl_addr_type;
+        addrd->adva_resolved = 1;
     }
     if (hdr->rxinfo.flags & BLE_MBUF_HDR_F_TARGETA_RESOLVED) {
         addrd->targeta = ble_ll_get_our_devaddr(scansm->own_addr_type & 1);
         addrd->targeta_type = scansm->own_addr_type & 1;
+        addrd->targeta_resolved = 1;
     }
 #endif
 }

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -2447,11 +2447,16 @@ ble_ll_scan_rx_pkt_in_restore_addr_data(struct ble_mbuf_hdr *hdr,
         addrd->adv_addr = rl->rl_identity_addr;
         addrd->adv_addr_type = rl->rl_addr_type;
         addrd->adva_resolved = 1;
+    } else {
+        addrd->adva_resolved = 0;
     }
+
     if (hdr->rxinfo.flags & BLE_MBUF_HDR_F_TARGETA_RESOLVED) {
         addrd->targeta = ble_ll_get_our_devaddr(scansm->own_addr_type & 1);
         addrd->targeta_type = scansm->own_addr_type & 1;
         addrd->targeta_resolved = 1;
+    } else {
+        addrd->targeta_resolved = 0;
     }
 #endif
 }

--- a/nimble/include/nimble/ble.h
+++ b/nimble/include/nimble/ble.h
@@ -88,6 +88,9 @@ struct ble_mbuf_hdr_rxinfo
  *       set for the same PDU (e.g. one use by scanner, other one used by
  *       connection)
  */
+#define BLE_MBUF_HDR_F_CONNECT_IND_TXD  (0x4000)
+#define BLE_MBUF_HDR_F_CONNECT_REQ_TXD  (0x4000)
+#define BLE_MBUF_HDR_F_CONNECT_RSP_RXD  (0x0008)
 #define BLE_MBUF_HDR_F_CONN_CREDIT      (0x8000)
 #define BLE_MBUF_HDR_F_IGNORED          (0x8000)
 #define BLE_MBUF_HDR_F_SCAN_REQ_TXD     (0x4000)


### PR DESCRIPTION
This is quite big refactor of initiator code. The main goal is to remove separate path for initiator scanner and use generic scanner also for initiator role. Also this cleans code up and optimizes some code paths and memory usage.