### PR TITLE
nimble/phy/cmac: Fix unexpected match on resolving list

### DIFF
--- a/nimble/drivers/dialog_cmac/src/ble_hw.c
+++ b/nimble/drivers/dialog_cmac/src/ble_hw.c
@@ -306,6 +306,12 @@ ble_hw_resolv_proc_disable(void)
 }
 
 void
+ble_hw_resolv_proc_reset(const uint8_t *addr)
+{
+    g_ble_hw_resolv_proc.f_match = 0;
+}
+
+void
 ble_hw_resolv_proc_start(const uint8_t *addr)
 {
     assert(g_ble_hw_resolv_proc.f_configured);

--- a/nimble/drivers/dialog_cmac/src/ble_hw_priv.h
+++ b/nimble/drivers/dialog_cmac/src/ble_hw_priv.h
@@ -24,6 +24,7 @@
 
 void ble_hw_resolv_proc_enable(void);
 void ble_hw_resolv_proc_disable(void);
+void ble_hw_resolv_proc_reset(void);
 void ble_hw_resolv_proc_start(const uint8_t *addr);
 
 #endif /* _BLE_HW_PRIV_H_ */

--- a/nimble/drivers/dialog_cmac/src/ble_phy.c
+++ b/nimble/drivers/dialog_cmac/src/ble_phy.c
@@ -1347,6 +1347,10 @@ ble_phy_rx_setup_xcvr(void)
 {
     uint8_t rf_chan = g_ble_phy_chan_to_rf[g_ble_phy_data.channel];
 
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
+    ble_hw_resolv_proc_reset();
+#endif
+
     CMAC->CM_EV_SET_REG = CMAC_CM_EV_SET_REG_EV1C_CALLBACK_VALID_SET_Msk;
 
     ble_rf_setup_rx(rf_chan, g_ble_phy_data.phy_mode_rx);


### PR DESCRIPTION
During scan window we restart rx after PDU without reinitializing phy,
this means we do not reenable resolving list. On CMAC this means flags
in resolver are not cleared so once we matched one device, we will
return match for all subsequent devices in that window. So we just need
to clear flag before starting any rx.