### PR TITLE
apps/bttester: add lost bond event

### DIFF
--- a/apps/bttester/src/bttester.h
+++ b/apps/bttester/src/bttester.h
@@ -412,6 +412,12 @@ struct gap_pairing_consent_req_ev {
     uint8_t address[6];
 } __packed;
 
+#define GAP_EV_BOND_LOST			0x8b
+struct gap_bond_lost_ev {
+    uint8_t address_type;
+    uint8_t address[6];
+} __packed;
+
 /* GATT Service */
 /* commands */
 #define GATT_READ_SUPPORTED_COMMANDS	0x01


### PR DESCRIPTION
When we receive GAP event BLE_GAP_EVENT_REPEAT_PAIRING it means
that we sent security request, but bond is lost - peer sent pair
request in return, which means it doesn't have keys anymore. Inform
Upper tester about it.