### PR TITLE
nimble/ll: Fix checking AUX_CONNECT_RSP

### DIFF
--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -1547,7 +1547,7 @@ ble_ll_scan_aux_check_connect_rsp(uint8_t *rxbuf,
     }
 #endif /* BLE_LL_CFG_FEAT_LL_PRIVACY */
 
-    if ((targeta_type != !!(pdu_data->hdr_byte & BLE_ADV_PDU_HDR_RXADD_MASK)) ||
+    if ((targeta_type != !!(pdu_data->hdr_byte & BLE_ADV_PDU_HDR_TXADD_MASK)) ||
         (memcmp(targeta, pdu_data->inita, 6) != 0)) {
         return -1;
     }


### PR DESCRIPTION
We should compare TargetA type in AUX_CONNECT_RSP to TxAdd bit in
AUX_CONNECT_REQ.