### PR TITLE
 nimble/ll: Fix encrypted payload length 

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -854,7 +854,6 @@ static uint16_t
 ble_ll_conn_adjust_pyld_len(struct ble_ll_conn_sm *connsm, uint16_t pyld_len)
 {
     uint16_t phy_max_tx_octets;
-    uint16_t mic_len;
     uint16_t ret;
 
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
@@ -877,19 +876,11 @@ ble_ll_conn_adjust_pyld_len(struct ble_ll_conn_sm *connsm, uint16_t pyld_len)
 
     ret = pyld_len;
 
-    mic_len = 0;
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION)
-    if (CONN_F_ENCRYPTED(connsm)) {
-        mic_len = BLE_LL_DATA_MIC_LEN;
-    }
-#endif
-
-
-    if (ret > connsm->eff_max_tx_octets - mic_len) {
+    if (ret > connsm->eff_max_tx_octets) {
         ret = connsm->eff_max_tx_octets;
     }
 
-    if (ret > phy_max_tx_octets - mic_len) {
+    if (ret > phy_max_tx_octets) {
         ret = phy_max_tx_octets;
     }
 


### PR DESCRIPTION
ble_ll_pdu_max_tx_octets_get() returns number of bytes that can be added between LL header and CRC so the complete PDU is no longer than maxTxTime allowed. However, if link is encrypted there will be also MIC added after the payload so effectively we need to stript that extra 4 bytes from allowed payload length.