### PR TITLE
host/l2cap: disconnect peer that sends L2CAP packets with hdr len > mtu

### DIFF
--- a/nimble/host/src/ble_l2cap.c
+++ b/nimble/host/src/ble_l2cap.c
@@ -400,8 +400,11 @@ ble_l2cap_rx(struct ble_hs_conn *conn,
         }
 
         if (l2cap_hdr.len > ble_l2cap_get_mtu(chan)) {
-            /* More data then we expected on the channel */
+            /* More data than we expected on the channel.
+             * Disconnect peer with invalid behaviour
+             */
             rc = BLE_HS_EBADDATA;
+            ble_l2cap_disconnect(chan);
             goto err;
         }
 


### PR DESCRIPTION
Rest of the checks disconnects peer if SDU size exceeds MTU, but value
in header is OK. We should also disconnect if PDU lenght in L2CAP packet
header exceeds it, regardles of how much data it actually contains, not
just return error.

This is affecting L2CAP/LE/CFC/BV-26-C and L2CAP/ECFC/BV-33-C