### PR TITLE
host/ble_att_svr: Reset handles index on attributes reset.

### DIFF
--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -2671,6 +2671,8 @@ ble_att_svr_reset(void)
         ble_att_svr_entry_free(entry);
     }
 
+    ble_att_svr_id = 0;
+    
     /* Note: prep entries do not get freed here because it is assumed there are
      * no established connections.
      */


### PR DESCRIPTION
Resets handles index when server's attributes are reset.
Prevents mix-up when attributes are cached.