### PR TITLE
host/ble_gattc: Cancel prepered writes if data doesn't match in response

### DIFF
--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -3765,17 +3765,20 @@ ble_gattc_write_long_rx_prep(struct ble_gattc_proc *proc,
                      proc->write_long.length) != 0) {
 
         rc = BLE_HS_EBADDATA;
-        goto err;
-    }
 
-    /* Send follow-up request. */
-    proc->write_long.attr.offset += OS_MBUF_PKTLEN(om);
-    rc = ble_gattc_write_long_resume(proc);
-    if (rc != 0) {
+        /* if data doesn't match up send cancel write */
+        ble_att_clt_tx_exec_write(proc->conn_handle, BLE_ATT_EXEC_WRITE_F_CANCEL);
         goto err;
-    }
+    } else {
+        /* Send follow-up request. */
+        proc->write_long.attr.offset += OS_MBUF_PKTLEN(om);
+        rc = ble_gattc_write_long_resume(proc);
+        if (rc != 0) {
+            goto err;
+        }
 
-    return 0;
+        return 0;
+    }
 
 err:
     /* XXX: Might need to cancel pending writes. */


### PR DESCRIPTION
If data received in ble_gattc_write_long_rx_prep() doesn't match
data sent in prepare write request we need not only return error in
function, but also send ATT_Execute_Write_Response with flag set to
BLE_ATT_EXEC_WRITE_F_CANCEL.

This is affecting GATT/CL/GAW/BI-32-C