### PR TITLE
ports: Build NimBLE with 32-bit environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ _addons: &addon_conf
     packages:
       - gcc-multilib
       - gcc-7-multilib
+      - g++-multilib
 
 go:
   - "1.16"

--- a/porting/examples/dummy/Makefile
+++ b/porting/examples/dummy/Makefile
@@ -60,6 +60,7 @@ OBJ := $(SRC:.c=.o)
 TINYCRYPT_OBJ := $(TINYCRYPT_SRC:.c=.o)
 
 CFLAGS := $(NIMBLE_CFLAGS)
+LDFLAGS := $(NIMBLE_LDFLAGS)
 
 .PHONY: all clean
 .DEFAULT: all
@@ -76,4 +77,4 @@ $(TINYCRYPT_OBJ): CFLAGS+=$(TINYCRYPT_CFLAGS)
 	$(CC) -c $(addprefix -I, $(INC)) $(CFLAGS) -o $@ $<
 
 dummy: $(OBJ) $(TINYCRYPT_OBJ)
-	$(CC) -o $@ $^
+	$(CC) -o $@ $^ $(LDFLAGS)

--- a/porting/examples/linux/Makefile
+++ b/porting/examples/linux/Makefile
@@ -81,7 +81,7 @@ CFLAGS =                    \
     -D_GNU_SOURCE           \
     $(NULL)
 
-LIBS := -lrt -lpthread -lstdc++
+LIBS := $(NIMBLE_LDFLAGS) -lrt -lpthread -lstdc++
 
 .PHONY: all clean
 .DEFAULT: all

--- a/porting/examples/linux_blemesh/Makefile
+++ b/porting/examples/linux_blemesh/Makefile
@@ -83,7 +83,7 @@ CFLAGS =                    \
     -D_GNU_SOURCE           \
     $(NULL)
 
-LIBS := -lrt -lpthread -lstdc++
+LIBS := $(NIMBLE_LDFLAGS) -lrt -lpthread -lstdc++
 
 .PHONY: all clean
 .DEFAULT: all

--- a/porting/nimble/Makefile.defs
+++ b/porting/nimble/Makefile.defs
@@ -19,7 +19,10 @@ ifeq (,$(NIMBLE_ROOT))
 $(error NIMBLE_ROOT shall be defined)
 endif
 
-NIMBLE_CFLAGS :=
+# For now this is required as there are places in NimBLE
+# assumingthat pointer is 4 bytes long.
+NIMBLE_CFLAGS := -m32
+NIMBLE_LDFLAGS := -m32
 
 NIMBLE_INCLUDE := \
 	$(NIMBLE_ROOT)/nimble/include \


### PR DESCRIPTION
Some code in NimBLE assumes that pointers are 4 bytes. Until this
is properly fixed build with -m32 to make sure resulting binary
is no misbehaving.