### PR TITLE
nimble: Allow to configure BLE version 5.3

### DIFF
--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1828,6 +1828,7 @@ struct ble_hci_ev_le_subev_biginfo_adv_report {
 #define BLE_HCI_VER_BCS_5_0                 (9)
 #define BLE_HCI_VER_BCS_5_1                 (10)
 #define BLE_HCI_VER_BCS_5_2                 (11)
+#define BLE_HCI_VER_BCS_5_3                 (12)
 
 #define BLE_LMP_VER_BCS_1_0b                (0)
 #define BLE_LMP_VER_BCS_1_1                 (1)
@@ -1841,6 +1842,7 @@ struct ble_hci_ev_le_subev_biginfo_adv_report {
 #define BLE_LMP_VER_BCS_5_0                 (9)
 #define BLE_LMP_VER_BCS_5_1                 (10)
 #define BLE_LMP_VER_BCS_5_2                 (11)
+#define BLE_LMP_VER_BCS_5_3                 (12)
 
 /* selected HCI and LMP version */
 #if MYNEWT_VAL(BLE_VERSION) == 50
@@ -1852,7 +1854,9 @@ struct ble_hci_ev_le_subev_biginfo_adv_report {
 #elif MYNEWT_VAL(BLE_VERSION) == 52
 #define BLE_HCI_VER_BCS BLE_HCI_VER_BCS_5_2
 #define BLE_LMP_VER_BCS BLE_LMP_VER_BCS_5_2
-
+#elif MYNEWT_VAL(BLE_VERSION) == 53
+#define BLE_HCI_VER_BCS BLE_HCI_VER_BCS_5_3
+#define BLE_LMP_VER_BCS BLE_LMP_VER_BCS_5_3
 #endif
 
 #define BLE_HCI_DATA_HDR_SZ                 4

--- a/nimble/syscfg.yml
+++ b/nimble/syscfg.yml
@@ -79,7 +79,7 @@ syscfg.defs:
             This allows to configure supported Bluetooth Core version. Some
             features may not be available if version is too low. Version is
             integer for easy comparison.
-        range: 50, 51, 52
+        range: 50, 51, 52, 53
         value: 50
     BLE_ISO:
         description: >


### PR DESCRIPTION
Core Specification 5.3 is available for some time already.