### PR TITLE
apps: Update transport selection method

### DIFF
--- a/apps/blehr/pkg.yml
+++ b/apps/blehr/pkg.yml
@@ -37,4 +37,4 @@ pkg.deps:
     - nimble/host/services/gap
     - nimble/host/services/gatt
     - nimble/host/store/config
-    - nimble/transport/ram
+    - nimble/transport

--- a/apps/blemesh/pkg.yml
+++ b/apps/blemesh/pkg.yml
@@ -34,4 +34,4 @@ pkg.deps:
     - nimble/host/services/gap
     - nimble/host/services/gatt
     - nimble/host/store/config
-    - nimble/transport/ram
+    - nimble/transport

--- a/apps/blemesh_light/pkg.yml
+++ b/apps/blemesh_light/pkg.yml
@@ -34,4 +34,4 @@ pkg.deps:
     - nimble/host/services/gap
     - nimble/host/services/gatt
     - nimble/host/store/config
-    - nimble/transport/ram
+    - nimble/transport

--- a/apps/blemesh_models_example_1/pkg.yml
+++ b/apps/blemesh_models_example_1/pkg.yml
@@ -31,4 +31,4 @@ pkg.deps:
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt
-    - nimble/transport/ram
+    - nimble/transport

--- a/apps/blemesh_models_example_2/pkg.yml
+++ b/apps/blemesh_models_example_2/pkg.yml
@@ -33,7 +33,7 @@ pkg.deps:
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt
-    - nimble/transport/ram
+    - nimble/transport
 
 pkg.lflags:
     - -DFLOAT_SUPPORT

--- a/apps/blemesh_shell/pkg.yml
+++ b/apps/blemesh_shell/pkg.yml
@@ -34,4 +34,4 @@ pkg.deps:
     - nimble/host/services/gap
     - nimble/host/services/gatt
     - nimble/host/store/config
-    - nimble/transport/ram
+    - nimble/transport

--- a/apps/blestress/pkg.yml
+++ b/apps/blestress/pkg.yml
@@ -36,4 +36,4 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host/services/gap"
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
     - "@apache-mynewt-nimble/nimble/host/store/config"
-    - "@apache-mynewt-nimble/nimble/transport/ram"
+    - "@apache-mynewt-nimble/nimble/transport"

--- a/apps/bttester/pkg.yml
+++ b/apps/bttester/pkg.yml
@@ -38,7 +38,7 @@ pkg.deps:
     - "@apache-mynewt-nimble/nimble/host/services/gatt"
     - "@apache-mynewt-nimble/nimble/host/services/dis"
     - "@apache-mynewt-nimble/nimble/host/store/config"
-    - "@apache-mynewt-nimble/nimble/transport/ram"
+    - "@apache-mynewt-nimble/nimble/transport"
     - "@apache-mynewt-core/hw/drivers/uart"
     - "@apache-mynewt-core/hw/drivers/rtt"
 

--- a/apps/ext_advertiser/pkg.yml
+++ b/apps/ext_advertiser/pkg.yml
@@ -31,7 +31,7 @@ pkg.deps:
     - nimble/host/services/gap
     - nimble/host/services/gatt
     - nimble/host/store/config
-    - nimble/transport/ram
+    - nimble/transport
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"

--- a/apps/mesh_badge/pkg.yml
+++ b/apps/mesh_badge/pkg.yml
@@ -36,4 +36,4 @@ pkg.deps:
     - nimble/host/services/gap
     - nimble/host/services/gatt
     - nimble/host/store/config
-    - nimble/transport/ram
+    - nimble/transport


### PR DESCRIPTION
Transport package should not be included directly.
Instead, nimble/transport should be included and
BLE_HCI_TRANSPORT syscfg value should specify transport,
and this will include correct package.

This commit changes nimble/transport/ram to nimble/transport in
all applications that still have deprecated way of transport
selection.

Default value of BLE_HCI_TRANSPORT is ram so syscfg.yml for
targets does not need to be updated.