### PR TITLE
nimble/usb: Add dependency on tinyusb

### DIFF
--- a/nimble/transport/usb/pkg.yml
+++ b/nimble/transport/usb/pkg.yml
@@ -31,6 +31,7 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/util/mem"
     - nimble
+    - "@tinyusb/tinyusb"
 
 pkg.apis:
     - ble_transport


### PR DESCRIPTION
USB transport requires tinyusb. This will make it easier for people
to use it as otherwise one needs to configure this in target
configuration.