### PR TITLE
nimble/ll: New connection strict scheduling

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -230,10 +230,6 @@ struct ble_ll_conn_sm
     uint8_t last_unmapped_chan;
     uint8_t num_used_chans;
 
-#if MYNEWT_VAL(BLE_LL_STRICT_CONN_SCHEDULING)
-    uint8_t period_occ_mask;    /* mask: period 0 = 0x01, period 3 = 0x08 */
-#endif
-
     /* Ack/Flow Control */
     uint8_t tx_seqnum;          /* note: can be 1 bit */
     uint8_t next_exp_seqnum;    /* note: can be 1 bit */

--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -397,6 +397,10 @@ uint8_t ble_ll_conn_calc_dci(struct ble_ll_conn_sm *conn, uint16_t latency);
 void ble_ll_conn_get_anchor(struct ble_ll_conn_sm *connsm, uint16_t conn_event,
                             uint32_t *anchor, uint8_t *anchor_usecs);
 
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+int ble_ll_conn_move_anchor(struct ble_ll_conn_sm *connsm, uint16_t offset);
+#endif
+
 struct ble_ll_scan_addr_data;
 struct ble_ll_scan_pdu_data;
 

--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -351,6 +351,12 @@ struct ble_ll_conn_sm
     uint16_t sync_transfer_skip;
     uint32_t sync_transfer_sync_timeout;
 #endif
+
+#if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
+    uint16_t css_slot_idx;
+    uint16_t css_slot_idx_pending;
+    uint8_t css_period_idx;
+#endif
 };
 
 /* Flags */

--- a/nimble/controller/include/controller/ble_ll_ctrl.h
+++ b/nimble/controller/include/controller/ble_ll_ctrl.h
@@ -292,7 +292,8 @@ struct ble_ll_len_req
 
 /* API */
 struct ble_ll_conn_sm;
-void ble_ll_ctrl_proc_start(struct ble_ll_conn_sm *connsm, int ctrl_proc);
+void ble_ll_ctrl_proc_start(struct ble_ll_conn_sm *connsm, int ctrl_proc,
+                            void *data);
 void ble_ll_ctrl_proc_stop(struct ble_ll_conn_sm *connsm, int ctrl_proc);
 int ble_ll_ctrl_rx_pdu(struct ble_ll_conn_sm *connsm, struct os_mbuf *om);
 void ble_ll_ctrl_chk_proc_start(struct ble_ll_conn_sm *connsm);

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -79,39 +79,6 @@ extern uint8_t g_ble_ll_sched_offset_ticks;
 struct ble_ll_sched_item;
 typedef int (*sched_cb_func)(struct ble_ll_sched_item *sch);
 typedef void (*sched_remove_cb_func)(struct ble_ll_sched_item *sch);
-/*
- * Strict connection scheduling (for the master) is different than how
- * connections are normally scheduled. With strict connection scheduling we
- * introduce the concept of a "period". A period is a collection of slots. Each
- * slot is 1.25 msecs in length. The number of slots in a period is determined
- * by the syscfg value BLE_LL_CONN_INIT_SLOTS. A collection of periods is called
- * an epoch. The length of an epoch is determined by the number of connections
- * (BLE_MAX_CONNECTIONS plus BLE_LL_ADD_STRICT_SCHED_PERIODS). Connections
- * will be scheduled at period boundaries. Any scanning/initiating/advertising
- * will be done in unused periods, if possible.
- */
-#if MYNEWT_VAL(BLE_LL_STRICT_CONN_SCHEDULING)
-#define BLE_LL_SCHED_PERIODS    (MYNEWT_VAL(BLE_MAX_CONNECTIONS) + \
-                                 MYNEWT_VAL(BLE_LL_ADD_STRICT_SCHED_PERIODS))
-
-struct ble_ll_sched_obj
-{
-    uint8_t sch_num_occ_periods;
-    uint32_t sch_occ_period_mask;
-    uint32_t sch_ticks_per_period;
-    uint32_t sch_ticks_per_epoch;
-    uint32_t sch_epoch_start;
-};
-
-extern struct ble_ll_sched_obj g_ble_ll_sched_data;
-
-/*
- * XXX: TODO:
- * -> How do we know epoch start is up to date? Not wrapped?
- * -> for now, only do this with no more than 32 connections.
- * -> Do not let initiating occur if no empty sched slots
- */
-#endif
 
 /*
  * Schedule item

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -176,11 +176,34 @@ int ble_ll_sched_dtm(struct ble_ll_sched_item *sch);
 #endif
 
 #if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
+#if !MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_FIXED)
 void ble_ll_sched_css_set_params(uint32_t slot_us, uint32_t period_slots);
+#endif
 void ble_ll_sched_css_set_conn_anchor(struct ble_ll_conn_sm *connsm);
+#if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_FIXED)
+static inline uint32_t
+ble_ll_sched_css_get_slot_us(void)
+{
+    return MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_SLOT_US);
+}
+
+static inline uint32_t
+ble_ll_sched_css_get_period_slots(void)
+{
+    return MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_PERIOD_SLOTS);
+}
+
+static inline uint32_t
+ble_ll_sched_css_get_conn_interval_us(void)
+{
+    return ble_ll_sched_css_get_period_slots() *
+           ble_ll_sched_css_get_slot_us() / 1250;
+}
+#else
 uint32_t ble_ll_sched_css_get_slot_us(void);
 uint32_t ble_ll_sched_css_get_period_slots(void);
 uint32_t ble_ll_sched_css_get_conn_interval_us(void);
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -175,6 +175,14 @@ void ble_ll_sched_stop(void);
 int ble_ll_sched_dtm(struct ble_ll_sched_item *sch);
 #endif
 
+#if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
+void ble_ll_sched_css_set_params(uint32_t slot_us, uint32_t period_slots);
+void ble_ll_sched_css_set_conn_anchor(struct ble_ll_conn_sm *connsm);
+uint32_t ble_ll_sched_css_get_slot_us(void);
+uint32_t ble_ll_sched_css_get_period_slots(void);
+uint32_t ble_ll_sched_css_get_conn_interval_us(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -860,7 +860,7 @@ ble_ll_conn_hci_read_rem_features(const uint8_t *cmdbuf, uint8_t len)
         }
 #endif
 
-        ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_FEATURE_XCHG);
+        ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_FEATURE_XCHG, NULL);
     }
 
     connsm->csmflags.cfbit.pending_hci_rd_features = 1;
@@ -980,7 +980,7 @@ ble_ll_conn_hci_update(const uint8_t *cmdbuf, uint8_t len)
         hcu->handle = handle;
 
         /* Start the control procedure */
-        ble_ll_ctrl_proc_start(connsm, ctrl_proc);
+        ble_ll_ctrl_proc_start(connsm, ctrl_proc, NULL);
     }
 
     return rc;
@@ -1257,7 +1257,7 @@ ble_ll_conn_hci_rd_rem_ver_cmd(const uint8_t *cmdbuf, uint8_t len)
      * be queued before the command status.
      */
     if (!connsm->csmflags.cfbit.version_ind_sent) {
-        ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_VERSION_XCHG);
+        ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_VERSION_XCHG, NULL);
     } else {
         connsm->pending_ctrl_procs |= (1 << BLE_LL_CTRL_PROC_VERSION_XCHG);
     }
@@ -1483,7 +1483,7 @@ ble_ll_conn_hci_le_start_encrypt(const uint8_t *cmdbuf, uint8_t len)
         connsm->enc_data.host_rand_num = le64toh(cmd->rand);
         connsm->enc_data.enc_div = le16toh(cmd->div);
         swap_buf(connsm->enc_data.enc_block.key, cmd->ltk, 16);
-        ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_ENCRYPT);
+        ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_ENCRYPT, NULL);
         rc = BLE_ERR_SUCCESS;
     }
 
@@ -1633,7 +1633,7 @@ ble_ll_conn_req_peer_sca(const uint8_t *cmdbuf, uint8_t len,
         return BLE_ERR_CTLR_BUSY;
     }
 
-    ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_SCA_UPDATE);
+    ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_SCA_UPDATE, NULL);
 
     return 0;
 }

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -59,6 +59,10 @@ extern "C" {
 #define BLE_LL_CONN_DEF_AUTH_PYLD_TMO       (3000)
 #define BLE_LL_CONN_AUTH_PYLD_OS_TMO(x)     ble_npl_time_ms_to_ticks32((x) * 10)
 
+#if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
+#define BLE_LL_CONN_CSS_NO_SLOT             (UINT16_MAX)
+#endif
+
 /* Global Link Layer connection parameters */
 struct ble_ll_conn_global_params
 {
@@ -127,6 +131,7 @@ struct ble_ll_conn_create_sm {
 };
 
 extern struct ble_ll_conn_create_sm g_ble_ll_conn_create_sm;
+extern struct ble_ll_conn_sm *g_ble_ll_conn_css_ref;
 
 /* Generic interface */
 struct ble_ll_len_req;
@@ -248,6 +253,14 @@ int ble_ll_conn_hci_ext_create(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_set_sync_transfer_params(const uint8_t *cmdbuf, uint8_t len,
                                     uint8_t *rspbuf, uint8_t *rsplen);
 int ble_ll_set_default_sync_transfer_params(const uint8_t *cmdbuf, uint8_t len);
+#endif
+
+#if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
+void ble_ll_conn_css_set_next_slot(uint16_t slot_idx);
+uint16_t ble_ll_conn_css_get_next_slot(void);
+int ble_ll_conn_css_is_slot_busy(uint16_t slot_idx);
+int ble_ll_conn_css_move(struct ble_ll_conn_sm *connsm, uint16_t slot_idx);
+
 #endif
 
 #ifdef __cplusplus

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -1960,7 +1960,7 @@ ble_ll_ctrl_initiate_dle(struct ble_ll_conn_sm *connsm)
         return;
     }
 
-    ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_DATA_LEN_UPD);
+    ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_DATA_LEN_UPD, NULL);
 }
 
 static void
@@ -2284,7 +2284,7 @@ ble_ll_ctrl_rx_chanmap_req(struct ble_ll_conn_sm *connsm, uint8_t *dptr)
  * @param ctrl_proc
  */
 static struct os_mbuf *
-ble_ll_ctrl_proc_init(struct ble_ll_conn_sm *connsm, int ctrl_proc)
+ble_ll_ctrl_proc_init(struct ble_ll_conn_sm *connsm, int ctrl_proc, void *data)
 {
     uint8_t len;
     uint8_t opcode;
@@ -2303,7 +2303,7 @@ ble_ll_ctrl_proc_init(struct ble_ll_conn_sm *connsm, int ctrl_proc)
         switch (ctrl_proc) {
         case BLE_LL_CTRL_PROC_CONN_UPDATE:
             opcode = BLE_LL_CTRL_CONN_UPDATE_IND;
-            ble_ll_ctrl_conn_upd_make(connsm, ctrdata, NULL);
+            ble_ll_ctrl_conn_upd_make(connsm, ctrdata, data);
             break;
         case BLE_LL_CTRL_PROC_CHAN_MAP_UPD:
             opcode = BLE_LL_CTRL_CHANNEL_MAP_REQ;
@@ -2452,7 +2452,7 @@ ble_ll_ctrl_terminate_start(struct ble_ll_conn_sm *connsm)
     BLE_LL_ASSERT(connsm->disconnect_reason != 0);
 
     ctrl_proc = BLE_LL_CTRL_PROC_TERMINATE;
-    om = ble_ll_ctrl_proc_init(connsm, ctrl_proc);
+    om = ble_ll_ctrl_proc_init(connsm, ctrl_proc, NULL);
     if (om) {
         CONN_F_TERMINATE_STARTED(connsm) = 1;
 
@@ -2472,7 +2472,8 @@ ble_ll_ctrl_terminate_start(struct ble_ll_conn_sm *connsm)
  * @param connsm Pointer to connection state machine.
  */
 void
-ble_ll_ctrl_proc_start(struct ble_ll_conn_sm *connsm, int ctrl_proc)
+ble_ll_ctrl_proc_start(struct ble_ll_conn_sm *connsm, int ctrl_proc,
+                       void *data)
 {
     struct os_mbuf *om;
 
@@ -2481,7 +2482,7 @@ ble_ll_ctrl_proc_start(struct ble_ll_conn_sm *connsm, int ctrl_proc)
     om = NULL;
     if (connsm->cur_ctrl_proc == BLE_LL_CTRL_PROC_IDLE) {
         /* Initiate the control procedure. */
-        om = ble_ll_ctrl_proc_init(connsm, ctrl_proc);
+        om = ble_ll_ctrl_proc_init(connsm, ctrl_proc, data);
         if (om) {
             /* Set the current control procedure */
             connsm->cur_ctrl_proc = ctrl_proc;
@@ -2548,7 +2549,7 @@ ble_ll_ctrl_chk_proc_start(struct ble_ll_conn_sm *connsm)
                     ble_ll_hci_ev_rd_rem_ver(connsm, BLE_ERR_SUCCESS);
                     CLR_PENDING_CTRL_PROC(connsm, i);
                 } else {
-                    ble_ll_ctrl_proc_start(connsm, i);
+                    ble_ll_ctrl_proc_start(connsm, i, NULL);
                     break;
                 }
             }
@@ -2863,7 +2864,7 @@ ll_ctrl_send_rsp:
         if (restart_encryption) {
             /* XXX: what happens if this fails? Meaning we cant allocate
                mbuf? */
-            ble_ll_ctrl_proc_init(connsm, BLE_LL_CTRL_PROC_ENCRYPT);
+            ble_ll_ctrl_proc_init(connsm, BLE_LL_CTRL_PROC_ENCRYPT, NULL);
         }
 #endif
     }

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -2106,6 +2106,16 @@ ble_ll_ctrl_rx_conn_param_req(struct ble_ll_conn_sm *connsm, uint8_t *dptr,
         return BLE_ERR_MAX;
     }
 
+#if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
+    /* Reject any attempts to change connection parameters by peripheral */
+    if (connsm->conn_role == BLE_LL_CONN_ROLE_CENTRAL) {
+        rsp_opcode = BLE_LL_CTRL_REJECT_IND_EXT;
+        rspbuf[1] = BLE_LL_CTRL_CONN_PARM_REQ;
+        rspbuf[2] = BLE_ERR_UNSUPPORTED;
+        return rsp_opcode;
+    }
+#endif
+
     /* XXX: remember to deal with this on the central: if the peripheral has
      * initiated a procedure we may have received its connection parameter
      * update request and have signaled the host with an event. If that

--- a/nimble/controller/src/ble_ll_hci_vs.c
+++ b/nimble/controller/src/ble_ll_hci_vs.c
@@ -136,6 +136,7 @@ ble_ll_hci_vs_set_tx_power(uint16_t ocf, const uint8_t *cmdbuf, uint8_t cmdlen,
 
 
 #if MYNEWT_VAL(BLE_LL_HCI_VS_CONN_STRICT_SCHED)
+#if !MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_FIXED)
 static int
 ble_ll_hci_vs_css_configure(const uint8_t *cmdbuf, uint8_t cmdlen,
                             uint8_t *rspbuf, uint8_t *rsplen)
@@ -167,6 +168,7 @@ ble_ll_hci_vs_css_configure(const uint8_t *cmdbuf, uint8_t cmdlen,
 
     return BLE_ERR_SUCCESS;
 }
+#endif
 
 static int
 ble_ll_hci_vs_css_set_next_slot(const uint8_t *cmdbuf, uint8_t cmdlen,
@@ -251,8 +253,10 @@ ble_ll_hci_vs_css(uint16_t ocf, const uint8_t *cmdbuf, uint8_t cmdlen,
     *rsplen = 0;
 
     switch (cmd->opcode) {
+#if !MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_FIXED)
     case BLE_HCI_VS_CSS_OP_CONFIGURE:
         return ble_ll_hci_vs_css_configure(cmdbuf, cmdlen, rspbuf, rsplen);
+#endif
     case BLE_HCI_VS_CSS_OP_SET_NEXT_SLOT:
         return ble_ll_hci_vs_css_set_next_slot(cmdbuf, cmdlen, rspbuf, rsplen);
     case BLE_HCI_VS_CSS_OP_SET_CONN_SLOT:

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -47,8 +47,10 @@ int32_t g_ble_ll_sched_max_early;
 
 #if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
 struct ble_ll_sched_css {
+#if !MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_FIXED)
     uint32_t slot_us;
     uint32_t period_slots;
+#endif
     uint32_t period_anchor_ticks;
     uint8_t period_anchor_rem_us;
     uint8_t period_anchor_idx;
@@ -56,8 +58,10 @@ struct ble_ll_sched_css {
 };
 
 static struct ble_ll_sched_css g_ble_ll_sched_css = {
+#if !MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_FIXED)
     .slot_us = MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_SLOT_US),
     .period_slots = MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_PERIOD_SLOTS),
+#endif
 };
 #endif
 
@@ -1182,12 +1186,14 @@ ble_ll_sched_init(void)
 }
 
 #if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
+#if !MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_FIXED)
 void
 ble_ll_sched_css_set_params(uint32_t slot_us, uint32_t period_slots)
 {
     g_ble_ll_sched_css.slot_us = slot_us;
     g_ble_ll_sched_css.period_slots = period_slots;
 }
+#endif
 
 void
 ble_ll_sched_css_set_conn_anchor(struct ble_ll_conn_sm *connsm)
@@ -1215,6 +1221,7 @@ ble_ll_sched_css_set_conn_anchor(struct ble_ll_conn_sm *connsm)
     }
 }
 
+#if !MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED_FIXED)
 inline uint32_t
 ble_ll_sched_css_get_slot_us(void)
 {
@@ -1234,5 +1241,6 @@ ble_ll_sched_css_get_conn_interval_us(void)
            ble_ll_sched_css_get_slot_us() /
            BLE_LL_CONN_ITVL_USECS;
 }
+#endif
 
 #endif

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -146,6 +146,27 @@ syscfg.defs:
             ensure interoperability with such devices set this value to 2 (or more).
         value: '0'
 
+    BLE_LL_CONN_STRICT_SCHED:
+        description: >
+            Enable connection strict scheduling (css).
+            In css mode, connections in central role are scheduled in fixed time
+            intervals called periods. Each period is divided into an arbitrary
+            number of slots and each connection anchor point is always scheduled
+            at slot boundary. This means (assuming only central connections are
+            active) it's possible to reliably schedule up to number-of-slots
+            connections each at period-duration interval, each connection will
+            be allocated at least one slot in each connection event.
+        value: 0
+    BLE_LL_CONN_STRICT_SCHED_SLOT_US:
+        description: >
+            Slot duration in microseconds. Shall be multiply of 1250us.
+        value: 3750
+    BLE_LL_CONN_STRICT_SCHED_PERIOD_SLOTS:
+        description: >
+            Number of slots per period. Duration of slot determines connection
+            interval used for each connection in central role.
+        value: 8
+
     # The number of random bytes to store
     BLE_LL_RNG_BUFSIZE:
         description: >

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -157,6 +157,12 @@ syscfg.defs:
             connections each at period-duration interval, each connection will
             be allocated at least one slot in each connection event.
         value: 0
+    BLE_LL_CONN_STRICT_SCHED_FIXED:
+        description: >
+            Enable fixed mode for connection strict scheduling, i.e. slot duration
+            and slots per period values are fixed to syscfg values and cannot
+            be changed in runtime. This allows for some compile-time optimizations.
+        value: 0
     BLE_LL_CONN_STRICT_SCHED_SLOT_US:
         description: >
             Slot duration in microseconds. Shall be multiply of 1250us.

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -363,6 +363,9 @@ syscfg.defs:
         description: >
             Enables support for vendor-specific HCI commands.
         value: MYNEWT_VAL(BLE_HCI_VS)
+    BLE_LL_HCI_VS_CONN_STRICT_SCHED:
+        description: xxx
+        value: 0
 
     BLE_LL_HCI_VS_EVENT_ON_ASSERT:
         description: >

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -146,27 +146,6 @@ syscfg.defs:
             ensure interoperability with such devices set this value to 2 (or more).
         value: '0'
 
-    # Strict scheduling
-    BLE_LL_STRICT_CONN_SCHEDULING:
-        description: >
-            Forces the scheduler on a central to schedule connections in fixed
-            time intervals called periods. If set to 0, the scheduler is not forced
-            to do this. If set to 1, the scheduler will only schedule connections at
-            period boundaries. See comments in ble_ll_sched.h for more details.
-        value: '0'
-
-    BLE_LL_ADD_STRICT_SCHED_PERIODS:
-        description: >
-            The number of additional periods that will be allocated for strict
-            scheduling. The total # of periods allocated for strict scheduling
-            will be equal to the number of connections plus this number.
-        value: '0'
-
-    BLE_LL_USECS_PER_PERIOD:
-        description: >
-            The number of usecs per period.
-        value: '3250'
-
     # The number of random bytes to store
     BLE_LL_RNG_BUFSIZE:
         description: >
@@ -505,6 +484,18 @@ syscfg.defs:
         description: Superseded by BLE_LL_CFG_FEAT_PERIPH_INIT_FEAT_XCHG
         value: 0
         defaunt: 1
+    BLE_LL_STRICT_CONN_SCHEDULING:
+        description: Superseded by BLE_LL_CONN_STRICT_SCHED
+        value: 0
+        defunct: 1
+    BLE_LL_ADD_STRICT_SCHED_PERIODS:
+        description: Superseded by BLE_LL_CONN_STRICT_SCHED
+        value: 0
+        defunct: 1
+    BLE_LL_USECS_PER_PERIOD:
+        description: Superseded by BLE_LL_CONN_STRICT_SCHED
+        value: 0
+        defunct: 1
 
 syscfg.vals.BLE_LL_CFG_FEAT_LL_EXT_ADV:
     BLE_LL_CFG_FEAT_LE_CSA2: 1

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1079,6 +1079,28 @@ struct ble_hci_vs_set_tx_pwr_rp {
     int8_t tx_power;
 } __attribute__((packed));
 
+#define BLE_HCI_OCF_VS_CSS                              (0x0003)
+struct ble_hci_vs_css_cp {
+    uint8_t opcode;
+} __attribute__((packed));
+#define BLE_HCI_VS_CSS_OP_CONFIGURE                     0x01
+struct ble_hci_vs_css_configure_cp {
+    uint8_t opcode;
+    uint32_t slot_us;
+    uint32_t period_slots;
+} __attribute__((packed));
+#define BLE_HCI_VS_CSS_OP_SET_NEXT_SLOT                 0x02
+struct ble_hci_vs_css_set_next_slot_cp {
+    uint8_t opcode;
+    uint16_t slot_idx;
+} __attribute__((packed));
+#define BLE_HCI_VS_CSS_OP_SET_CONN_SLOT                 0x03
+struct ble_hci_vs_css_set_conn_slot_cp {
+    uint8_t opcode;
+    uint16_t conn_handle;
+    uint16_t slot_idx;
+} __attribute__((packed));
+
 /* Command Specific Definitions */
 /* --- Set controller to host flow control (OGF 0x03, OCF 0x0031) --- */
 #define BLE_HCI_CTLR_TO_HOST_FC_OFF         (0)


### PR DESCRIPTION
This replaces existing implementation of connection strict scheduling with a new one that allows host to modify scheduling in runtime.

In the simplest case a slot duration and number of slots per period have to be configured. This determines scheduling interval (slot duration) and connection interval for each connection (slot duration * slots per period). Each new central connection will now be scheduled at slot boundary and have the same connection interval, this guaranteed that two connections won't overlap.

By default, for each new connection 1st unused slot is allocated. However, it's possible to allocate specific slot to each connection using hci_vs command in 2 ways:
- set slot for new connection prior to sending connection create command,
- set slot for existing connection at any time, this will move anchor point.