### PR TITLE
host/l2cap_sig: don't allow to set MPS between existing MPS values

### DIFF
--- a/nimble/host/src/ble_l2cap_sig.c
+++ b/nimble/host/src/ble_l2cap_sig.c
@@ -796,16 +796,17 @@ ble_l2cap_sig_credit_base_reconfig_req_rx(uint16_t conn_handle,
 
         if (chan[i]->peer_coc_mps > req->mps) {
             reduction_mps++;
-            if (reduction_mps > 1) {
-                rsp->result = htole16(BLE_L2CAP_ERR_RECONFIG_REDUCTION_MPS_NOT_ALLOWED);
-                goto failed;
-            }
         }
 
         if (chan[i]->coc_tx.mtu > req->mtu) {
             rsp->result = htole16(BLE_L2CAP_ERR_RECONFIG_REDUCTION_MTU_NOT_ALLOWED);
             goto failed;
         }
+    }
+
+    if (reduction_mps > 0 && cid_cnt > 1) {
+        rsp->result = htole16(BLE_L2CAP_ERR_RECONFIG_REDUCTION_MPS_NOT_ALLOWED);
+        goto failed;
     }
 
     ble_hs_unlock();


### PR DESCRIPTION
If reconfiguration request contains >1 CID and MPS value is reduced for
only one of them this request should still fail. In other words, it's
not allowed to reconfigure MPS to a value between the existing MPS
values of different channels.

This is affecting L2CAP/ECFC/BI-04-C