### PR TITLE
nimble/ll: Fix master SCA in LE Connection Complete Event

### DIFF
--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -200,7 +200,9 @@ ble_ll_conn_comp_event_send(struct ble_ll_conn_sm *connsm, uint8_t status,
             enh_ev->conn_itvl = htole16(connsm->conn_itvl);
             enh_ev->conn_latency = htole16(connsm->slave_latency);
             enh_ev->supervision_timeout = htole16(connsm->supervision_tmo);
-            enh_ev->mca = connsm->master_sca;
+            if (connsm->conn_role == BLE_LL_CONN_ROLE_SLAVE) {
+                enh_ev->mca = connsm->master_sca;
+            }
         }
 
         ble_ll_hci_event_send(hci_ev);
@@ -225,7 +227,9 @@ ble_ll_conn_comp_event_send(struct ble_ll_conn_sm *connsm, uint8_t status,
             ev->conn_itvl = htole16(connsm->conn_itvl);
             ev->conn_latency = htole16(connsm->slave_latency);
             ev->supervision_timeout = htole16(connsm->supervision_tmo);
-            ev->mca = connsm->master_sca;
+            if (connsm->conn_role == BLE_LL_CONN_ROLE_SLAVE) {
+                ev->mca = connsm->master_sca;
+            }
         }
 
         ble_ll_hci_event_send(hci_ev);


### PR DESCRIPTION
MCA in LE (Enhanced) Connection Complete Event is valid only for
peripheral role (5.3 V4 Part E 7.7.6.5.1).