### PR TITLE
apps/blehci: Add full console option

### DIFF
--- a/apps/blehci/pkg.yml
+++ b/apps/blehci/pkg.yml
@@ -23,7 +23,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - "@apache-mynewt-core/sys/console/stub"
+    - "@apache-mynewt-core/sys/console"
     - "@apache-mynewt-core/sys/log/stub"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/kernel/os"

--- a/apps/blehci/syscfg.yml
+++ b/apps/blehci/syscfg.yml
@@ -21,3 +21,5 @@ syscfg.vals:
     OS_MAIN_STACK_SIZE: 64
     # Use UART transport by default
     BLE_HCI_TRANSPORT: uart
+    # Stub console
+    CONSOLE_MODE: stub

--- a/apps/blehcibridge/pkg.yml
+++ b/apps/blehcibridge/pkg.yml
@@ -23,6 +23,7 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
+    - "@apache-mynewt-core/sys/console"
     - "@apache-mynewt-core/sys/log/stub"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/kernel/os"
@@ -31,10 +32,3 @@ pkg.deps:
 
 pkg.req_apis:
     - ble_transport
-
-pkg.deps.'CONSOLE_MODE=="full"':
-    - "@apache-mynewt-core/sys/console/full"
-pkg.deps.'CONSOLE_MODE=="minimal":
-    - "@apache-mynewt-core/sys/console/minimal"
-pkg.deps.'CONSOLE_MODE=="stub":
-    - "@apache-mynewt-core/sys/console/stub"

--- a/apps/blehcibridge/syscfg.yml
+++ b/apps/blehcibridge/syscfg.yml
@@ -16,20 +16,13 @@
 # under the License.
 #
 
-syscfg.defs:
-    CONSOLE_MODE:
-        description: Which console to use
-        value: stub
-        choices:
-            - full
-            - minimal
-            - stub
-
 syscfg.vals:
     # Default task settings
     OS_MAIN_STACK_SIZE: 64
     # Use USB transport by default
     BLE_HCI_TRANSPORT: usb
+    # Stub console
+    CONSOLE_MODE: stub
 
     SHELL_TASK: 1
 


### PR DESCRIPTION
So far blehci always used console/stub.
For debugging purpose it may be useful to enable console without
modifying blehci application pkg.deps.

Default value is still stub.