### PR TITLE
host/mesh: fix clients array indexing in proxy_srv

### DIFF
--- a/nimble/host/mesh/src/proxy_msg.h
+++ b/nimble/host/mesh/src/proxy_msg.h
@@ -45,6 +45,7 @@ struct bt_mesh_proxy_role {
 
 struct bt_mesh_proxy_client {
 	struct bt_mesh_proxy_role *cli;
+	uint16_t conn_handle;
 	uint16_t filter[MYNEWT_VAL(BLE_MESH_PROXY_FILTER_SIZE)];
 	enum __packed {
 		NONE,


### PR DESCRIPTION
find_client() should return client from clients[conn_handle - 1],
as connection handles are counted from 1, but arrays are indexed from 0.
This will make sure we use all possible connections, and not leave first
element of clients[] as NULL.