### PR TITLE
apps/bttester: handle options of created L2CAP server

### DIFF
--- a/apps/bttester/src/bttester.h
+++ b/apps/bttester/src/bttester.h
@@ -754,6 +754,8 @@ struct l2cap_read_supported_commands_rp {
 	uint8_t data[0];
 } __packed;
 
+#define L2CAP_CONNECT_OPT_ECFC		0x01
+
 #define L2CAP_CONNECT			0x02
 struct l2cap_connect_cmd {
 	uint8_t address_type;
@@ -761,6 +763,7 @@ struct l2cap_connect_cmd {
 	uint16_t psm;
 	uint16_t mtu;
 	uint8_t num;
+	uint8_t options;
 } __packed;
 
 struct l2cap_connect_rp {

--- a/apps/bttester/src/bttester.h
+++ b/apps/bttester/src/bttester.h
@@ -755,6 +755,7 @@ struct l2cap_read_supported_commands_rp {
 } __packed;
 
 #define L2CAP_CONNECT_OPT_ECFC		0x01
+#define L2CAP_CONNECT_OPT_HOLD_CREDIT	0x02
 
 #define L2CAP_CONNECT			0x02
 struct l2cap_connect_cmd {
@@ -807,6 +808,11 @@ struct l2cap_reconfigure_cmd {
     uint16_t mtu;
     uint8_t num;
     uint8_t idxs[];
+} __packed;
+
+#define L2CAP_CREDITS		0x08
+struct l2cap_credits_cmd {
+    uint8_t chan_id;
 } __packed;
 
 /* events */

--- a/apps/bttester/src/l2cap.c
+++ b/apps/bttester/src/l2cap.c
@@ -397,6 +397,7 @@ static void connect(uint8_t *data, uint16_t len)
 	uint16_t mtu = htole16(cmd->mtu);
 	int rc;
 	int i, j;
+	bool ecfc = cmd->options & L2CAP_CONNECT_OPT_ECFC;
 
 	SYS_LOG_DBG("connect: type: %d addr: %s", addr->type, bt_hex(addr->val, 6));
 
@@ -439,11 +440,11 @@ static void connect(uint8_t *data, uint16_t len)
 	    }
 	}
 
-	if (cmd->num == 1) {
+	if (cmd->num == 1 && !ecfc) {
 		rc = ble_l2cap_connect(desc.conn_handle, htole16(cmd->psm),
 				       mtu, sdu_rx[0],
 				       tester_l2cap_event, NULL);
-	} else if (cmd->num > 1) {
+	} else if (ecfc) {
 		rc = ble_l2cap_enhanced_connect(desc.conn_handle,
 						htole16(cmd->psm), mtu,
 						cmd->num, sdu_rx,


### PR DESCRIPTION
This PR adds support for argument `options` in BTP command `connect`, which allows us to create ECFC connection on single channel and hold L2CAP credits and manually give them back at chosen moment.