### PR TITLE
nimble/include: fixed vendor command description

### DIFF
--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1061,7 +1061,7 @@ struct ble_hci_le_set_host_feat_cp {
     uint8_t val;
 } __attribute__((packed));
 
-/* --- Vendor specific commands (OGF 0x00FF) */
+/* --- Vendor specific commands (OGF 0x003F) */
 #define BLE_HCI_OCF_VS_RD_STATIC_ADDR                 (0x0001)
 struct ble_hci_vs_rd_static_addr_rp {
     uint8_t addr[6];


### PR DESCRIPTION
Proper OGF for vendor specific cmd: 0x3F