### PR TITLE
nimble/ll: Fix starting ctrl proc timer

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -40,6 +40,7 @@
 #include "controller/ble_phy.h"
 #include "controller/ble_ll_utils.h"
 #include "ble_ll_conn_priv.h"
+#include "ble_ll_ctrl_priv.h"
 
 #if (BLETEST_THROUGHPUT_TEST == 1)
 extern void bletest_completed_pkt(uint16_t handle);
@@ -3772,6 +3773,9 @@ ble_ll_conn_module_init(void)
         /* Initialize fixed schedule elements */
         connsm->conn_sch.sched_type = BLE_LL_SCHED_TYPE_CONN;
         connsm->conn_sch.cb_arg = connsm;
+
+        ble_ll_ctrl_init_conn_sm(connsm);
+
         ++connsm;
     }
 

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -559,11 +559,6 @@ ble_ll_ctrl_proc_rsp_timer_cb(struct ble_npl_event *ev)
 static void
 ble_ll_ctrl_start_rsp_timer(struct ble_ll_conn_sm *connsm)
 {
-    ble_npl_callout_init(&connsm->ctrl_proc_rsp_timer,
-                    &g_ble_ll_data.ll_evq,
-                    ble_ll_ctrl_proc_rsp_timer_cb,
-                    connsm);
-
     /* Re-start timer. Control procedure timeout is 40 seconds */
     ble_npl_callout_reset(&connsm->ctrl_proc_rsp_timer,
                      ble_npl_time_ms_to_ticks32(BLE_LL_CTRL_PROC_TIMEOUT_MS));
@@ -2885,4 +2880,11 @@ ble_ll_ctrl_tx_done(struct os_mbuf *txpdu, struct ble_ll_conn_sm *connsm)
 
     os_mbuf_free_chain(txpdu);
     return rc;
+}
+
+void
+ble_ll_ctrl_init_conn_sm(struct ble_ll_conn_sm *connsm)
+{
+    ble_npl_callout_init(&connsm->ctrl_proc_rsp_timer, &g_ble_ll_data.ll_evq,
+                         ble_ll_ctrl_proc_rsp_timer_cb, connsm);
 }

--- a/nimble/controller/src/ble_ll_ctrl_priv.h
+++ b/nimble/controller/src/ble_ll_ctrl_priv.h
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BLE_LL_CTRL_PRIV_
+#define H_BLE_LL_CTRL_PRIV_
+
+#include "controller/ble_ll_conn.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ble_ll_ctrl_init_conn_sm(struct ble_ll_conn_sm *connsm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_BLE_LL_CTRL_PRIV_ */


### PR DESCRIPTION
We cannot just initialize callout prior to restarting since this will
wipe it out and thus break callouts queue if it was already added there.
Instead, initialize once on module init.