### PR TITLE
nimble/hs: Fix startup without central and peripheral supported

### DIFF
--- a/nimble/host/src/ble_hs_startup.c
+++ b/nimble/host/src/ble_hs_startup.c
@@ -86,6 +86,7 @@ ble_hs_startup_le_read_sup_f_tx(void)
     return 0;
 }
 
+#if MYNEWT_VAL(BLE_ROLE_CENTRAL) || MYNEWT_VAL(BLE_ROLE_PERIPHERAL)
 static int
 ble_hs_startup_le_read_buf_sz_tx(uint16_t *out_pktlen, uint8_t *out_max_pkts)
 {
@@ -155,6 +156,7 @@ ble_hs_startup_read_buf_sz(void)
 
     return 0;
 }
+#endif
 
 static int
 ble_hs_startup_read_bd_addr(void)
@@ -343,10 +345,12 @@ ble_hs_startup_go(void)
         return rc;
     }
 
+#if MYNEWT_VAL(BLE_ROLE_CENTRAL) || MYNEWT_VAL(BLE_ROLE_PERIPHERAL)
     rc = ble_hs_startup_read_buf_sz();
     if (rc != 0) {
         return rc;
     }
+#endif
 
     rc = ble_hs_startup_le_read_sup_f_tx();
     if (rc != 0) {


### PR DESCRIPTION
There's no need to read buffers size if both central and peripheral
roles are not supported. Also host will fail to start if controller
does not ale support those roles since HCI command is not supported
in such case.