### PR TITLE
nimble/phy/nrf: Remove workrounds for ifs on LE Coded

### DIFF
--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -703,17 +703,6 @@ ble_phy_wfr_enable(int txrx, uint8_t tx_phy_mode, uint32_t wfr_usecs)
          * by waiting 1 usec more.
          */
         end_time += 1;
-#if MYNEWT_VAL(BLE_PHY_CODED_RX_IFS_EXTRA_MARGIN) > 0
-        if ((phy == BLE_PHY_MODE_CODED_125KBPS) ||
-                                    (phy == BLE_PHY_MODE_CODED_500KBPS)) {
-            /*
-             * Some controllers exceed T_IFS when transmitting on coded phy
-             * so let's wait a bit longer to be able to talk to them if this
-             * workaround is enabled.
-             */
-            end_time += MYNEWT_VAL(BLE_PHY_CODED_RX_IFS_EXTRA_MARGIN);
-        }
-#endif
     } else {
         /*
          * RX shall start no later than wfr_usecs after RX enabled.

--- a/nimble/drivers/nrf52/syscfg.yml
+++ b/nimble/drivers/nrf52/syscfg.yml
@@ -22,16 +22,6 @@ syscfg.defs:
             Enable SystemView tracing module for radio driver.
         value: 0
 
-    BLE_PHY_CODED_RX_IFS_EXTRA_MARGIN:
-        description: >
-            This defines additional margin for T_IFS tolerance while in
-            RX on coded phy to allow maintaining connections with some
-            controllers that exceed proper T_IFS (150 usecs) by more
-            than allowed 2 usecs.
-            This value shall be only used for debugging purposes. It is
-            strongly recommended to keep this settings at default value
-            to ensure compliance with specification.
-        value: 0
     BLE_PHY_DBG_TIME_TXRXEN_READY_PIN:
         description: >
             When set to proper GPIO pin number, this pin will be set


### PR DESCRIPTION
BLE_PHY_CODED_RX_IFS_EXTRA_MARGIN was added with initial implementation
for LE Coded to workaround problems with some early releases of devices
that could not keep ifs timing properly. We do not want it anymore, all
devices should have ifs implemented properly in 2021 already.