### PR TITLE
nimble/transport/cmac: Flush UART on CMAC error

### DIFF
--- a/nimble/transport/dialog_cmac/cmac_driver/include/cmac_driver/cmac_shared.h
+++ b/nimble/transport/dialog_cmac/cmac_driver/include/cmac_driver/cmac_shared.h
@@ -142,6 +142,7 @@ typedef int (cmac_mbox_read_cb)(const void *data, uint16_t len);
 typedef void (cmac_mbox_write_notif_cb)(void);
 void cmac_mbox_set_read_cb(cmac_mbox_read_cb *cb);
 void cmac_mbox_set_write_notif_cb(cmac_mbox_write_notif_cb *cb);
+int cmac_mbox_has_data(void);
 int cmac_mbox_read(void);
 int cmac_mbox_write(const void *data, uint16_t len);
 

--- a/nimble/transport/dialog_cmac/cmac_driver/src/cmac_mbox.c
+++ b/nimble/transport/dialog_cmac/cmac_driver/src/cmac_mbox.c
@@ -47,6 +47,18 @@ cmac_mbox_set_write_notif_cb(cmac_mbox_write_notif_cb *cb)
 }
 
 int
+cmac_mbox_has_data(void)
+{
+#if MYNEWT_VAL(BLE_HOST) || MYNEWT_VAL(BLE_HCI_BRIDGE)
+    volatile struct cmac_mbox *mbox = &g_cmac_shared_data->mbox_c2s;
+#else
+    volatile struct cmac_mbox *mbox = &g_cmac_shared_data.mbox_s2c;
+#endif
+
+    return mbox->rd_off != mbox->wr_off;
+}
+
+int
 cmac_mbox_read(void)
 {
 #if MYNEWT_VAL(BLE_HOST) || MYNEWT_VAL(BLE_HCI_BRIDGE)


### PR DESCRIPTION
When CMAC is used with HCI bridge over UART we should wait for all
data to be flushed from UART before asserting on error, otherwise we
will lose debug events.