### PR TITLE
nimble/sm: Ensure bonded flag is set in sm_result on new pair & bond.

### DIFF
--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -2041,14 +2041,16 @@ ble_sm_key_exch_success(struct ble_sm_proc *proc, struct ble_sm_result *res)
     /* The procedure is now complete.  Update connection bonded state and
      * terminate procedure.
      */
+    int bonded = !!(proc->flags & BLE_SM_PROC_F_BONDING);
     ble_sm_update_sec_state(proc->conn_handle, 1,
                             !!(proc->flags & BLE_SM_PROC_F_AUTHENTICATED),
-                            !!(proc->flags & BLE_SM_PROC_F_BONDING),
+                            bonded,
                             proc->key_size);
     proc->state = BLE_SM_PROC_STATE_NONE;
 
     res->app_status = 0;
     res->enc_cb = 1;
+    res->bonded = bonded;
 }
 
 static void


### PR DESCRIPTION
The bonded flag was not set on new connection in ble_gap_enc_event()

Without this change, the `if (bonded)` was always `false` on re-connection of a bonded peer in: 
https://github.com/apache/mynewt-nimble/blob/0ef8d590db8bc741f3e25610c6e3e6d11dba2c6c/nimble/host/src/ble_gap.c#L5799