### PR TITLE
apps: remove deprecated BLE_PUBLIC_DEV_ADDR

### DIFF
--- a/apps/blecsc/syscfg.yml
+++ b/apps/blecsc/syscfg.yml
@@ -32,7 +32,7 @@ syscfg.vals:
     CONFIG_FCB: 1
 
     # Set public device address.
-    BLE_PUBLIC_DEV_ADDR: ((uint8_t[6]){0xcc, 0xbb, 0xaa, 0x33, 0x22, 0x11})
+    BLE_LL_PUBLIC_DEV_ADDR: 0x1122aabb33cc
 
     # Set device appearance to Cycling Speed and Cadence Sensor
     BLE_SVC_GAP_APPEARANCE: BLE_SVC_GAP_APPEARANCE_CYC_SPEED_AND_CADENCE_SENSOR

--- a/apps/blehr/syscfg.yml
+++ b/apps/blehr/syscfg.yml
@@ -32,7 +32,7 @@ syscfg.vals:
     CONFIG_FCB: 1
 
     # Set public device address.
-    BLE_PUBLIC_DEV_ADDR: ((uint8_t[6]){0xcc, 0xbb, 0xaa, 0x33, 0x22, 0x11})
+    BLE_LL_PUBLIC_DEV_ADDR: 0x1122aabb33cc
 
     # Whether to save data to sys/config, or just keep it in RAM.
     BLE_STORE_CONFIG_PERSIST: 0

--- a/apps/blestress/src/rx_stress.c
+++ b/apps/blestress/src/rx_stress.c
@@ -155,7 +155,8 @@ rx_stress_simple_adv(struct rx_stress_adv_set *adv_set)
     assert (rc == 0);
 
     if (own_addr_type == 0) {
-        memcpy(addr.val, MYNEWT_VAL(BLE_PUBLIC_DEV_ADDR), 6);
+        rc = ble_hs_id_copy_addr(BLE_ADDR_PUBLIC, addr.val, NULL);
+        assert (rc == 0);
     } else {
         rc = ble_hs_id_gen_rnd(1, &addr);
         assert (rc == 0);

--- a/apps/bttester/src/gap.c
+++ b/apps/bttester/src/gap.c
@@ -166,18 +166,6 @@ static void controller_index_list(uint8_t *data,  uint16_t len)
 		    BTP_INDEX_NONE, (uint8_t *) rp, sizeof(buf));
 }
 
-static int check_pub_addr_unassigned(void)
-{
-#ifdef ARCH_sim
-	return 0;
-#else
-	uint8_t zero_addr[BLE_DEV_ADDR_LEN] = { 0 };
-
-	return memcmp(MYNEWT_VAL(BLE_PUBLIC_DEV_ADDR),
-		      zero_addr, BLE_DEV_ADDR_LEN) == 0;
-#endif
-}
-
 static void controller_info(uint8_t *data, uint16_t len)
 {
 	struct gap_read_controller_info_rp rp;
@@ -212,15 +200,14 @@ static void controller_info(uint8_t *data, uint16_t len)
 		supported_settings |= BIT(GAP_SETTINGS_PRIVACY);
 		memcpy(rp.address, addr.val, sizeof(rp.address));
 	} else {
-		if (check_pub_addr_unassigned()) {
+		rc = ble_hs_id_copy_addr(BLE_ADDR_PUBLIC, rp.address, NULL);
+		if (rc) {
 			own_addr_type = BLE_OWN_ADDR_RANDOM;
 			memcpy(rp.address, addr.val, sizeof(rp.address));
 			supported_settings |= BIT(GAP_SETTINGS_STATIC_ADDRESS);
 			current_settings |= BIT(GAP_SETTINGS_STATIC_ADDRESS);
 		} else {
 			own_addr_type = BLE_OWN_ADDR_PUBLIC;
-			memcpy(rp.address, MYNEWT_VAL(BLE_PUBLIC_DEV_ADDR),
-			       sizeof(rp.address));
 		}
 	}
 

--- a/nimble/host/mesh/src/shell.c
+++ b/nimble/host/mesh/src/shell.c
@@ -707,10 +707,9 @@ static int check_pub_addr_unassigned(void)
 #ifdef ARCH_sim
 	return 0;
 #else
-	uint8_t zero_addr[BLE_DEV_ADDR_LEN] = { 0 };
+	uint8_t addr[BLE_DEV_ADDR_LEN];
 
-	return memcmp(MYNEWT_VAL(BLE_PUBLIC_DEV_ADDR),
-		      zero_addr, BLE_DEV_ADDR_LEN) == 0;
+	return ble_hs_id_copy_addr(BLE_ADDR_PUBLIC, addr, NULL) != 0;
 #endif
 }
 

--- a/targets/dialog_cmac/syscfg.yml
+++ b/targets/dialog_cmac/syscfg.yml
@@ -32,4 +32,4 @@ syscfg.vals:
     BLE_LL_SCHED_AUX_CHAIN_MAFS_DELAY: 150
 
     # NOTE: set public address in target settings
-    # BLE_PUBLIC_DEV_ADDR: "(uint8_t[6]){0xff, 0xff, 0xff, 0xff, 0xff, 0xff}"
+    # BLE_LL_PUBLIC_DEV_ADDR: 0xffffffffffff


### PR DESCRIPTION
ble_hs_id_copy_addr() is used whenever deprecated value was used
for getting public address.
