### PR TITLE
apps: Remove controller direct dependency

### DIFF
--- a/apps/blecsc/pkg.yml
+++ b/apps/blecsc/pkg.yml
@@ -32,7 +32,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/sysinit"
     - "@apache-mynewt-core/sys/id"
-    - nimble/controller
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt

--- a/apps/blehr/pkg.yml
+++ b/apps/blehr/pkg.yml
@@ -32,7 +32,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/sysinit"
     - "@apache-mynewt-core/sys/id"
-    - nimble/controller
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt

--- a/apps/blemesh/pkg.yml
+++ b/apps/blemesh/pkg.yml
@@ -29,7 +29,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/shell"
-    - nimble/controller
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt

--- a/apps/blemesh_light/pkg.yml
+++ b/apps/blemesh_light/pkg.yml
@@ -29,7 +29,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/shell"
-    - nimble/controller
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt

--- a/apps/blemesh_models_example_1/pkg.yml
+++ b/apps/blemesh_models_example_1/pkg.yml
@@ -27,7 +27,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/console/full"
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/stats/full"
-    - nimble/controller
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt

--- a/apps/blemesh_models_example_2/pkg.yml
+++ b/apps/blemesh_models_example_2/pkg.yml
@@ -29,7 +29,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/encoding/base64"
     - "@apache-mynewt-core/sys/config"
-    - nimble/controller
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt

--- a/apps/blemesh_shell/pkg.yml
+++ b/apps/blemesh_shell/pkg.yml
@@ -29,7 +29,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/shell"
-    - nimble/controller
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt

--- a/apps/blestress/pkg.yml
+++ b/apps/blestress/pkg.yml
@@ -30,7 +30,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/full"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/id"
-    - "@apache-mynewt-nimble/nimble/controller"
     - "@apache-mynewt-nimble/nimble/host"
     - "@apache-mynewt-nimble/nimble/host/util"
     - "@apache-mynewt-nimble/nimble/host/services/gap"

--- a/apps/bttester/pkg.yml
+++ b/apps/bttester/pkg.yml
@@ -31,7 +31,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/shell"
-    - "@apache-mynewt-nimble/nimble/controller"
     - "@apache-mynewt-nimble/nimble/host"
     - "@apache-mynewt-nimble/nimble/host/util"
     - "@apache-mynewt-nimble/nimble/host/services/gap"

--- a/apps/ext_advertiser/pkg.yml
+++ b/apps/ext_advertiser/pkg.yml
@@ -25,7 +25,6 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - nimble/controller
     - nimble/host
     - nimble/host/util
     - nimble/host/services/gap

--- a/apps/mesh_badge/pkg.yml
+++ b/apps/mesh_badge/pkg.yml
@@ -31,7 +31,6 @@ pkg.deps:
     - "@apache-mynewt-core/sys/log/modlog"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/sys/shell"
-    - nimble/controller
     - nimble/host
     - nimble/host/services/gap
     - nimble/host/services/gatt


### PR DESCRIPTION
Direct dependency on controller is incorrect when
controller runs on another core.