### PR TITLE
Fix loopback in net

### DIFF
--- a/nimble/host/mesh/src/net.c
+++ b/nimble/host/mesh/src/net.c
@@ -398,7 +398,7 @@ static void bt_mesh_net_local(struct ble_npl_event *work)
 		       rx.ctx.addr, rx.seq, sub);
 
 		(void) bt_mesh_trans_recv(buf, &rx);
-		net_buf_unref(buf);
+		os_mbuf_free_chain(buf);
 	}
 }
 
@@ -480,7 +480,7 @@ static int loopback(const struct bt_mesh_net_tx *tx, const uint8_t *data,
 {
 	struct os_mbuf *buf;
 
-	buf = os_mbuf_get_pkthdr(&loopback_os_mbuf_pool, 0);
+	buf = os_mbuf_get_pkthdr(&loopback_os_mbuf_pool, BT_MESH_NET_HDR_LEN);
 	if (!buf) {
 		BT_WARN("Unable to allocate loopback");
 		return -ENOMEM;

--- a/nimble/host/mesh/src/net.h
+++ b/nimble/host/mesh/src/net.h
@@ -271,7 +271,12 @@ extern struct bt_mesh_net bt_mesh;
 
 static inline void *net_buf_user_data(const struct os_mbuf *buf)
 {
-	return (void *)buf->om_data;
+    /* In Zephyr at the end of net_buf (which is ported as os_mbuf) is place
+     * for user_data, which is array of octets, just like os_mbuf's om_data. Let's just
+     * use last octets (starting at start of om_data + total size of data mbuf can hold -
+     * intended user_data size) of om_data as Zephyr's user_data.
+     */
+    return (void *)(buf->om_data + buf->om_omp->omp_databuf_len - MYNEWT_VAL(BLE_MESH_NET_BUF_USER_DATA_SIZE));
 }
 
 int bt_mesh_net_create(uint16_t idx, uint8_t flags, const uint8_t key[16],

--- a/nimble/host/mesh/syscfg.yml
+++ b/nimble/host/mesh/syscfg.yml
@@ -233,6 +233,11 @@ syscfg.defs:
             but has a different purpose.
         value: 10
 
+    BLE_MESH_NET_BUF_USER_DATA_SIZE:
+        description: >
+            Number of octets that are used as user_data at the end of os_mbufs
+        value: 4
+
     BLE_MESH_ADV_BUF_COUNT:
         description: >
             Number of advertising buffers available. This should be chosen

--- a/porting/examples/linux_blemesh/include/syscfg/syscfg.h
+++ b/porting/examples/linux_blemesh/include/syscfg/syscfg.h
@@ -772,6 +772,10 @@
 #endif
 
 /* Overridden by @apache-mynewt-nimble/porting/targets/linux_blemesh (defined by @apache-mynewt-nimble/nimble/host/mesh) */
+#ifndef MYNEWT_VAL_BLE_MESH_NET_BUF_USER_DATA_SIZE
+#define MYNEWT_VAL_BLE_MESH_NET_BUF_USER_DATA_SIZE (4)
+#endif
+
 #ifndef MYNEWT_VAL_BLE_MESH_ADV_BUF_COUNT
 #define MYNEWT_VAL_BLE_MESH_ADV_BUF_COUNT (20)
 #endif


### PR DESCRIPTION
net_buf structure in Zephyr has field user_data, which was wrongly
ported as os_mbuf->om_data. To stick with porting net_buf as os_mbuf
we can base on old Zephyr's implementation, which was changed in commit
dd09cbc1c455ab1e067b53f46bee7b6d50689bbc. Before it, user_data was part
of data buffer of net_buf. We can implement this the same way, so
data_buf is last N octets of os_mbuf->om_data.