### PR TITLE
host/mesh: fix disconnect

### DIFF
--- a/nimble/host/mesh/src/pb_gatt_srv.c
+++ b/nimble/host/mesh/src/pb_gatt_srv.c
@@ -159,15 +159,9 @@ void gatt_connected_pb_gatt(uint16_t conn_handle, uint8_t err)
 	BT_DBG("conn %p err 0x%02x", (void *)conn, err);
 }
 
-void gatt_disconnected_pb_gatt(uint16_t conn_handle, uint8_t reason)
+void gatt_disconnected_pb_gatt(struct ble_gap_conn_desc conn, uint8_t reason)
 {
-	struct ble_gap_conn_desc info;
-
-	struct ble_hs_conn *conn;
-
-	conn = ble_hs_conn_find(conn_handle);
-	bt_conn_get_info(conn, &info);
-	if (info.role != BLE_GAP_ROLE_SLAVE ||
+	if (conn.role != BLE_GAP_ROLE_SLAVE ||
 	    !service_registered) {
 		return;
 	}
@@ -177,9 +171,9 @@ void gatt_disconnected_pb_gatt(uint16_t conn_handle, uint8_t reason)
 		cli = NULL;
 	}
 
-	BT_DBG("conn %p reason 0x%02x", (void *)conn, reason);
+	BT_DBG("conn_handle %d reason 0x%02x", conn.conn_handle, reason);
 
-	bt_mesh_pb_gatt_close(conn_handle);
+	bt_mesh_pb_gatt_close(conn.conn_handle);
 
 	if (bt_mesh_is_provisioned()) {
 		(void)bt_mesh_pb_gatt_disable();

--- a/nimble/host/mesh/src/pb_gatt_srv.h
+++ b/nimble/host/mesh/src/pb_gatt_srv.h
@@ -14,7 +14,7 @@ int bt_mesh_pb_gatt_enable(void);
 int bt_mesh_pb_gatt_disable(void);
 
 int prov_ccc_write(uint16_t conn_handle, uint8_t type);
-void gatt_disconnected_pb_gatt(uint16_t conn_handle, uint8_t err);
+void gatt_disconnected_pb_gatt(struct ble_gap_conn_desc conn, uint8_t err);
 void gatt_connected_pb_gatt(uint16_t conn_handle, uint8_t err);
 void resolve_svc_handles(void);
 

--- a/nimble/host/mesh/src/proxy_srv.c
+++ b/nimble/host/mesh/src/proxy_srv.c
@@ -825,15 +825,11 @@ static void gatt_connected(uint16_t conn_handle)
 	}
 }
 
-static void gatt_disconnected(uint16_t conn_handle, uint8_t reason)
+static void gatt_disconnected(struct ble_gap_conn_desc conn, uint8_t reason)
 {
-	struct ble_gap_conn_desc info;
 	struct bt_mesh_proxy_client *client;
-	struct ble_hs_conn *conn;
 
-	conn = ble_hs_conn_find(conn_handle);
-	bt_conn_get_info(conn, &info);
-	if (info.role != BLE_GAP_ROLE_SLAVE) {
+	if (conn.role != BLE_GAP_ROLE_SLAVE) {
 		return;
 	}
 
@@ -843,7 +839,7 @@ static void gatt_disconnected(uint16_t conn_handle, uint8_t reason)
 	}
 
 	conn_count--;
-	client = find_client(conn_handle);
+	client = find_client(conn.conn_handle);
 	if (client->cli) {
 		bt_mesh_proxy_role_cleanup(client->cli);
 		client->cli = NULL;
@@ -938,10 +934,10 @@ int ble_mesh_proxy_gap_event(struct ble_gap_event *event, void *arg)
 	    (event->type == BLE_GAP_EVENT_ADV_COMPLETE)) {
 		ble_mesh_handle_connect(event, arg);
 	} else if (event->type == BLE_GAP_EVENT_DISCONNECT) {
-		gatt_disconnected(event->disconnect.conn.conn_handle,
+		gatt_disconnected(event->disconnect.conn,
 				   event->disconnect.reason);
 #if MYNEWT_VAL(BLE_MESH_PB_GATT)
-		gatt_disconnected_pb_gatt(event->disconnect.conn.conn_handle,
+		gatt_disconnected_pb_gatt(event->disconnect.conn,
 				  event->disconnect.reason);
 #endif
 	} else if (event->type == BLE_GAP_EVENT_SUBSCRIBE) {


### PR DESCRIPTION
We should use connection descriptor from event, as connection no longer
exists.