### PR TITLE
[wip] nimble/ll: Add zero-copy rx

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -585,6 +585,10 @@ void ble_ll_rand_prand_get(uint8_t *prand);
 int ble_ll_rand_start(void);
 uint32_t ble_ll_rand(void);
 
+#if MYNEWT_VAL(BLE_LL_ZERO_COPY_RX)
+uint8_t *ble_ll_rxbuf_get(void);
+#endif
+
 static inline int
 ble_ll_get_addr_type(uint8_t txrxflag)
 {

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -308,6 +308,11 @@ syscfg.defs:
             packets for receive on secondary advertising channel.
          value: 0
 
+    BLE_LL_ZERO_COPY_RX:
+        description: >
+            Enables zero-copy rx path.
+        value: 0
+
     BLE_PUBLIC_DEV_ADDR:
         description: >
             Allows the target or app to override the public device address


### PR DESCRIPTION
This adds support for zero-copy rx. When enabled, phy receives data directly into mbuf and thus there's no need to copy received PDU from phy buffer into mbuf which significantly reduces processing time.

When zero-copy rx is enabled, phy shall request rxbuf from LL which is a pointer to data portion of an mbuf. It's guaranteed that returned buffer has enough continuous space to fit complete PDU. If LL cannot allocate new mbuf at that time, it will return pointer to temporary flat buffer so rx can still work as usual. After rx, LL uses usual routines to alloc and copy rxpdu, but they work in a slightly different way as 'alloc' returns mbuf preallocated previously and 'copy' copies only mbuf header. This way we can keep changes to a minimum, even though this is not the most optimized approach and support has to be added to each phy separately.

Currently rxpdus are allocated from msys so it has to have pool with buffers large enough to fit complete PDU with required headers. We may add an option for dedicated pool in future.

Enabling zero-copy rx can significantly improve scheduling reliability especially on CMAC - previously it was quite challenging to schedule aux chain scan at offset close to 300us (Tmafs) and we were either just in time for preamble or too late, now it can be scheduled with a dozen of microseconds to spare.