### PR TITLE
nimble/ll: Compile out not enabled GAP roles

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -108,11 +108,13 @@ struct ble_ll_obj
     /* Current Link Layer state */
     uint8_t ll_state;
 
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL) || MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
     /* Number of ACL data packets supported */
     uint8_t ll_num_acl_pkts;
 
     /* ACL data packet size */
     uint16_t ll_acl_pkt_size;
+#endif
 
     /* Preferred PHY's */
     uint8_t ll_pref_tx_phys;
@@ -129,14 +131,18 @@ struct ble_ll_obj
     struct ble_ll_pkt_q ll_rx_pkt_q;
 
     /* Packet transmit queue */
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL) || MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
     struct ble_npl_event ll_tx_pkt_ev;
+#endif
     struct ble_ll_pkt_q ll_tx_pkt_q;
 
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL) || MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
     /* Data buffer overflow event */
     struct ble_npl_event ll_dbuf_overflow_ev;
 
     /* Number of completed packets event */
     struct ble_npl_event ll_comp_pkt_ev;
+#endif
 
     /* HW error callout */
     struct ble_npl_callout ll_hw_err_timer;
@@ -214,12 +220,24 @@ extern STATS_SECT_DECL(ble_ll_stats) ble_ll_stats;
 
 /* States */
 #define BLE_LL_STATE_STANDBY        (0)
+#if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
 #define BLE_LL_STATE_ADV            (1)
+#endif
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
 #define BLE_LL_STATE_SCANNING       (2)
+#endif
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_LL_STATE_CONNECTION     (4)
+#endif
+#if MYNEWT_VAL(BLE_LL_DTM)
 #define BLE_LL_STATE_DTM            (5)
+#endif
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER) && MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV)
 #define BLE_LL_STATE_SYNC           (6)
+#endif
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER) && MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 #define BLE_LL_STATE_SCAN_AUX       (7)
+#endif
 
 /* LL Features */
 #define BLE_LL_FEAT_LE_ENCRYPTION    (0x0000000001)

--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -34,8 +34,13 @@ extern "C" {
 
 /* Roles */
 #define BLE_LL_CONN_ROLE_NONE           (0)
+
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_LL_CONN_ROLE_MASTER         (1)
+#endif
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
 #define BLE_LL_CONN_ROLE_SLAVE          (2)
+#endif
 
 /* Connection states */
 #define BLE_LL_CONN_STATE_IDLE          (0)
@@ -370,8 +375,17 @@ struct ble_ll_conn_sm
 #define CONN_F_AUX_CONN_REQ(csm)  ((csm)->csmflags.cfbit.aux_conn_req)
 
 /* Role */
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define CONN_IS_MASTER(csm)         (csm->conn_role == BLE_LL_CONN_ROLE_MASTER)
+#else
+#define CONN_IS_MASTER(csm)         (false)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
 #define CONN_IS_SLAVE(csm)          (csm->conn_role == BLE_LL_CONN_ROLE_SLAVE)
+#else
+#define CONN_IS_SLAVE(csm)          (false)
+#endif
 
 /*
  * Given a handle, returns an active connection state machine (or NULL if the

--- a/nimble/controller/include/controller/ble_ll_scan.h
+++ b/nimble/controller/include/controller/ble_ll_scan.h
@@ -152,14 +152,18 @@ struct ble_ll_scan_sm
     struct ble_ll_scan_phy *scanp_next;
     struct ble_ll_scan_phy scan_phys[BLE_LL_SCAN_PHY_NUMBER];
 
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
     /* Connection sm for initiator scan */
     struct ble_ll_conn_sm *connsm;
+#endif
 };
 
 /* Scan types */
 #define BLE_SCAN_TYPE_PASSIVE   (BLE_HCI_SCAN_TYPE_PASSIVE)
 #define BLE_SCAN_TYPE_ACTIVE    (BLE_HCI_SCAN_TYPE_ACTIVE)
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SCAN_TYPE_INITIATE  (2)
+#endif
 
 /*---- HCI ----*/
 /* Set scanning parameters */
@@ -219,7 +223,11 @@ uint8_t *ble_ll_scan_get_local_rpa(void);
 void ble_ll_scan_sm_stop(int chk_disable);
 
 /* Resume scanning */
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
 void ble_ll_scan_chk_resume(void);
+#else
+static inline void ble_ll_scan_chk_resume(void) { };
+#endif
 
 /* Called when wait for response timer expires in scanning mode */
 void ble_ll_scan_wfr_timer_exp(void);

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -65,48 +65,171 @@
  */
 
 /* Supported states */
-#define BLE_LL_S_NCA                    (0x00000000001)
-#define BLE_LL_S_SA                     (0x00000000002)
-#define BLE_LL_S_CA                     (0x00000000004)
-#define BLE_LL_S_HDCA                   (0x00000000008)
-#define BLE_LL_S_PS                     (0x00000000010)
-#define BLE_LL_S_AS                     (0x00000000020)
-#define BLE_LL_S_INIT                   (0x00000000040)
-#define BLE_LL_S_SLAVE                  (0x00000000080)
-#define BLE_LL_S_NCA_PS                 (0x00000000100)
-#define BLE_LL_S_SA_PS                  (0x00000000200)
-#define BLE_LL_S_CA_PS                  (0x00000000400)
-#define BLE_LL_S_HDCA_PS                (0x00000000800)
-#define BLE_LL_S_NCA_AS                 (0x00000001000)
-#define BLE_LL_S_SA_AS                  (0x00000002000)
-#define BLE_LL_S_CA_AS                  (0x00000004000)
-#define BLE_LL_S_HDCA_AS                (0x00000008000)
-#define BLE_LL_S_NCA_INIT               (0x00000010000)
-#define BLE_LL_S_SA_INIT                (0x00000020000)
-#define BLE_LL_S_NCA_MASTER             (0x00000040000)
-#define BLE_LL_S_SA_MASTER              (0x00000080000)
-#define BLE_LL_S_NCA_SLAVE              (0x00000100000)
-#define BLE_LL_S_SA_SLAVE               (0x00000200000)
-#define BLE_LL_S_PS_INIT                (0x00000400000)
-#define BLE_LL_S_AS_INIT                (0x00000800000)
-#define BLE_LL_S_PS_MASTER              (0x00001000000)
-#define BLE_LL_S_AS_MASTER              (0x00002000000)
-#define BLE_LL_S_PS_SLAVE               (0x00004000000)
-#define BLE_LL_S_AS_SLAVE               (0x00008000000)
-#define BLE_LL_S_INIT_MASTER            (0x00010000000)
-#define BLE_LL_S_LDCA                   (0x00020000000)
-#define BLE_LL_S_LDCA_PS                (0x00040000000)
-#define BLE_LL_S_LDCA_AS                (0x00080000000)
-#define BLE_LL_S_CA_INIT                (0x00100000000)
-#define BLE_LL_S_HDCA_INIT              (0x00200000000)
-#define BLE_LL_S_LDCA_INIT              (0x00400000000)
-#define BLE_LL_S_CA_MASTER              (0x00800000000)
-#define BLE_LL_S_HDCA_MASTER            (0x01000000000)
-#define BLE_LL_S_LDCA_MASTER            (0x02000000000)
-#define BLE_LL_S_CA_SLAVE               (0x04000000000)
-#define BLE_LL_S_HDCA_SLAVE             (0x08000000000)
-#define BLE_LL_S_LDCA_SLAVE             (0x10000000000)
-#define BLE_LL_S_INIT_SLAVE             (0x20000000000)
+#if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
+#define BLE_LL_S_NCA                    ((uint64_t)1 << 0)
+#define BLE_LL_S_SA                     ((uint64_t)1 << 1)
+#else
+#define BLE_LL_S_NCA                    ((uint64_t)0 << 0)
+#define BLE_LL_S_SA                     ((uint64_t)0 << 1)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
+#define BLE_LL_S_CA                     ((uint64_t)1 << 2)
+#define BLE_LL_S_HDCA                   ((uint64_t)1 << 3)
+#else
+#define BLE_LL_S_CA                     ((uint64_t)0 << 2)
+#define BLE_LL_S_HDCA                   ((uint64_t)0 << 3)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
+#define BLE_LL_S_PS                     ((uint64_t)1 << 4)
+#define BLE_LL_S_AS                     ((uint64_t)1 << 5)
+#else
+#define BLE_LL_S_PS                     ((uint64_t)0 << 4)
+#define BLE_LL_S_AS                     ((uint64_t)0 << 5)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+#define BLE_LL_S_INIT                   ((uint64_t)1 << 6)
+#else
+#define BLE_LL_S_INIT                   ((uint64_t)0 << 6)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
+#define BLE_LL_S_SLAVE                  ((uint64_t)1 << 7)
+#else
+#define BLE_LL_S_SLAVE                  ((uint64_t)0 << 7)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER) && MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
+#define BLE_LL_S_NCA_PS                 ((uint64_t)1 << 8)
+#define BLE_LL_S_SA_PS                  ((uint64_t)1 << 9)
+#else
+#define BLE_LL_S_NCA_PS                 ((uint64_t)0 << 8)
+#define BLE_LL_S_SA_PS                  ((uint64_t)0 << 9)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) && MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
+#define BLE_LL_S_CA_PS                  ((uint64_t)1 << 10)
+#define BLE_LL_S_HDCA_PS                ((uint64_t)1 << 11)
+#else
+#define BLE_LL_S_CA_PS                  ((uint64_t)0 << 10)
+#define BLE_LL_S_HDCA_PS                ((uint64_t)0 << 11)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER) && MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
+#define BLE_LL_S_NCA_AS                 ((uint64_t)1 << 12)
+#define BLE_LL_S_SA_AS                  ((uint64_t)1 << 13)
+#else
+#define BLE_LL_S_NCA_AS                 ((uint64_t)0 << 12)
+#define BLE_LL_S_SA_AS                  ((uint64_t)0 << 13)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) && MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
+#define BLE_LL_S_CA_AS                  ((uint64_t)1 << 14)
+#define BLE_LL_S_HDCA_AS                ((uint64_t)1 << 15)
+#else
+#define BLE_LL_S_CA_AS                  ((uint64_t)0 << 14)
+#define BLE_LL_S_HDCA_AS                ((uint64_t)0 << 15)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER) && MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+#define BLE_LL_S_NCA_INIT               ((uint64_t)1 << 16)
+#define BLE_LL_S_SA_INIT                ((uint64_t)1 << 17)
+#define BLE_LL_S_NCA_MASTER             ((uint64_t)1 << 18)
+#define BLE_LL_S_SA_MASTER              ((uint64_t)1 << 19)
+#else
+#define BLE_LL_S_NCA_INIT               ((uint64_t)0 << 16)
+#define BLE_LL_S_SA_INIT                ((uint64_t)0 << 17)
+#define BLE_LL_S_NCA_MASTER             ((uint64_t)0 << 18)
+#define BLE_LL_S_SA_MASTER              ((uint64_t)0 << 19)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER) && MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
+#define BLE_LL_S_NCA_SLAVE              ((uint64_t)1 << 20)
+#define BLE_LL_S_SA_SLAVE               ((uint64_t)1 << 21)
+#else
+#define BLE_LL_S_NCA_SLAVE              ((uint64_t)0 << 20)
+#define BLE_LL_S_SA_SLAVE               ((uint64_t)0 << 21)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER) && MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+/* We do not support passive scanning while initiating yet */
+#define BLE_LL_S_PS_INIT                ((uint64_t)0 << 22)
+/* We do not support active scanning while initiating yet */
+#define BLE_LL_S_AS_INIT                ((uint64_t)0 << 23)
+#define BLE_LL_S_PS_MASTER              ((uint64_t)1 << 24)
+#define BLE_LL_S_AS_MASTER              ((uint64_t)1 << 25)
+#else
+#define BLE_LL_S_PS_INIT                ((uint64_t)0 << 22)
+#define BLE_LL_S_AS_INIT                ((uint64_t)0 << 23)
+#define BLE_LL_S_PS_MASTER              ((uint64_t)0 << 24)
+#define BLE_LL_S_AS_MASTER              ((uint64_t)0 << 25)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER) && MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
+#define BLE_LL_S_PS_SLAVE               ((uint64_t)1 << 26)
+#define BLE_LL_S_AS_SLAVE               ((uint64_t)1 << 27)
+#else
+#define BLE_LL_S_PS_SLAVE               ((uint64_t)0 << 26)
+#define BLE_LL_S_AS_SLAVE               ((uint64_t)0 << 27)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+#define BLE_LL_S_INIT_MASTER            ((uint64_t)1 << 28)
+#else
+#define BLE_LL_S_INIT_MASTER            ((uint64_t)0 << 28)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
+#define BLE_LL_S_LDCA                   ((uint64_t)1 << 29)
+#else
+#define BLE_LL_S_LDCA                   ((uint64_t)0 << 29)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) && MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
+#define BLE_LL_S_LDCA_PS                ((uint64_t)1 << 30)
+#define BLE_LL_S_LDCA_AS                ((uint64_t)1 << 31)
+#else
+#define BLE_LL_S_LDCA_PS                ((uint64_t)0 << 30)
+#define BLE_LL_S_LDCA_AS                ((uint64_t)0 << 31)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) && MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+#define BLE_LL_S_CA_INIT                ((uint64_t)1 << 32)
+#define BLE_LL_S_HDCA_INIT              ((uint64_t)1 << 33)
+#define BLE_LL_S_LDCA_INIT              ((uint64_t)1 << 34)
+#else
+#define BLE_LL_S_CA_INIT                ((uint64_t)0 << 32)
+#define BLE_LL_S_HDCA_INIT              ((uint64_t)0 << 33)
+#define BLE_LL_S_LDCA_INIT              ((uint64_t)0 << 34)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+#define BLE_LL_S_CA_MASTER              ((uint64_t)1 << 35)
+#define BLE_LL_S_HDCA_MASTER            ((uint64_t)1 << 36)
+#define BLE_LL_S_LDCA_MASTER            ((uint64_t)1 << 37)
+#else
+#define BLE_LL_S_CA_MASTER              ((uint64_t)0 << 35)
+#define BLE_LL_S_HDCA_MASTER            ((uint64_t)0 << 36)
+#define BLE_LL_S_LDCA_MASTER            ((uint64_t)0 << 37)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
+#define BLE_LL_S_CA_SLAVE               ((uint64_t)1 << 38)
+#define BLE_LL_S_HDCA_SLAVE             ((uint64_t)1 << 39)
+#define BLE_LL_S_LDCA_SLAVE             ((uint64_t)1 << 40)
+#else
+#define BLE_LL_S_CA_SLAVE               ((uint64_t)0 << 38)
+#define BLE_LL_S_HDCA_SLAVE             ((uint64_t)0 << 39)
+#define BLE_LL_S_LDCA_SLAVE             ((uint64_t)0 << 40)
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) && MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+#define BLE_LL_S_INIT_SLAVE             ((uint64_t)1 << 41)
+#else
+#define BLE_LL_S_INIT_SLAVE             ((uint64_t)0 << 41)
+#endif
 
 #define BLE_LL_SUPPORTED_STATES             \
 (                                           \

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -64,6 +64,7 @@ struct ble_ll_conn_global_params
 {
     uint8_t master_chan_map[BLE_LL_CONN_CHMAP_LEN];
     uint8_t num_used_chans;
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL) || MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
     uint8_t supp_max_tx_octets;
     uint8_t supp_max_rx_octets;
     uint8_t conn_init_max_tx_octets;
@@ -74,6 +75,7 @@ struct ble_ll_conn_global_params
     uint16_t conn_init_max_tx_time_coded;
     uint16_t supp_max_tx_time;
     uint16_t supp_max_rx_time;
+#endif
 };
 extern struct ble_ll_conn_global_params g_ble_ll_conn_params;
 

--- a/nimble/controller/src/ble_ll_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_supp_cmd.c
@@ -27,7 +27,11 @@
 #include "controller/ble_ll_hci.h"
 
 /* Octet 0 */
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SUPP_CMD_DISCONNECT             (1 << 5)
+#else
+#define BLE_SUPP_CMD_DISCONNECT             (0 << 5)
+#endif
 #define BLE_LL_SUPP_CMD_OCTET_0             (BLE_SUPP_CMD_DISCONNECT)
 
 /* Octet 5 */
@@ -64,7 +68,12 @@
 
 /* Octet 15 */
 #define BLE_SUPP_CMD_RD_BD_ADDR             (1 << 1)
+
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SUPP_CMD_RD_RSSI                (1 << 5)
+#else
+#define BLE_SUPP_CMD_RD_RSSI                (0 << 5)
+#endif
 
 #define BLE_LL_SUPP_CMD_OCTET_15            \
 (                                           \
@@ -77,9 +86,15 @@
 #define BLE_SUPP_CMD_LE_RD_BUF_SIZE         (1 << 1)
 #define BLE_SUPP_CMD_LE_RD_LOC_FEAT         (1 << 2)
 #define BLE_SUPP_CMD_LE_SET_RAND_ADDR       (1 << 4)
+#if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
 #define BLE_SUPP_CMD_LE_SET_ADV_PARAMS      (1 << 5)
 #define BLE_SUPP_CMD_LE_SET_ADV_TX_PWR      (1 << 6)
 #define BLE_SUPP_CMD_LE_SET_ADV_DATA        (1 << 7)
+#else
+#define BLE_SUPP_CMD_LE_SET_ADV_PARAMS      (0 << 5)
+#define BLE_SUPP_CMD_LE_SET_ADV_TX_PWR      (0 << 6)
+#define BLE_SUPP_CMD_LE_SET_ADV_DATA        (0 << 7)
+#endif
 
 #define BLE_LL_SUPP_CMD_OCTET_25            \
 (                                           \
@@ -93,12 +108,28 @@
 )
 
 /* Octet 26 */
+#if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
 #define BLE_SUPP_CMD_LE_SET_SCAN_RSP_DATA   (1 << 0)
 #define BLE_SUPP_CMD_LE_SET_ADV_ENABLE      (1 << 1)
+#else
+#define BLE_SUPP_CMD_LE_SET_SCAN_RSP_DATA   (0 << 0)
+#define BLE_SUPP_CMD_LE_SET_ADV_ENABLE      (0 << 1)
+#endif
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
 #define BLE_SUPP_CMD_LE_SET_SCAN_PARAMS     (1 << 2)
 #define BLE_SUPP_CMD_LE_SET_SCAN_ENABLE     (1 << 3)
+#else
+#define BLE_SUPP_CMD_LE_SET_SCAN_PARAMS     (0 << 2)
+#define BLE_SUPP_CMD_LE_SET_SCAN_ENABLE     (0 << 3)
+#endif
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SUPP_CMD_LE_CREATE_CONN         (1 << 4)
 #define BLE_SUPP_CMD_LE_CREATE_CONN_CANCEL  (1 << 5)
+#else
+#define BLE_SUPP_CMD_LE_CREATE_CONN         (0 << 4)
+#define BLE_SUPP_CMD_LE_CREATE_CONN_CANCEL  (0 << 5)
+
+#endif
 #define BLE_SUPP_CMD_LE_RD_WHITELIST_SIZE   (1 << 6)
 #define BLE_SUPP_CMD_LE_CLR_WHITELIST       (1 << 7)
 
@@ -117,10 +148,19 @@
 /* Octet 27 */
 #define BLE_SUPP_CMD_LE_ADD_DEV_WHITELIST   (1 << 0)
 #define BLE_SUPP_CMD_LE_RMV_DEV_WHITELIST   (1 << 1)
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SUPP_CMD_LE_CONN_UPDATE         (1 << 2)
+#else
+#define BLE_SUPP_CMD_LE_CONN_UPDATE         (0 << 2)
+#endif
 #define BLE_SUPP_CMD_LE_SET_HOST_CHAN_CLASS (1 << 3)
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SUPP_CMD_LE_RD_CHAN_MAP         (1 << 4)
 #define BLE_SUPP_CMD_LE_RD_REM_USED_FEAT    (1 << 5)
+#else
+#define BLE_SUPP_CMD_LE_RD_CHAN_MAP         (0 << 4)
+#define BLE_SUPP_CMD_LE_RD_REM_USED_FEAT    (0 << 5)
+#endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION)
 #define BLE_SUPP_CMD_LE_ENCRYPT             (1 << 6)
 #else
@@ -142,9 +182,18 @@
 
 /* Octet 28 */
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION)
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SUPP_CMD_LE_START_ENCRYPT       (1 << 0)
+#else
+#define BLE_SUPP_CMD_LE_START_ENCRYPT       (0 << 0)
+#endif
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
 #define BLE_SUPP_CMD_LE_LTK_REQ_REPLY       (1 << 1)
 #define BLE_SUPP_CMD_LE_LTK_REQ_NEG_REPLY   (1 << 2)
+#else
+#define BLE_SUPP_CMD_LE_LTK_REQ_REPLY       (0 << 1)
+#define BLE_SUPP_CMD_LE_LTK_REQ_NEG_REPLY   (0 << 2)
+#endif
 #else
 #define BLE_SUPP_CMD_LE_START_ENCRYPT       (0 << 0)
 #define BLE_SUPP_CMD_LE_LTK_REQ_REPLY       (0 << 1)
@@ -175,6 +224,7 @@
 )
 
 /* Octet 33 */
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SUPP_CMD_LE_REM_CONN_PRR        (1 << 4)
 #define BLE_SUPP_CMD_LE_REM_CONN_PRNR       (1 << 5)
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_DATA_LEN_EXT)
@@ -184,6 +234,13 @@
 #define BLE_SUPP_CMD_LE_SET_DATALEN         (0 << 6)
 #define BLE_SUPP_CMD_LE_RD_SUGG_DATALEN     (0 << 7)
 #endif
+#else
+#define BLE_SUPP_CMD_LE_REM_CONN_PRR        (0 << 4)
+#define BLE_SUPP_CMD_LE_REM_CONN_PRNR       (0 << 5)
+#define BLE_SUPP_CMD_LE_SET_DATALEN         (0 << 6)
+#define BLE_SUPP_CMD_LE_RD_SUGG_DATALEN     (0 << 7)
+#endif
+
 
 #define BLE_LL_SUPP_CMD_OCTET_33            \
 (                                           \
@@ -194,8 +251,12 @@
 )
 
 /* Octet 34 */
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_DATA_LEN_EXT)
 #define BLE_SUPP_CMD_LE_WR_SUGG_DATALEN     (1 << 0)
+#else
+#define BLE_SUPP_CMD_LE_WR_SUGG_DATALEN     (0 << 0)
+#endif
 #else
 #define BLE_SUPP_CMD_LE_WR_SUGG_DATALEN     (0 << 0)
 #endif
@@ -239,9 +300,15 @@
 #endif
 #define BLE_SUPP_CMD_LE_RD_MAX_DATALEN      (1 << 3)
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SUPP_CMD_LE_READ_PHY            (1 << 4)
 #define BLE_SUPP_CMD_LE_SET_DEFAULT_PHY     (1 << 5)
 #define BLE_SUPP_CMD_LE_SET_PHY             (1 << 6)
+#else
+#define BLE_SUPP_CMD_LE_READ_PHY            (0 << 4)
+#define BLE_SUPP_CMD_LE_SET_DEFAULT_PHY     (0 << 5)
+#define BLE_SUPP_CMD_LE_SET_PHY             (0 << 6)
+#endif
 #else
 #define BLE_SUPP_CMD_LE_READ_PHY            (0 << 4)
 #define BLE_SUPP_CMD_LE_SET_DEFAULT_PHY     (0 << 5)
@@ -273,7 +340,7 @@
 #define BLE_SUPP_CMD_LE_ENHANCED_TX_TEST    (0 << 0)
 #endif
 
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV) && MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
 #define BLE_SUPP_CMD_LE_SET_ADVS_RAND_ADDR  (1 << 1)
 #define BLE_SUPP_CMD_LE_SET_EXT_ADV_PARAM   (1 << 2)
 #define BLE_SUPP_CMD_LE_SET_EXT_ADV_DATA    (1 << 3)
@@ -304,14 +371,14 @@
 )
 
 /* Octet 37 */
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV) && MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
 #define BLE_SUPP_CMD_LE_REMOVE_ADVS         (1 << 0)
 #define BLE_SUPP_CMD_LE_CLEAR_ADVS          (1 << 1)
 #else
 #define BLE_SUPP_CMD_LE_REMOVE_ADVS         (0 << 0)
 #define BLE_SUPP_CMD_LE_CLEAR_ADVS          (0 << 1)
 #endif
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV) && MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
 #define BLE_SUPP_CMD_LE_SET_PADV_PARAM      (1 << 2)
 #define BLE_SUPP_CMD_LE_SET_PADV_DATA       (1 << 3)
 #define BLE_SUPP_CMD_LE_SET_PADV_ENABLE     (1 << 4)
@@ -321,9 +388,18 @@
 #define BLE_SUPP_CMD_LE_SET_PADV_ENABLE     (0 << 4)
 #endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
 #define BLE_SUPP_CMD_LE_SET_EXT_SCAN_PARAM  (1 << 5)
 #define BLE_SUPP_CMD_LE_SET_EXT_SCAN_ENABLE (1 << 6)
+#else
+#define BLE_SUPP_CMD_LE_SET_EXT_SCAN_PARAM  (0 << 5)
+#define BLE_SUPP_CMD_LE_SET_EXT_SCAN_ENABLE (0 << 6)
+#endif
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 #define BLE_SUPP_CMD_LE_EXT_CREATE_CONN     (1 << 7)
+#else
+#define BLE_SUPP_CMD_LE_EXT_CREATE_CONN     (0 << 7)
+#endif
 #else
 #define BLE_SUPP_CMD_LE_SET_EXT_SCAN_PARAM  (0 << 5)
 #define BLE_SUPP_CMD_LE_SET_EXT_SCAN_ENABLE (0 << 6)
@@ -343,7 +419,7 @@
 )
 
 /* Octet 38 */
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV) && MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
 #define BLE_SUPP_CMD_LE_PADV_CREATE_SYNC    (1 << 0)
 #define BLE_SUPP_CMD_LE_PADV_CREATE_SYNC_C  (1 << 1)
 #define BLE_SUPP_CMD_LE_PADV_TERMINATE_SYNC (1 << 2)
@@ -391,7 +467,8 @@
 )
 
 /* Octet 40 */
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV) && MYNEWT_VAL(BLE_VERSION) >= 51
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV) && MYNEWT_VAL(BLE_VERSION) >= 51 && \
+    MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
 #define BLE_SUPP_CMD_LE_PADV_RECV_ENABLE (1 << 5)
 #else
 #define BLE_SUPP_CMD_LE_PADV_RECV_ENABLE (0 << 5)

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -41,7 +41,7 @@
 
 #include "stats/stats.h"
 
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV) && MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
 
 /* defines number of events that can be lost during sync establishment
  * before failed to be established error is reported

--- a/nimble/controller/src/ble_ll_whitelist.c
+++ b/nimble/controller/src/ble_ll_whitelist.c
@@ -48,8 +48,6 @@ struct ble_ll_whitelist_entry g_ble_ll_whitelist[BLE_LL_WHITELIST_SIZE];
 static int
 ble_ll_whitelist_chg_allowed(void)
 {
-    int rc;
-
     /*
      * This command is not allowed if:
      *  -> advertising uses the whitelist and we are currently advertising.
@@ -57,11 +55,19 @@ ble_ll_whitelist_chg_allowed(void)
      *  -> initiating uses whitelist and a LE create connection command is in
      *     progress
      */
-    rc = 1;
-    if (!ble_ll_adv_can_chg_whitelist() || !ble_ll_scan_can_chg_whitelist()) {
-        rc = 0;
+#if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
+    if (ble_ll_adv_can_chg_whitelist()) {
+        return 1;
     }
-    return rc;
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
+    if (ble_ll_scan_can_chg_whitelist()) {
+        return 1;
+    }
+#endif
+
+    return 0;
 }
 
 /**

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -23,6 +23,30 @@ syscfg.defs:
             this setting shall not be overriden.
         value: 1
 
+    BLE_LL_ROLE_CENTRAL:
+        description: 'Enables controller support for the Central role.'
+        value: MYNEWT_VAL(BLE_ROLE_CENTRAL)
+        restrictions:
+            - 'BLE_LL_ROLE_OBSERVER if 1'
+
+    BLE_LL_ROLE_PERIPHERAL:
+        description: 'Enables controller support for the Peripheral role.'
+        value: MYNEWT_VAL(BLE_ROLE_PERIPHERAL)
+        restrictions:
+            - 'BLE_LL_ROLE_BROADCASTER if 1'
+
+    BLE_LL_ROLE_BROADCASTER:
+        description: 'Enables controller support for the Broadcaster role.'
+        value: MYNEWT_VAL(BLE_ROLE_BROADCASTER)
+        restrictions:
+            - 'BLE_LL_ROLE_OBSERVER if 0'
+
+    BLE_LL_ROLE_OBSERVER:
+        description: 'Enables controller support for the Observer role.'
+        value: MYNEWT_VAL(BLE_ROLE_OBSERVER)
+        restrictions:
+            - 'BLE_LL_ROLE_BROADCASTER if 0'
+
     BLE_HW_WHITELIST_ENABLE:
         description: >
             Used to enable hardware white list
@@ -184,21 +208,21 @@ syscfg.defs:
         description: >
             This option enables/disables encryption support in the controller.
             This option saves both both code and RAM.
-        value: '1'
+        value: 'MYNEWT_VAL_BLE_LL_ROLE_CENTRAL || MYNEWT_VAL_BLE_LL_ROLE_PERIPHERAL'
 
     BLE_LL_CFG_FEAT_CONN_PARAM_REQ:
         description: >
             This option enables/disables the connection parameter request
             procedure.  This is implemented in the controller but is disabled
             by default.
-        value: '1'
+        value: 'MYNEWT_VAL_BLE_LL_ROLE_CENTRAL || MYNEWT_VAL_BLE_LL_ROLE_PERIPHERAL'
 
     BLE_LL_CFG_FEAT_SLAVE_INIT_FEAT_XCHG:
         description: >
             This option allows a slave to initiate the feature exchange
             procedure.  This feature is implemented but currently has no impact
             on code or ram size
-        value: '1'
+        value: 'MYNEWT_VAL_BLE_LL_ROLE_CENTRAL || MYNEWT_VAL_BLE_LL_ROLE_PERIPHERAL'
 
     BLE_LL_CFG_FEAT_LE_PING:
         description: >
@@ -213,7 +237,7 @@ syscfg.defs:
             the controller. If enabled, the controller is allowed to change the
             size of tx/rx pdu's used in a connection. This option has only
             minor impact on code size and non on RAM.
-        value: '1'
+        value: 'MYNEWT_VAL_BLE_LL_ROLE_CENTRAL || MYNEWT_VAL_BLE_LL_ROLE_PERIPHERAL'
 
     BLE_LL_CFG_FEAT_LL_PRIVACY:
         description: >
@@ -248,8 +272,6 @@ syscfg.defs:
             This option is used to enable/disable support for Periodic
             Advertising Feature.
         value: MYNEWT_VAL(BLE_PERIODIC_ADV)
-        restrictions:
-            - 'BLE_LL_CFG_FEAT_LL_EXT_ADV if 1'
 
     BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_CNT:
         description: >
@@ -273,6 +295,8 @@ syscfg.defs:
             limit number of ACL packets sent at once from controller to avoid
             congestion on HCI transport if feature is also supported by host.
         value: 0
+        restrictions:
+            - '(BLE_ROLE_CENTRAL || BLE_ROLE_PERIPHERAL) if 1'
 
     BLE_LL_CFG_FEAT_LL_SCA_UPDATE:
         description: >

--- a/nimble/syscfg.yml
+++ b/nimble/syscfg.yml
@@ -67,6 +67,7 @@ syscfg.defs:
         value: 0
         restrictions:
             - 'BLE_PERIODIC_ADV if 1'
+            - '(BLE_ROLE_CENTRAL || BLE_ROLE_PERIPHERAL) if 1'
 
     BLE_EXT_ADV_MAX_SIZE:
         description: >

--- a/nimble/transport/uart/src/ble_hci_uart.c
+++ b/nimble/transport/uart/src/ble_hci_uart.c
@@ -755,7 +755,9 @@ ble_hci_uart_rx_skip_acl(uint8_t data)
     if (rxd_bytes == ble_hci_uart_state.rx_acl.len) {
 /* XXX: I dont like this but for now this denotes controller only */
 #if MYNEWT_VAL(BLE_CONTROLLER)
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
         ble_ll_data_buffer_overflow();
+#endif
 #endif
         ble_hci_uart_state.rx_type = BLE_HCI_UART_H4_NONE;
     }


### PR DESCRIPTION
This gives some FLASH and RAM savings for applications that use only
subset of GAP roles. LL features are also tuned depending on selected
GAP roles.

Examples of FLASH and RAM usage:
BLE_ROLE_CENTRAL: 1
BLE_ROLE_PERIPHERAL: 1
BLE_ROLE_BROADCASTER: 1
BLE_ROLE_OBSERVER: 1
56122   19661 @apache-mynewt-nimble_nimble_controller.a

BLE_ROLE_CENTRAL: 0
BLE_ROLE_PERIPHERAL: 1
BLE_ROLE_BROADCASTER: 1
BLE_ROLE_OBSERVER: 1
51344   19589 @apache-mynewt-nimble_nimble_controller.a

BLE_ROLE_CENTRAL: 0
BLE_ROLE_PERIPHERAL: 1
BLE_ROLE_BROADCASTER: 1
BLE_ROLE_OBSERVER: 0
35694   15232 @apache-mynewt-nimble_nimble_controller.a

BLE_ROLE_CENTRAL: 1
BLE_ROLE_PERIPHERAL: 0
BLE_ROLE_BROADCASTER: 1
BLE_ROLE_OBSERVER: 1
53338   19593 @apache-mynewt-nimble_nimble_controller.a

BLE_ROLE_CENTRAL: 1
BLE_ROLE_PERIPHERAL: 0
BLE_ROLE_BROADCASTER: 0
BLE_ROLE_OBSERVER: 1
42040   12925 @apache-mynewt-nimble_nimble_controller.a

BLE_ROLE_CENTRAL: 0
BLE_ROLE_PERIPHERAL: 0
BLE_ROLE_BROADCASTER: 1
BLE_ROLE_OBSERVER: 1
34800   12525 @apache-mynewt-nimble_nimble_controller.a

BLE_ROLE_CENTRAL: 0
BLE_ROLE_PERIPHERAL: 0
BLE_ROLE_BROADCASTER: 1
BLE_ROLE_OBSERVER: 0
19126    8168 @apache-mynewt-nimble_nimble_controller.a