### PR TITLE
nimble/ll: Fix assert on aux scan

### DIFF
--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -577,6 +577,7 @@ ble_ll_hci_ev_send_ext_adv_report(struct os_mbuf *rxpdu,
         ble_ll_hci_event_send(*hci_ev);
 
         *hci_ev = hci_ev_next;
+        hci_ev_next = NULL;
     } while ((offset < data_len) && *hci_ev);
 
     return truncated ? -1 : 0;


### PR DESCRIPTION
hci_ev_next was never set to NULL so in case last PDU in chain was
fragmented an assert was triggered since on last chunk (i.e. completed)
we expect hci_ev_next to be NULL.