### PR TITLE
nimble/ll: Add support for iso broadcasting (BIG)

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -233,6 +233,9 @@ extern STATS_SECT_DECL(ble_ll_stats) ble_ll_stats;
 #if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER) && MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 #define BLE_LL_STATE_SCAN_AUX       (7)
 #endif
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+#define BLE_LL_STATE_BIG            (8)
+#endif
 
 /* LL Features */
 #define BLE_LL_FEAT_LE_ENCRYPTION       (0x0000000001)
@@ -291,6 +294,7 @@ extern STATS_SECT_DECL(ble_ll_stats) ble_ll_stats;
 /* LL timing */
 #define BLE_LL_IFS                  (150)       /* usecs */
 #define BLE_LL_MAFS                 (300)       /* usecs */
+#define BLE_LL_MSS                  (150)       /* usecs */
 
 /*
  * BLE LL device address. Note that element 0 of the array is the LSB and

--- a/nimble/controller/include/controller/ble_ll_adv.h
+++ b/nimble/controller/include/controller/ble_ll_adv.h
@@ -199,6 +199,13 @@ int ble_ll_adv_periodic_enable(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_adv_periodic_set_info_transfer(const uint8_t *cmdbuf, uint8_t len,
                                           uint8_t *rspbuf, uint8_t *rsplen);
 
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+struct ble_ll_iso_big;
+struct ble_ll_adv_sm *ble_ll_adv_sync_get(uint8_t handle);
+int ble_ll_adv_sync_add_big(struct ble_ll_adv_sm *advsm, struct ble_ll_iso_big *big);
+int ble_ll_adv_sync_remove_big(struct ble_ll_adv_sm *advsm, struct ble_ll_iso_big *big);
+#endif /* BLE_LL_ISO_BROADCASTER */
+
 /* Called to notify adv code about RPA rotation */
 void ble_ll_adv_rpa_timeout(void);
 

--- a/nimble/controller/include/controller/ble_ll_iso_big.h
+++ b/nimble/controller/include/controller/ble_ll_iso_big.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BLE_LL_ISO_BIG_
+#define H_BLE_LL_ISO_BIG_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+
+struct ble_ll_iso_big;
+
+int ble_ll_iso_big_biginfo_copy(struct ble_ll_iso_big *big, uint8_t *dptr,
+                                uint32_t base_ticks, uint8_t base_rem_us);
+int ble_ll_iso_big_biginfo_len(struct ble_ll_iso_big *big);
+
+/* HCI command handlers */
+int ble_ll_iso_big_hci_create(const uint8_t *cmdbuf, uint8_t len);
+int ble_ll_iso_big_hci_create_test(const uint8_t *cmdbuf, uint8_t len);
+int ble_ll_iso_big_hci_terminate(const uint8_t *cmdbuf, uint8_t len);
+void ble_ll_iso_big_hci_evt_complete(void);
+
+void ble_ll_iso_big_init(void);
+
+#endif /* BLE_LL_ISO_BROADCASTER */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_BLE_LL_ISO_BIG_ */

--- a/nimble/controller/include/controller/ble_ll_isoal.h
+++ b/nimble/controller/include/controller/ble_ll_isoal.h
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BLE_LL_ISOAL_
+#define H_BLE_LL_ISOAL_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ISO)
+
+/* HCI command handlers */
+int ble_ll_isoal_hci_setup_data_path(const uint8_t *cmdbuf, uint8_t cmdlen,
+                                     uint8_t *rspbuf, uint8_t *rsplen);
+int ble_ll_isoal_hci_remove_data_path(const uint8_t *cmdbuf, uint8_t cmdlen,
+                                      uint8_t *rspbuf, uint8_t *rsplen);
+
+void ble_ll_isoal_init(void);
+
+#endif /* BLE_LL_ISO */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_BLE_LL_ISOAL_ */

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -70,6 +70,7 @@ extern uint8_t g_ble_ll_sched_offset_ticks;
 #define BLE_LL_SCHED_TYPE_PERIODIC  (6)
 #define BLE_LL_SCHED_TYPE_SYNC      (7)
 #define BLE_LL_SCHED_TYPE_SCAN_AUX  (8)
+#define BLE_LL_SCHED_TYPE_BIG       (9)
 
 /* Return values for schedule callback. */
 #define BLE_LL_SCHED_STATE_RUNNING  (0)
@@ -205,6 +206,10 @@ uint32_t ble_ll_sched_css_get_period_slots(void);
 uint32_t ble_ll_sched_css_get_conn_interval_us(void);
 #endif
 #endif
+
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+int ble_ll_sched_iso_big(struct ble_ll_sched_item *sch, int first);
+#endif /* BLE_LL_ISO_BROADCASTER */
 
 #ifdef __cplusplus
 }

--- a/nimble/controller/include/controller/ble_ll_utils.h
+++ b/nimble/controller/include/controller/ble_ll_utils.h
@@ -21,8 +21,8 @@
 
 uint32_t ble_ll_utils_calc_access_addr(void);
 uint8_t ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap);
-uint8_t ble_ll_utils_calc_dci_csa2(uint16_t event_cntr, uint16_t channel_id,
-                                   uint8_t num_used_chans, const uint8_t *chanmap);
+uint8_t ble_ll_utils_dci_csa2(uint16_t counter, uint16_t chan_id,
+                              uint8_t num_used_chans, const uint8_t *chan_map);
 uint16_t ble_ll_utils_dci_iso_event(uint16_t counter, uint16_t chan_id,
                                     uint16_t *prn_sub_lu, uint8_t num_used_chans,
                                     const uint8_t *chan_map, uint16_t *remap_idx);

--- a/nimble/controller/include/controller/ble_ll_utils.h
+++ b/nimble/controller/include/controller/ble_ll_utils.h
@@ -23,6 +23,12 @@ uint32_t ble_ll_utils_calc_access_addr(void);
 uint8_t ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap);
 uint8_t ble_ll_utils_calc_dci_csa2(uint16_t event_cntr, uint16_t channel_id,
                                    uint8_t num_used_chans, const uint8_t *chanmap);
+uint16_t ble_ll_utils_dci_iso_event(uint16_t counter, uint16_t chan_id,
+                                    uint16_t *prn_sub_lu, uint8_t num_used_chans,
+                                    const uint8_t *chan_map, uint16_t *remap_idx);
+uint16_t ble_ll_utils_dci_iso_subevent(uint16_t chan_id, uint16_t *prn_sub_lu,
+                                       uint8_t num_used_chans, const uint8_t *chan_map,
+                                       uint16_t *remap_idx);
 uint8_t ble_ll_utils_calc_num_used_chans(const uint8_t *chan_map);
 uint32_t ble_ll_utils_calc_window_widening(uint32_t anchor_point,
                                            uint32_t last_anchor_point,

--- a/nimble/controller/include/controller/ble_ll_utils.h
+++ b/nimble/controller/include/controller/ble_ll_utils.h
@@ -19,6 +19,11 @@
 
 #include <stdint.h>
 
+#define MIN(_a, _b) ((_a) < (_b) ? (_a) : (_b))
+#define MAX(_a, _b) ((_a) < (_b) ? (_a) : (_b))
+#define CLAMP(_n, _min, _max) (MAX(_min, MIN(_n, _max)))
+#define IN_RANGE(_n, _min, _max) (((_n) >= (_min)) && ((_n) <= (_max)))
+
 uint32_t ble_ll_utils_calc_access_addr(void);
 uint8_t ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap);
 uint8_t ble_ll_utils_dci_csa2(uint16_t counter, uint16_t chan_id,

--- a/nimble/controller/include/controller/ble_ll_utils.h
+++ b/nimble/controller/include/controller/ble_ll_utils.h
@@ -25,6 +25,7 @@
 #define IN_RANGE(_n, _min, _max) (((_n) >= (_min)) && ((_n) <= (_max)))
 
 uint32_t ble_ll_utils_calc_access_addr(void);
+uint32_t ble_ll_utils_calc_seed_aa(void);
 uint8_t ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap);
 uint8_t ble_ll_utils_dci_csa2(uint16_t counter, uint16_t chan_id,
                               uint8_t num_used_chans, const uint8_t *chan_map);

--- a/nimble/controller/include/controller/ble_ll_utils.h
+++ b/nimble/controller/include/controller/ble_ll_utils.h
@@ -23,7 +23,7 @@ uint32_t ble_ll_utils_calc_access_addr(void);
 uint8_t ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap);
 uint8_t ble_ll_utils_calc_dci_csa2(uint16_t event_cntr, uint16_t channel_id,
                                    uint8_t num_used_chans, const uint8_t *chanmap);
-uint8_t ble_ll_utils_calc_num_used_chans(const uint8_t *chanmap);
+uint8_t ble_ll_utils_calc_num_used_chans(const uint8_t *chan_map);
 uint32_t ble_ll_utils_calc_window_widening(uint32_t anchor_point,
                                            uint32_t last_anchor_point,
                                            uint8_t central_sca);

--- a/nimble/controller/include/controller/ble_ll_utils.h
+++ b/nimble/controller/include/controller/ble_ll_utils.h
@@ -26,6 +26,7 @@
 
 uint32_t ble_ll_utils_calc_access_addr(void);
 uint32_t ble_ll_utils_calc_seed_aa(void);
+uint32_t ble_ll_utils_calc_big_aa(uint32_t seed_aa, uint32_t n);
 uint8_t ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap);
 uint8_t ble_ll_utils_dci_csa2(uint16_t counter, uint16_t chan_id,
                               uint8_t num_used_chans, const uint8_t *chan_map);

--- a/nimble/controller/include/controller/ble_phy.h
+++ b/nimble/controller/include/controller/ble_phy.h
@@ -65,6 +65,7 @@ struct os_mbuf;
 #define BLE_PHY_TRANSITION_NONE     (0)
 #define BLE_PHY_TRANSITION_RX_TX    (1)
 #define BLE_PHY_TRANSITION_TX_RX    (2)
+#define BLE_PHY_TRANSITION_TX_TX    (3)
 
 /* PHY error codes */
 #define BLE_PHY_ERR_RADIO_STATE     (1)

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -45,6 +45,7 @@
 #include "controller/ble_ll_sync.h"
 #include "controller/ble_ll_plna.h"
 #include "controller/ble_ll_isoal.h"
+#include "controller/ble_ll_iso_big.h"
 #include "ble_ll_conn_priv.h"
 #include "ble_ll_hci_priv.h"
 #include "ble_ll_priv.h"
@@ -1677,6 +1678,13 @@ ble_ll_reset(void)
     ble_ll_plna_lna_init();
 #endif
 
+#if MYNEWT_VAL(BLE_LL_ISO)
+    ble_ll_isoal_init();
+#endif
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+    ble_ll_iso_big_init();
+#endif
+
     /* Re-initialize the PHY */
     rc = ble_phy_init();
 
@@ -1929,8 +1937,11 @@ ble_ll_init(void)
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_ISO)
     features |= BLE_LL_FEAT_CIS_CENTRAL;
     features |= BLE_LL_FEAT_CIS_PERIPH;
+    features |= BLE_LL_FEAT_CIS_HOST;
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
     features |= BLE_LL_FEAT_ISO_BROADCASTER;
-    features |= BLE_LL_FEAT_ISO_HOST_SUPPORT;
 #endif
 
     lldata->ll_supp_features = features;
@@ -1956,6 +1967,9 @@ ble_ll_init(void)
 
 #if MYNEWT_VAL(BLE_LL_ISO)
     ble_ll_isoal_init();
+#endif
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+    ble_ll_iso_big_init();
 #endif
 
 #if MYNEWT

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -44,6 +44,7 @@
 #include "controller/ble_ll_trace.h"
 #include "controller/ble_ll_sync.h"
 #include "controller/ble_ll_plna.h"
+#include "controller/ble_ll_isoal.h"
 #include "ble_ll_conn_priv.h"
 #include "ble_ll_hci_priv.h"
 #include "ble_ll_priv.h"
@@ -1951,6 +1952,10 @@ ble_ll_init(void)
 
 #if MYNEWT_VAL(BLE_LL_HCI_VS)
     ble_ll_hci_vs_init();
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ISO)
+    ble_ll_isoal_init();
 #endif
 
 #if MYNEWT

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -1371,10 +1371,10 @@ ble_ll_adv_aux_calculate(struct ble_ll_adv_sm *advsm,
     aux->ext_hdr = 0;
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CSA2)
-    aux->chan = ble_ll_utils_calc_dci_csa2(advsm->event_cntr++,
-                                           advsm->channel_id,
-                                           g_ble_ll_conn_params.num_used_chans,
-                                           g_ble_ll_conn_params.central_chan_map);
+    aux->chan = ble_ll_utils_dci_csa2(advsm->event_cntr++,
+                                      advsm->channel_id,
+                                      g_ble_ll_conn_params.num_used_chans,
+                                      g_ble_ll_conn_params.central_chan_map);
 #else
     aux->chan = ble_ll_utils_remapped_channel(ble_ll_rand() % BLE_PHY_NUM_DATA_CHANS,
                                               g_ble_ll_conn_params.central_chan_map);
@@ -2316,10 +2316,10 @@ ble_ll_adv_periodic_schedule_first(struct ble_ll_adv_sm *advsm,
      * Preincrement event counter as we later send this in PDU so make sure
      * same values are used
      */
-    chan = ble_ll_utils_calc_dci_csa2(++advsm->periodic_event_cntr,
-                                      advsm->periodic_channel_id,
-                                      advsm->periodic_num_used_chans,
-                                      advsm->periodic_chanmap);
+    chan = ble_ll_utils_dci_csa2(++advsm->periodic_event_cntr,
+                                 advsm->periodic_channel_id,
+                                 advsm->periodic_num_used_chans,
+                                 advsm->periodic_chanmap);
 
     ble_ll_adv_sync_calculate(advsm, sync, 0, chan);
 
@@ -2405,10 +2405,10 @@ ble_ll_adv_periodic_schedule_next(struct ble_ll_adv_sm *advsm)
     BLE_LL_ASSERT(rem_sync_data_len > 0);
 
     /* we use separate counter for chaining */
-    chan = ble_ll_utils_calc_dci_csa2(advsm->periodic_chain_event_cntr++,
-                                      advsm->periodic_channel_id,
-                                      advsm->periodic_num_used_chans,
-                                      advsm->periodic_chanmap);
+    chan = ble_ll_utils_dci_csa2(advsm->periodic_chain_event_cntr++,
+                                 advsm->periodic_channel_id,
+                                 advsm->periodic_num_used_chans,
+                                 advsm->periodic_chanmap);
 
     ble_ll_adv_sync_calculate(advsm, sync_next, next_sync_data_offset, chan);
     max_usecs = ble_ll_pdu_tx_time_get(sync_next->payload_len, advsm->sec_phy);

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -746,8 +746,8 @@ ble_ll_conn_calc_dci(struct ble_ll_conn_sm *conn, uint16_t latency)
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CSA2)
     if (CONN_F_CSA2_SUPP(conn)) {
-        return ble_ll_utils_calc_dci_csa2(conn->event_cntr, conn->channel_id,
-                                          conn->num_used_chans, conn->chanmap);
+        return ble_ll_utils_dci_csa2(conn->event_cntr, conn->channel_id,
+                                     conn->num_used_chans, conn->chanmap);
     }
 #endif
 

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -35,6 +35,7 @@
 #include "controller/ble_ll_sync.h"
 #include "controller/ble_ll_isoal.h"
 #include "controller/ble_ll_iso.h"
+#include "controller/ble_ll_iso_big.h"
 #include "ble_ll_priv.h"
 #include "ble_ll_conn_priv.h"
 #include "ble_ll_hci_priv.h"
@@ -655,6 +656,10 @@ ble_ll_hci_le_cmd_send_cmd_status(uint16_t ocf)
     case BLE_HCI_OCF_LE_GEN_DHKEY:
     case BLE_HCI_OCF_LE_SET_PHY:
     case BLE_HCI_OCF_LE_PERIODIC_ADV_CREATE_SYNC:
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+    case BLE_HCI_OCF_LE_CREATE_BIG:
+    case BLE_HCI_OCF_LE_CREATE_BIG_TEST:
+#endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_SCA_UPDATE)
     case BLE_HCI_OCF_LE_REQ_PEER_SCA:
 #endif
@@ -1223,6 +1228,19 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
         rc = ble_ll_set_default_sync_transfer_params(cmdbuf, len);
         break;
 #endif
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+    case BLE_HCI_OCF_LE_CREATE_BIG:
+        *cb = ble_ll_iso_big_hci_evt_complete;
+        rc = ble_ll_iso_big_hci_create(cmdbuf, len);
+        break;
+    case BLE_HCI_OCF_LE_CREATE_BIG_TEST:
+        *cb = ble_ll_iso_big_hci_evt_complete;
+        rc = ble_ll_iso_big_hci_create_test(cmdbuf, len);
+        break;
+    case BLE_HCI_OCF_LE_TERMINATE_BIG:
+        rc = ble_ll_iso_big_hci_terminate(cmdbuf, len);
+        break;
+#endif /* BLE_LL_ISO_BROADCASTER */
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_ISO)
     case BLE_HCI_OCF_LE_READ_ISO_TX_SYNC:
         rc = ble_ll_iso_read_tx_sync(cmdbuf, len);
@@ -1241,12 +1259,6 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
         break;
     case BLE_HCI_OCF_LE_REJECT_CIS_REQ:
         rc = ble_ll_iso_reject_cis_req(cmdbuf, len);
-        break;
-    case BLE_HCI_OCF_LE_CREATE_BIG:
-        rc = ble_ll_iso_create_big(cmdbuf, len);
-        break;
-    case BLE_HCI_OCF_LE_TERMINATE_BIG:
-        rc = ble_ll_iso_terminate_big(cmdbuf, len);
         break;
     case BLE_HCI_OCF_LE_BIG_CREATE_SYNC:
         rc = ble_ll_iso_big_create_sync(cmdbuf, len);

--- a/nimble/controller/src/ble_ll_iso_big.c
+++ b/nimble/controller/src/ble_ll_iso_big.c
@@ -83,6 +83,8 @@ struct big_params {
 };
 
 struct ble_ll_iso_big {
+    struct ble_ll_adv_sm *advsm;
+
     uint8_t handle;
     uint8_t num_bis;
     uint16_t iso_interval;
@@ -454,6 +456,7 @@ ble_ll_iso_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 {
     struct ble_ll_iso_big *big = NULL;
     struct ble_ll_iso_bis *bis;
+    struct ble_ll_adv_sm *advsm;
     uint32_t seed_aa;
     uint8_t idx;
     int rc;
@@ -474,8 +477,16 @@ ble_ll_iso_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
 
     BLE_LL_ASSERT(big);
 
-    /* TODO find valid advertising instance */
+    advsm = ble_ll_adv_sync_get(adv_handle);
+    if (!advsm) {
+        return -ENOENT;
+    }
 
+    if (ble_ll_adv_sync_add_big(advsm, big) < 0) {
+        return -ENOENT;
+    }
+
+    big->advsm = advsm;
     big->handle = big_handle;
 
     seed_aa = ble_ll_utils_calc_seed_aa();

--- a/nimble/controller/src/ble_ll_iso_big.c
+++ b/nimble/controller/src/ble_ll_iso_big.c
@@ -1,0 +1,756 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <syscfg/syscfg.h>
+#include <nimble/ble.h>
+#include <nimble/ble_hci_trans.h>
+#include <nimble/hci_common.h>
+#include <controller/ble_ll.h>
+#include <controller/ble_ll_adv.h>
+#include <controller/ble_ll_hci.h>
+#include <controller/ble_ll_iso_big.h>
+#include <controller/ble_ll_sched.h>
+#include <controller/ble_ll_tmr.h>
+#include <controller/ble_ll_utils.h>
+#include <controller/ble_ll_whitelist.h>
+
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+
+/* XXX make those configurable */
+#define BIG_POOL_SIZE           (10)
+#define BIS_POOL_SIZE           (20)
+
+#define BIG_HANDLE_INVALID      (0xff)
+
+struct ble_ll_iso_big;
+
+struct ble_ll_iso_bis {
+    struct ble_ll_iso_big *big;
+    uint8_t num;
+    uint16_t handle;
+    uint64_t payload_cntr;
+
+    uint32_t aa;
+    uint32_t crc_init;
+    uint16_t chan_id;
+
+    struct {
+        uint16_t prn_sub_lu;
+        uint16_t remap_idx;
+
+        uint8_t subevent_num;
+        uint8_t n;
+        uint8_t g;
+    } tx;
+
+
+    STAILQ_ENTRY(ble_ll_iso_bis) bis_q_next;
+};
+
+STAILQ_HEAD(ble_ll_iso_bis_q, ble_ll_iso_bis);
+
+struct big_params {
+    uint8_t bn; /* 1-7, mandatory 1 */
+    uint8_t pto; /* 0-15, mandatory 0 */
+    uint8_t irc; /* 1-15  */
+    uint8_t nse; /* 1-31 */
+    uint32_t sdu_interval;
+    uint16_t iso_interval;
+    uint16_t max_transport_latency;
+    uint16_t max_sdu;
+    uint8_t max_pdu;
+    uint8_t interleaved : 1;
+    uint8_t framed : 1;
+    uint8_t encrypted : 1;
+};
+
+struct ble_ll_iso_big {
+    uint8_t handle;
+    uint8_t num_bis;
+    uint16_t iso_interval;
+    uint16_t bis_spacing;
+    uint16_t sub_interval;
+    uint8_t max_pdu;
+    uint16_t max_sdu;
+    uint16_t mpt;
+    uint8_t bn; /* 1-7, mandatory 1 */
+    uint8_t pto; /* 0-15, mandatory 0 */
+    uint8_t irc; /* 1-15  */
+    uint8_t nse; /* 1-31 */
+    uint8_t interleaved : 1;
+    uint8_t framed : 1;
+    uint8_t encrypted : 1;
+    uint8_t gc;
+
+    uint32_t sdu_interval;
+
+    uint32_t ctrl_aa;
+    uint16_t crc_init;
+    uint8_t chan_map[5];
+    uint8_t chan_map_used;
+
+    uint8_t biginfo[33];
+
+    uint64_t big_counter;
+    uint32_t bis_counter;
+
+    uint32_t sync_delay;
+    uint32_t event_start;
+    uint8_t event_start_us;
+    struct ble_ll_sched_item sch;
+    struct ble_npl_event event_done;
+
+    struct {
+        uint16_t subevents_rem;
+        uint8_t xxx;
+        struct ble_ll_iso_bis *bis;
+    } tx;
+
+    struct ble_ll_iso_bis_q bis_q;
+};
+
+static struct ble_ll_iso_big big_pool[BIG_POOL_SIZE];
+static struct ble_ll_iso_bis bis_pool[BIS_POOL_SIZE];
+static uint8_t big_pool_free = BIG_POOL_SIZE;
+static uint8_t bis_pool_free = BIS_POOL_SIZE;
+
+static struct ble_ll_iso_big *big_pending;
+static struct ble_ll_iso_big *big_active;
+
+static void
+ble_ll_iso_big_biginfo_calc(struct ble_ll_iso_big *big, uint32_t seed_aa)
+{
+    uint8_t *buf;
+
+    buf = big->biginfo;
+
+    /* big_offset, big_offset_units, iso_interval, num_bis */
+    put_le32(buf, (big->num_bis << 27) | (big->iso_interval << 15));
+    buf += 4;
+
+    /* nse, bn */
+    *(uint8_t *)buf = (big->bn << 5) | (big->nse);
+    buf += 1;
+
+    /* sub_interval, pto */
+    put_le24(buf,(big->pto << 20) | (big->sub_interval));
+    buf += 3;
+
+    /* bis_spacing, irc */
+    put_le24(buf, (big->irc << 20) | (big->bis_spacing));
+    buf += 3;
+
+    /* max_pdu, rfu */
+    put_le16(buf, big->max_pdu);
+    buf += 2;
+
+    /* seed_access_address */
+    put_le32(buf, seed_aa);
+    buf += 4;
+
+    /* sdu_interval, max_sdu */
+    put_le32(buf, (big->max_sdu << 20) | (big->sdu_interval));
+    buf += 4;
+
+    /* base_crc_init */
+    put_le16(buf, big->crc_init);
+    buf += 2;
+
+    /* chm, phy */
+    memcpy(buf, big->chan_map, 5);
+    buf += 5;
+
+    /* bis_payload_cnt, framing */
+    memset(buf, 0x00, 5);
+}
+
+int
+ble_ll_iso_big_biginfo_copy(struct ble_ll_iso_big *big, uint8_t *dptr,
+                            uint32_t base_ticks, uint8_t base_rem_us)
+{
+    uint64_t counter;
+    uint32_t offset_us;
+    uint32_t offset;
+    uint32_t d_ticks;
+    uint8_t d_rem_us;
+
+    counter = big->big_counter * big->bn;
+
+    d_ticks = big->event_start - base_ticks;
+    d_rem_us = big->event_start_us;
+    ble_ll_tmr_sub(&d_ticks, &d_rem_us, base_rem_us);
+
+    offset_us = ble_ll_tmr_t2u(d_ticks) + d_rem_us;
+    if (offset_us <= 600) {
+        counter++;
+        offset_us += big->iso_interval * 1250;
+    }
+    if (offset_us >= 491460) {
+        offset = 0x4000 | (offset_us / 300);
+    } else {
+        offset = offset_us / 30;
+    }
+
+    *dptr++ = 1 + (big->encrypted ? 57 : 33);
+    *dptr++ = 0x2c;
+
+    memcpy(dptr, big->biginfo, 33);
+    put_le32(dptr, get_le32(dptr) | (offset & 0x7fff));
+    dptr += 28;
+
+    *dptr++ = counter & 0xff;
+    *dptr++ = (counter >> 8) & 0xff;
+    *dptr++ = (counter >> 16) & 0xff;
+    *dptr++ = (counter >> 24) & 0xff;
+    *dptr++ = (counter >> 32) & 0xff;
+
+    if (big->encrypted) {
+        dptr += 8;
+        dptr += 16;
+    }
+
+    return 0;
+}
+
+int
+ble_ll_iso_big_biginfo_len(struct ble_ll_iso_big *big)
+{
+    return 2 + (big->encrypted ? 57 : 33);
+}
+
+static void
+ble_ll_iso_big_update_event_start(struct ble_ll_iso_big *big)
+{
+    os_sr_t sr;
+
+    OS_ENTER_CRITICAL(sr);
+    big->event_start = big->sch.start_time + g_ble_ll_sched_offset_ticks;
+    big->event_start_us = big->sch.remainder;
+    OS_EXIT_CRITICAL(sr);
+}
+
+static void
+ble_ll_iso_big_event_done(struct ble_ll_iso_big *big)
+{
+    int rc;
+
+    big->sch.start_time = big->event_start;
+    big->sch.remainder = big->event_start_us;
+
+    do {
+        big->big_counter++;
+        big->bis_counter += big->bn;
+
+        /* XXX precalculate some data here? */
+
+        ble_ll_tmr_add(&big->sch.start_time, &big->sch.remainder,
+                       big->iso_interval * 1250);
+        big->sch.end_time = big->sch.start_time +
+                            ble_ll_tmr_u2t_up(big->sync_delay) + 1;
+        big->sch.start_time -= g_ble_ll_sched_offset_ticks;
+
+        rc = ble_ll_sched_iso_big(&big->sch, 0);
+    } while (rc < 0);
+
+    ble_ll_iso_big_update_event_start(big);
+}
+
+static void
+ble_ll_iso_big_event_done_ev(struct ble_npl_event *ev)
+{
+    struct ble_ll_iso_big *big;
+
+    big = ble_npl_event_get_arg(ev);
+
+    ble_ll_iso_big_event_done(big);
+}
+
+static void
+ble_ll_iso_big_event_done_to_ll(struct ble_ll_iso_big *big)
+{
+    big_active = NULL;
+    ble_ll_state_set(BLE_LL_STATE_STANDBY);
+    ble_npl_eventq_put(&g_ble_ll_data.ll_evq, &big->event_done);
+}
+
+static uint8_t
+ble_ll_iso_big_subevent_pdu_cb(uint8_t *dptr, void *arg, uint8_t *hdr_byte)
+{
+    struct ble_ll_iso_big *big;
+    struct ble_ll_iso_bis *bis;
+    uint32_t counter_tx;
+
+    big = arg;
+    bis = big->tx.bis;
+
+    /* Core 5.3, Vol 6, Part B, 4.4.6.6 */
+    if (bis->tx.g < big->irc) {
+        counter_tx = big->bis_counter + bis->tx.n;
+    } else {
+        counter_tx = big->bis_counter + big->pto * (bis->tx.g - big->irc + 1);
+    }
+
+    *hdr_byte = 0x00;
+
+    /* XXX dummy data for testing */
+    memset(dptr, bis->num | (bis->num << 4), big->max_pdu);
+    dptr[0] = bis->tx.g;
+    dptr[1] = bis->tx.n;
+    put_be32(dptr + 2, counter_tx);
+    dptr[6] = 0xff;
+
+    return big->max_pdu;
+}
+
+static int
+ble_ll_iso_big_subevent_tx(struct ble_ll_iso_big *big)
+{
+    struct ble_ll_iso_bis *bis;
+    uint16_t chan_idx;
+    int rc;
+
+    bis = big->tx.bis;
+
+    if (bis->tx.subevent_num == 1) {
+        chan_idx = ble_ll_utils_dci_iso_event(big->big_counter, bis->chan_id,
+                                              &bis->tx.prn_sub_lu,
+                                              big->chan_map_used,
+                                              big->chan_map,
+                                              &bis->tx.remap_idx);
+    } else {
+        chan_idx = ble_ll_utils_dci_iso_subevent(bis->chan_id,
+                                                 &bis->tx.prn_sub_lu,
+                                                 big->chan_map_used,
+                                                 big->chan_map,
+                                                 &bis->tx.remap_idx);
+    }
+
+    ble_phy_setchan(chan_idx, bis->aa, bis->crc_init);
+
+    rc = ble_phy_tx(ble_ll_iso_big_subevent_pdu_cb, big,
+                    big->tx.subevents_rem > 1 ? BLE_PHY_TRANSITION_TX_TX
+                                              : BLE_PHY_TRANSITION_NONE);
+    return rc;
+}
+
+static void
+ble_ll_iso_big_subevent_txend_cb(void *arg)
+{
+    struct ble_ll_iso_big *big;
+    struct ble_ll_iso_bis *bis;
+    int rc;
+
+    big = arg;
+    bis = big->tx.bis;
+
+    bis->tx.n++;
+    if (bis->tx.n == big->bn) {
+        bis->tx.n = 0;
+        bis->tx.g++;
+    }
+
+    /* Switch to next BIS if interleaved or all subevents for current BIS were
+     * transmitted.
+     */
+    if (big->interleaved || (bis->tx.subevent_num == big->nse)) {
+        bis = STAILQ_NEXT(bis, bis_q_next);
+        if (!bis) {
+            bis = STAILQ_FIRST(&big->bis_q);
+        }
+        big->tx.bis = bis;
+    }
+
+    bis->tx.subevent_num++;
+
+    big->tx.subevents_rem--;
+
+    if (big->tx.subevents_rem > 0) {
+        rc = ble_ll_iso_big_subevent_tx(big);
+        if (rc) {
+            ble_phy_disable();
+            ble_ll_iso_big_event_done_to_ll(big);
+        }
+        return;
+    }
+
+    ble_ll_iso_big_event_done_to_ll(big);
+}
+
+static int
+ble_ll_iso_big_event_sched_cb(struct ble_ll_sched_item *sch)
+{
+    struct ble_ll_iso_big *big;
+    struct ble_ll_iso_bis *bis;
+    int rc;
+
+    big = sch->cb_arg;
+
+    ble_ll_state_set(BLE_LL_STATE_BIG);
+    big_active = big;
+
+    ble_ll_whitelist_disable();
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
+    ble_phy_resolv_list_disable();
+#endif
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_ENCRYPTION)
+    /* TODO add encryption support */
+    ble_phy_encrypt_disable();
+#endif
+#if (BLE_LL_BT5_PHY_SUPPORTED == 1)
+    /* TODO add support for more phys */
+    ble_phy_mode_set(BLE_PHY_MODE_1M, BLE_PHY_MODE_1M);
+#endif
+
+    /* XXX calculate this in advance at the end of previous event? */
+    big->tx.subevents_rem = big->num_bis * big->nse;
+    big->tx.bis = STAILQ_FIRST(&big->bis_q);
+    STAILQ_FOREACH(bis, &big->bis_q, bis_q_next) {
+        bis->tx.subevent_num = 1;
+        bis->tx.n = 0;
+        bis->tx.g = 0;
+    }
+
+    rc = ble_phy_tx_set_start_time(sch->start_time + g_ble_ll_sched_offset_ticks,
+                                   sch->remainder);
+    if (rc) {
+        ble_phy_disable();
+        ble_ll_iso_big_event_done_to_ll(big);
+        return BLE_LL_SCHED_STATE_DONE;
+    }
+
+    ble_phy_set_txend_cb(ble_ll_iso_big_subevent_txend_cb, big);
+
+    rc = ble_ll_iso_big_subevent_tx(big);
+    if (rc) {
+        ble_phy_disable();
+        ble_ll_iso_big_event_done_to_ll(big);
+        return BLE_LL_SCHED_STATE_DONE;
+    }
+
+    return BLE_LL_SCHED_STATE_RUNNING;
+}
+
+static int
+ble_ll_iso_big_create(uint8_t big_handle, uint8_t adv_handle, uint8_t num_bis,
+                      struct big_params *bp)
+{
+    struct ble_ll_iso_big *big = NULL;
+    struct ble_ll_iso_bis *bis;
+    uint32_t seed_aa;
+    uint8_t idx;
+    int rc;
+
+    if ((big_pool_free == 0) || (bis_pool_free < num_bis)) {
+        return -ENOMEM;
+    }
+
+    /* Find free BIG */
+    for (idx = 0; idx < BIG_POOL_SIZE; idx++) {
+        if (!big && big_pool[idx].handle == BIG_HANDLE_INVALID) {
+            big = &big_pool[idx];
+        }
+        if (big_pool[idx].handle == big_handle) {
+            return -EALREADY;
+        }
+    }
+
+    BLE_LL_ASSERT(big);
+
+    /* TODO find valid advertising instance */
+
+    big->handle = big_handle;
+
+    seed_aa = ble_ll_utils_calc_seed_aa();
+    big->ctrl_aa = ble_ll_utils_calc_big_aa(seed_aa, 0);
+    big->crc_init = ble_ll_rand();
+    big->chan_map[0] = 0xff;
+    big->chan_map[1] = 0xff;
+    big->chan_map[2] = 0xff;
+    big->chan_map[3] = 0xff;
+    big->chan_map[4] = 0x1f;
+    big->chan_map_used = 37;
+
+    big->big_counter = 0;
+    big->bis_counter = 0;
+
+    /* Allocate BISes */
+    STAILQ_INIT(&big->bis_q);
+    big->num_bis = 0;
+    for (idx = 0; (big->num_bis < num_bis) && (idx < BIS_POOL_SIZE); idx++) {
+        bis = &bis_pool[idx];
+        if (bis->big) {
+            continue;
+        }
+
+        big->num_bis++;
+        STAILQ_INSERT_TAIL(&big->bis_q, bis, bis_q_next);
+
+        bis->big = big;
+        bis->num = big->num_bis;
+        bis->aa = ble_ll_utils_calc_big_aa(seed_aa, big->num_bis);
+        bis->crc_init = (big->crc_init << 8) | (big->num_bis);
+        bis->chan_id = bis->aa ^ (bis->aa >> 16);
+    }
+
+    big_pool_free--;
+    bis_pool_free -= num_bis;
+
+    big->bn = bp->bn;
+    big->pto = bp->pto;
+    big->irc = bp->irc;
+    big->nse = bp->nse;
+    big->interleaved = bp->interleaved;
+    big->framed = bp->framed;
+    big->encrypted = bp->encrypted;
+    big->sdu_interval = bp->sdu_interval;
+    big->iso_interval = bp->iso_interval;
+    big->max_sdu = bp->max_sdu;
+    big->max_pdu = bp->max_pdu;
+    big->mpt = ble_ll_pdu_tx_time_get(big->max_pdu, BLE_PHY_MODE_1M);
+
+    /* Core 5.3, Vol 6, Part B, 4.4.6.4 */
+    if (big->interleaved) {
+        big->bis_spacing = big->mpt + BLE_LL_MSS;
+        big->sub_interval = big->num_bis * big->bis_spacing;
+    } else {
+        big->sub_interval = big->mpt + BLE_LL_MSS;
+        big->bis_spacing = big->nse * big->sub_interval;
+    }
+    big->sync_delay = (big->num_bis - 1) * big->bis_spacing +
+                      (big->nse - 1) * big->sub_interval + big->mpt;
+
+    /* Core 5.3, Vol 6, Part B, 4.4.6.6 */
+    big->gc = big->nse / big->bn;
+    if (big->irc == big->gc) {
+        big->pto = 0;
+    }
+
+    ble_ll_iso_big_biginfo_calc(big, seed_aa);
+
+    /* For now we will schedule complete event as single item. This allows for
+     * shortest possible subevent space (150us) but can create sequence of long
+     * events that will block scheduler from other activities. To mitigate this
+     * we use preempt_none strategy so scheudling is opportunistic and depending
+     * on other activities this may create gaps in stream.
+     * Eventually we should allow for some more robust scheduling, e.g. per-BIS
+     * for sequential arrangement or per-subevent for interleaved, or event
+     * per-BIS-subevent but this requires larger subevent space since 150us is
+     * not enough for some phys to run scheduler item.
+     */
+
+    /* Schedule 1st event a bit in future */
+    big->sch.start_time = ble_ll_tmr_get() + ble_ll_tmr_u2t(1000);
+    big->sch.remainder = 0;
+    big->sch.end_time = big->sch.start_time +
+                        ble_ll_tmr_u2t_up(big->sync_delay) + 1;
+    big->sch.start_time -= g_ble_ll_sched_offset_ticks;
+
+    rc = ble_ll_sched_iso_big(&big->sch, 1);
+    if (rc < 0) {
+        /* TODO free resources */
+        return -ENOMEM;
+    }
+
+    ble_ll_iso_big_update_event_start(big);
+
+    big_pending = big;
+
+    return 0;
+}
+
+void
+ble_ll_iso_big_hci_evt_complete(void)
+{
+    struct ble_ll_iso_big *big;
+    struct ble_ll_iso_bis *bis;
+    struct ble_hci_ev_le_subev_create_big_complete *evt;
+    struct ble_hci_ev *hci_ev;
+    uint8_t idx;
+
+    big = big_pending;
+    big_pending = NULL;
+
+    if (!big) {
+        return;
+    }
+
+    hci_ev = (void *)ble_hci_trans_buf_alloc(BLE_HCI_TRANS_BUF_EVT_HI);
+    if (!hci_ev) {
+        BLE_LL_ASSERT(0);
+        /* XXX should we retry later? */
+        return;
+    }
+    hci_ev->opcode = BLE_HCI_EVCODE_LE_META;
+    hci_ev->length = sizeof(*evt) + big->num_bis * sizeof(evt->bis[0]);
+
+    evt = (void *)hci_ev->data;
+    memset(evt, 0, hci_ev->length);
+    evt->subev_code = BLE_HCI_LE_SUBEV_CREATE_BIG_COMPLETE;
+    evt->status = 0x00;
+
+    evt->big_handle = big->handle;
+    put_le24(evt->big_sync_delay, big->sync_delay);
+    put_le24(evt->transport_latency, big->sync_delay);
+    evt->phy = 0x01;
+    evt->nse = big->nse;
+    evt->bn = big->bn;
+    evt->pto = big->pto;
+    evt->irc = big->irc;
+    evt->max_pdu = htole16(big->max_pdu);
+    evt->iso_interval = htole16(big->iso_interval);
+    evt->bis_cnt = big->num_bis;
+
+    idx = 0;
+    STAILQ_FOREACH(bis, &big->bis_q, bis_q_next) {
+        evt->bis[idx] = htole16(bis->handle);
+        idx++;
+    }
+
+    ble_ll_hci_event_send(hci_ev);
+}
+
+int
+ble_ll_iso_big_hci_create(const uint8_t *cmdbuf, uint8_t len)
+{
+    const struct ble_hci_le_create_big_cp *cmd = (void *)cmdbuf;
+    struct big_params bp;
+
+    if (len != sizeof(*cmd)) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
+    }
+
+    if (!IN_RANGE(cmd->big_handle, 0x00, 0xef) ||
+        !IN_RANGE(cmd->adv_handle, 0x00, 0xef) ||
+        !IN_RANGE(cmd->num_bis, 0x01, 0x1f) ||
+        !IN_RANGE(get_le24(cmd->sdu_interval), 0x0000ff, 0x0fffff) ||
+        !IN_RANGE(le16toh(cmd->max_sdu), 0x0001, 0x0fff) ||
+        !IN_RANGE(le16toh(cmd->max_transport_latency), 0x0005, 0x0fa0) ||
+        !IN_RANGE(cmd->rtn, 0x00, 0x1e) ||
+        (cmd->packing > 1) || (cmd->framing > 1) || (cmd->encryption) > 1) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
+    }
+
+    bp.sdu_interval = get_le24(cmd->sdu_interval);
+    bp.max_transport_latency = le16toh(cmd->max_transport_latency);
+    bp.max_sdu = le16toh(cmd->max_sdu);
+    bp.interleaved = cmd->packing;
+    bp.framed = cmd->framing;
+    bp.encrypted = cmd->encryption;
+
+    /* TODO calculate stuff */
+    (void)bp;
+
+    return BLE_ERR_CONN_REJ_RESOURCES;
+}
+
+int
+ble_ll_iso_big_hci_create_test(const uint8_t *cmdbuf, uint8_t len)
+{
+    const struct ble_hci_le_create_big_test_cp *cmd = (void *)cmdbuf;
+    struct big_params bp;
+    int err;
+
+    if (len != sizeof(*cmd)) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
+    }
+
+    if (!IN_RANGE(cmd->big_handle, 0x00, 0xef) ||
+        !IN_RANGE(cmd->adv_handle, 0x00, 0xef) ||
+        !IN_RANGE(cmd->num_bis, 0x01, 0x1f) ||
+        !IN_RANGE(get_le24(cmd->sdu_interval), 0x0000ff, 0x0fffff) ||
+        !IN_RANGE(le16toh(cmd->iso_interval), 0x0004, 0x0c80) ||
+        !IN_RANGE(cmd->nse, 0x01, 0x1f) ||
+        !IN_RANGE(le16toh(cmd->max_sdu), 0x0001, 0x0fff) ||
+        !IN_RANGE(le16toh(cmd->max_pdu), 0x0001, 0x00fb) ||
+        /* phy */
+        (cmd->packing > 1) || (cmd->framing > 1) ||
+        !IN_RANGE(cmd->bn, 0x01, 0x07) ||
+        !IN_RANGE(cmd->irc, 0x01, 0x0f) ||
+        !IN_RANGE(cmd->pto, 0x00, 0x0f) ||
+        (cmd->encryption) > 1) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
+    }
+
+    bp.bn = cmd->bn;
+    bp.pto = cmd->pto;
+    bp.irc = cmd->irc;
+    bp.nse = cmd->nse;
+    bp.sdu_interval = get_le24(cmd->sdu_interval);
+    bp.iso_interval = le16toh(cmd->iso_interval);
+    bp.max_sdu = le16toh(cmd->max_sdu);
+    bp.max_pdu = le16toh(cmd->max_pdu);
+    bp.interleaved = cmd->packing;
+    bp.framed = cmd->framing;
+    bp.encrypted = cmd->encryption;
+
+    err = ble_ll_iso_big_create(cmd->big_handle, cmd->adv_handle, cmd->num_bis,
+                                &bp);
+    switch (err) {
+    case 0:
+        break;
+    case -EINVAL:
+        return BLE_ERR_INV_HCI_CMD_PARMS;
+    case -ENOMEM:
+        return BLE_ERR_CONN_REJ_RESOURCES;
+    case -ENOENT:
+        return BLE_ERR_UNK_ADV_INDENT;
+    default:
+        return BLE_ERR_UNSPECIFIED;
+    }
+
+    return 0;
+}
+
+int
+ble_ll_iso_big_hci_terminate(const uint8_t *cmdbuf, uint8_t len)
+{
+    return BLE_ERR_UNSUPPORTED;
+}
+
+void
+ble_ll_iso_big_init(void)
+{
+    struct ble_ll_iso_big *big;
+    struct ble_ll_iso_bis *bis;
+    uint8_t idx;
+
+    memset(big_pool, 0, sizeof(big_pool));
+    memset(bis_pool, 0, sizeof(bis_pool));
+
+    for (idx = 0; idx < BIG_POOL_SIZE; idx++) {
+        big = &big_pool[idx];
+
+        big->handle = BIG_HANDLE_INVALID;
+
+        big->sch.sched_type = BLE_LL_SCHED_TYPE_BIG;
+        big->sch.sched_cb = ble_ll_iso_big_event_sched_cb;
+        big->sch.cb_arg = big;
+
+        ble_npl_event_init(&big->event_done, ble_ll_iso_big_event_done_ev, big);
+    }
+
+    for (idx = 0; idx < BIS_POOL_SIZE; idx++) {
+        bis = &bis_pool[idx];
+        bis->handle = 0x0100 | idx;
+    }
+}
+
+#endif /* BLE_LL_ISO_BROADCASTER */

--- a/nimble/controller/src/ble_ll_isoal.c
+++ b/nimble/controller/src/ble_ll_isoal.c
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdint.h>
+#include <syscfg/syscfg.h>
+#include <nimble/hci_common.h>
+#include <controller/ble_ll_isoal.h>
+
+#if MYNEWT_VAL(BLE_LL_ISO)
+
+int
+ble_ll_isoal_hci_setup_data_path(const uint8_t *cmdbuf, uint8_t cmdlen,
+                                 uint8_t *rspbuf, uint8_t *rsplen)
+{
+    const struct ble_hci_le_iso_setup_data_path_cp *cmd = (const void *)cmdbuf;
+    struct ble_hci_le_iso_setup_data_path_rp *rsp = (void *)rspbuf;
+
+    /* XXX accepts anything for now */
+    rsp->iso_handle = cmd->iso_handle;
+    *rsplen = 2;
+
+    return 0;
+}
+
+int
+ble_ll_isoal_hci_remove_data_path(const uint8_t *cmdbuf, uint8_t cmdlen,
+                                  uint8_t *rspbuf, uint8_t *rsplen)
+{
+    const struct ble_hci_le_iso_remove_data_path_cp *cmd = (const void *)cmdbuf;
+    struct ble_hci_le_iso_remove_data_path_rp *rsp = (void *)rspbuf;
+
+    /* XXX accepts anything for now */
+    rsp->iso_handle = cmd->iso_handle;
+    *rsplen = 2;
+
+    return 0;
+}
+
+void
+ble_ll_isoal_init(void)
+{
+}
+
+#endif /* BLE_LL_ISO */

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -1178,8 +1178,8 @@ ble_ll_sync_next_event(struct ble_ll_sync_sm *sm, uint32_t cur_ww_adjust)
     }
 
     /* Calculate channel index of next event */
-    sm->chan_index = ble_ll_utils_calc_dci_csa2(sm->event_cntr, sm->channel_id,
-                                                sm->num_used_chans, sm->chanmap);
+    sm->chan_index = ble_ll_utils_dci_csa2(sm->event_cntr, sm->channel_id,
+                                           sm->num_used_chans, sm->chanmap);
 
     cur_ww = ble_ll_utils_calc_window_widening(sm->anchor_point,
                                                sm->last_anchor_point,
@@ -1409,8 +1409,8 @@ ble_ll_sync_info_event(struct ble_ll_scan_addr_data *addrd,
     sm->window_widening = BLE_LL_JITTER_USECS;
 
     /* Calculate channel index of first event */
-    sm->chan_index = ble_ll_utils_calc_dci_csa2(sm->event_cntr, sm->channel_id,
-                                                sm->num_used_chans, sm->chanmap);
+    sm->chan_index = ble_ll_utils_dci_csa2(sm->event_cntr, sm->channel_id,
+                                           sm->num_used_chans, sm->chanmap);
 
     if (ble_ll_sched_sync(&sm->sch, rxhdr->beg_cputime, rxhdr->rem_usecs,
                           offset, sm->phy_mode)) {
@@ -1957,8 +1957,8 @@ ble_ll_sync_periodic_ind(struct ble_ll_conn_sm *connsm,
     sm->phy_mode = phy_mode;
 
     /* Calculate channel index of first event */
-    sm->chan_index = ble_ll_utils_calc_dci_csa2(sm->event_cntr, sm->channel_id,
-                                                sm->num_used_chans, sm->chanmap);
+    sm->chan_index = ble_ll_utils_dci_csa2(sm->event_cntr, sm->channel_id,
+                                           sm->num_used_chans, sm->chanmap);
 
     /* get anchor for specified conn event */
     conn_event_count = get_le16(sync_ind + 20);

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -183,6 +183,32 @@ ble_ll_utils_calc_seed_aa(void)
     return seed_aa;
 }
 
+uint32_t
+ble_ll_utils_calc_big_aa(uint32_t seed_aa, uint32_t n)
+{
+    uint32_t d;
+    uint32_t dw;
+
+    /* Core 5.3, Vol 6, Part B, 2.1.2 */
+    /* TODO simplify? */
+    d = ((35 * n) + 42) % 128;
+    dw = (!!(d & (1 << 0)) << 31) |
+         (!!(d & (1 << 0)) << 30) |
+         (!!(d & (1 << 0)) << 29) |
+         (!!(d & (1 << 0)) << 28) |
+         (!!(d & (1 << 0)) << 27) |
+         (!!(d & (1 << 0)) << 26) |
+         (!!(d & (1 << 1)) << 25) |
+         (!!(d & (1 << 6)) << 24) |
+         (!!(d & (1 << 1)) << 23) |
+         (!!(d & (1 << 5)) << 21) |
+         (!!(d & (1 << 4)) << 20) |
+         (!!(d & (1 << 3)) << 18) |
+         (!!(d & (1 << 2)) << 17);
+
+    return seed_aa ^ dw;
+}
+
 uint8_t
 ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap)
 {

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -202,10 +202,22 @@ ble_ll_utils_calc_num_used_chans(const uint8_t *chan_map)
 }
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CSA2)
-static uint16_t
-ble_ll_utils_csa2_perm(uint16_t in)
+#if __thumb2__
+static inline uint32_t
+ble_ll_utils_csa2_perm(uint32_t val)
 {
-    uint16_t out = 0;
+    __asm__ volatile (".syntax unified      \n"
+                      "rbit %[val], %[val]  \n"
+                      "rev %[val], %[val]   \n"
+                      : [val] "+r" (val));
+
+    return val;
+}
+#else
+static uint32_t
+ble_ll_utils_csa2_perm(uint32_t in)
+{
+    uint32_t out = 0;
     int i;
 
     for (i = 0; i < 8; i++) {
@@ -218,6 +230,7 @@ ble_ll_utils_csa2_perm(uint16_t in)
 
     return out;
 }
+#endif
 
 static uint16_t
 ble_ll_utils_csa2_prng(uint16_t counter, uint16_t ch_id)

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -182,32 +182,23 @@ ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap)
 }
 
 uint8_t
-ble_ll_utils_calc_num_used_chans(const uint8_t *chmap)
+ble_ll_utils_calc_num_used_chans(const uint8_t *chan_map)
 {
-    int i;
-    int j;
-    uint8_t mask;
-    uint8_t chanbyte;
-    uint8_t used_channels;
+    uint32_t u32 = 0;
+    uint32_t num_used_chans = 0;
+    unsigned idx;
 
-    used_channels = 0;
-    for (i = 0; i < BLE_LL_CHMAP_LEN; ++i) {
-        chanbyte = chmap[i];
-        if (chanbyte) {
-            if (chanbyte == 0xff) {
-                used_channels += 8;
-            } else {
-                mask = 0x01;
-                for (j = 0; j < 8; ++j) {
-                    if (chanbyte & mask) {
-                        ++used_channels;
-                    }
-                    mask <<= 1;
-                }
-            }
+    for (idx = 0; idx < 37; idx++) {
+        if ((idx % 8) == 0) {
+            u32 = chan_map[idx / 8];
         }
+        if (u32 & 1) {
+            num_used_chans++;
+        }
+        u32 >>= 1;
     }
-    return used_channels;
+
+    return num_used_chans;
 }
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CSA2)

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -339,16 +339,16 @@ ble_ll_utils_csa2_calc_chan_idx(uint16_t prn_e, uint8_t num_used_chans,
 }
 
 uint8_t
-ble_ll_utils_calc_dci_csa2(uint16_t event_cntr, uint16_t channel_id,
-                           uint8_t num_used_chans, const uint8_t *chanmap)
+ble_ll_utils_dci_csa2(uint16_t counter, uint16_t chan_id,
+                      uint8_t num_used_chans, const uint8_t *chan_map)
 {
     uint16_t prn_e;
     uint16_t chan_idx;
     uint16_t remap_idx;
 
-    prn_e = ble_ll_utils_csa2_prng(event_cntr, channel_id);
+    prn_e = ble_ll_utils_csa2_prng(counter, chan_id);
 
-    chan_idx = ble_ll_utils_csa2_calc_chan_idx(prn_e, num_used_chans, chanmap,
+    chan_idx = ble_ll_utils_csa2_calc_chan_idx(prn_e, num_used_chans, chan_map,
                                                &remap_idx);
 
     return chan_idx;

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -232,23 +232,39 @@ ble_ll_utils_csa2_perm(uint32_t in)
 }
 #endif
 
+static inline uint32_t
+ble_ll_utils_csa2_mam(uint32_t a, uint32_t b)
+{
+    return (17 * a + b) % 65536;
+}
+
+static uint16_t
+ble_ll_utils_csa2_prn_s(uint16_t counter, uint16_t ch_id)
+{
+    uint32_t prn_s;
+
+    prn_s = counter ^ ch_id;
+
+    prn_s = ble_ll_utils_csa2_perm(prn_s);
+    prn_s = ble_ll_utils_csa2_mam(prn_s, ch_id);
+
+    prn_s = ble_ll_utils_csa2_perm(prn_s);
+    prn_s = ble_ll_utils_csa2_mam(prn_s, ch_id);
+
+    prn_s = ble_ll_utils_csa2_perm(prn_s);
+    prn_s = ble_ll_utils_csa2_mam(prn_s, ch_id);
+
+    return prn_s;
+}
+
 static uint16_t
 ble_ll_utils_csa2_prng(uint16_t counter, uint16_t ch_id)
 {
+    uint16_t prn_s;
     uint16_t prn_e;
 
-    prn_e = counter ^ ch_id;
-
-    prn_e = ble_ll_utils_csa2_perm(prn_e);
-    prn_e = (prn_e * 17) + ch_id;
-
-    prn_e = ble_ll_utils_csa2_perm(prn_e);
-    prn_e = (prn_e * 17) + ch_id;
-
-    prn_e = ble_ll_utils_csa2_perm(prn_e);
-    prn_e = (prn_e * 17) + ch_id;
-
-    prn_e = prn_e ^ ch_id;
+    prn_s = ble_ll_utils_csa2_prn_s(counter, ch_id);
+    prn_e = prn_s ^ ch_id;
 
     return prn_e;
 }

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -144,6 +144,45 @@ ble_ll_utils_calc_access_addr(void)
     return aa;
 }
 
+uint32_t
+ble_ll_utils_calc_seed_aa(void)
+{
+    uint32_t seed_aa;
+
+    while (1) {
+        seed_aa = ble_ll_utils_calc_access_addr();
+
+        /* saa(19) == saa(15) */
+        if (!!(seed_aa & (1 << 19)) != !!(seed_aa & (1 << 15))) {
+            continue;
+        }
+
+        /* saa(22) = saa(16) */
+        if (!!(seed_aa & (1 << 22)) != !!(seed_aa & (1 << 16))) {
+            continue;
+        }
+
+        /* saa(22) != saa(15) */
+        if (!!(seed_aa & (1 << 22)) == !!(seed_aa & (1 << 15))) {
+            continue;
+        }
+
+        /* saa(25) == 0 */
+        if (seed_aa & (1 << 25)) {
+            continue;
+        }
+
+        /* saa(23) == 1 */
+        if (!(seed_aa & (1 << 23))) {
+            continue;
+        }
+
+        break;
+    }
+
+    return seed_aa;
+}
+
 uint8_t
 ble_ll_utils_remapped_channel(uint8_t remap_index, const uint8_t *chanmap)
 {

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -415,6 +415,21 @@ syscfg.defs:
             should be enabled.
         value: -1
 
+    BLE_LL_ISO:
+        description: >
+            Enable support for isochronous data.
+            This enables common code (e.g. ISOAL) for all types of isochronous
+            data, particular ISO features have to be enabled separately.
+        restrictions:
+            - (BLE_VERSION >= 52) if 1
+        value: 0
+    BLE_LL_ISO_BROADCASTER:
+        description: >
+            Enable support for Isochronous Broadcasting state.
+        restrictions:
+            - BLE_LL_ISO if 1
+        value: 0
+
     BLE_LL_SYSINIT_STAGE:
         description: >
             Sysinit stage for the NimBLE controller.

--- a/nimble/controller/test/src/ble_ll_csa2_test.c
+++ b/nimble/controller/test/src/ble_ll_csa2_test.c
@@ -22,6 +22,7 @@
 #include "testutil/testutil.h"
 #include "controller/ble_ll_test.h"
 #include "controller/ble_ll_conn.h"
+#include "controller/ble_ll_utils.h"
 #include "ble_ll_csa2_test.h"
 
 TEST_CASE_SELF(ble_ll_csa2_test_1)
@@ -108,8 +109,179 @@ TEST_CASE_SELF(ble_ll_csa2_test_2)
     TEST_ASSERT(rc == 34);
 }
 
+TEST_CASE_SELF(ble_ll_csa2_test_3)
+{
+    uint8_t chan_map[5];
+    uint8_t num_used_chans;
+    uint16_t chan_id;
+    uint16_t prn_sub_lu;
+    uint16_t chan_idx;
+    uint16_t remap_idx;
+
+    /* Sample data: Core 5.3, Vol 6, Part C, 3.1 */
+    chan_map[0] = 0xff;
+    chan_map[1] = 0xff;
+    chan_map[2] = 0xff;
+    chan_map[3] = 0xff;
+    chan_map[4] = 0x1f;
+    num_used_chans = ble_ll_utils_calc_num_used_chans(chan_map);
+    TEST_ASSERT(num_used_chans == 37);
+    chan_id = 0x305f;
+
+    chan_idx = ble_ll_utils_dci_iso_event(0, chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 56857);
+    TEST_ASSERT(chan_idx == 25);
+    TEST_ASSERT(remap_idx == 25);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 11710);
+    TEST_ASSERT(chan_idx == 1);
+    TEST_ASSERT(remap_idx == 1);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 16649);
+    TEST_ASSERT(chan_idx == 16);
+    TEST_ASSERT(remap_idx == 16);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 38198);
+    TEST_ASSERT(chan_idx == 36);
+    TEST_ASSERT(remap_idx == 36);
+
+    chan_idx = ble_ll_utils_dci_iso_event(1, chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 1685);
+    TEST_ASSERT(chan_idx == 20);
+    TEST_ASSERT(remap_idx == 20);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 20925);
+    TEST_ASSERT(chan_idx == 36);
+    TEST_ASSERT(remap_idx == 36);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 11081);
+    TEST_ASSERT(chan_idx == 12);
+    TEST_ASSERT(remap_idx == 12);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 48920);
+    TEST_ASSERT(chan_idx == 34);
+    TEST_ASSERT(remap_idx == 34);
+
+    chan_idx = ble_ll_utils_dci_iso_event(2, chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 38301);
+    TEST_ASSERT(chan_idx == 6);
+    TEST_ASSERT(remap_idx == 6);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 6541);
+    TEST_ASSERT(chan_idx == 18);
+    TEST_ASSERT(remap_idx == 18);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 14597);
+    TEST_ASSERT(chan_idx == 32);
+    TEST_ASSERT(remap_idx == 32);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 62982);
+    TEST_ASSERT(chan_idx == 21);
+    TEST_ASSERT(remap_idx == 21);
+
+    chan_idx = ble_ll_utils_dci_iso_event(3, chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 27475);
+    TEST_ASSERT(chan_idx == 21);
+    TEST_ASSERT(remap_idx == 21);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 40400);
+    TEST_ASSERT(chan_idx == 4);
+    TEST_ASSERT(remap_idx == 4);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 30015);
+    TEST_ASSERT(chan_idx == 22);
+    TEST_ASSERT(remap_idx == 22);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 49818);
+    TEST_ASSERT(chan_idx == 8);
+    TEST_ASSERT(remap_idx == 8);
+
+    /* Sample data: Core 5.3, Vol 6, Part C, 3.2 */
+    chan_map[0] = 0x00;
+    chan_map[1] = 0x06;
+    chan_map[2] = 0xe0;
+    chan_map[3] = 0x00;
+    chan_map[4] = 0x1e;
+    num_used_chans = ble_ll_utils_calc_num_used_chans(chan_map);
+    TEST_ASSERT(num_used_chans == 9);
+    chan_id = 0x305f;
+
+    chan_idx = ble_ll_utils_dci_iso_event(6, chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 10975);
+    TEST_ASSERT(chan_idx == 23);
+    TEST_ASSERT(remap_idx == 4);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 14383);
+    TEST_ASSERT(chan_idx == 35);
+    TEST_ASSERT(remap_idx == 7);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 28946);
+    TEST_ASSERT(chan_idx == 21);
+    TEST_ASSERT(remap_idx == 2);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 61038);
+    TEST_ASSERT(chan_idx == 36);
+    TEST_ASSERT(remap_idx == 8);
+
+    chan_idx = ble_ll_utils_dci_iso_event(7, chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 5490);
+    TEST_ASSERT(chan_idx == 9);
+    TEST_ASSERT(remap_idx == 0);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 4108);
+    TEST_ASSERT(chan_idx == 22);
+    TEST_ASSERT(remap_idx == 3);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 45462);
+    TEST_ASSERT(chan_idx == 36);
+    TEST_ASSERT(remap_idx == 8);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 64381);
+    TEST_ASSERT(chan_idx == 33);
+    TEST_ASSERT(remap_idx == 5);
+
+    chan_idx = ble_ll_utils_dci_iso_event(8, chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 46970);
+    TEST_ASSERT(chan_idx == 34);
+    TEST_ASSERT(remap_idx == 6);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 7196);
+    TEST_ASSERT(chan_idx == 9);
+    TEST_ASSERT(remap_idx == 0);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 33054);
+    TEST_ASSERT(chan_idx == 33);
+    TEST_ASSERT(remap_idx == 5);
+
+    chan_idx = ble_ll_utils_dci_iso_subevent(chan_id, &prn_sub_lu, num_used_chans, chan_map, &remap_idx);
+    TEST_ASSERT((prn_sub_lu ^ chan_id) == 42590);
+    TEST_ASSERT(chan_idx == 10);
+    TEST_ASSERT(remap_idx == 1);
+}
+
 TEST_SUITE(ble_ll_csa2_test_suite)
 {
     ble_ll_csa2_test_1();
     ble_ll_csa2_test_2();
+    ble_ll_csa2_test_3();
 }

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -833,7 +833,7 @@ struct ble_hci_le_set_default_periodic_sync_transfer_params_cp {
 #define BLE_HCI_OCF_LE_GENERATE_DHKEY_V2                 (0x005E)
 #define BLE_HCI_OCF_LE_MODIFY_SCA                        (0x005F)
 
-#if MYNEWT_VAL(BLE_ISO)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_ISO)
 #define BLE_HCI_OCF_LE_READ_ISO_TX_SYNC                  (0x0061)
 struct ble_hci_le_read_iso_tx_sync_cp {
     uint16_t conn_handle;
@@ -942,16 +942,17 @@ struct ble_hci_le_reject_cis_request_cp {
 struct ble_hci_le_reject_cis_request_rp {
     uint16_t conn_handle;
 } __attribute__((packed));
+#endif
 
 #define BLE_HCI_OCF_LE_CREATE_BIG                        (0x0068)
 struct ble_hci_le_create_big_cp {
     uint8_t big_handle;
     uint8_t adv_handle;
-    uint8_t bis_cnt;
+    uint8_t num_bis;
     uint8_t sdu_interval[3];
     uint16_t max_sdu;
     uint16_t max_transport_latency;
-    uint8_t rnt;
+    uint8_t rtn;
     uint8_t phy;
     uint8_t packing;
     uint8_t framing;
@@ -959,12 +960,11 @@ struct ble_hci_le_create_big_cp {
     uint8_t broadcast_code[16];
 } __attribute__((packed));
 
-#if MYNEWT_VAL(BLE_ISO_TEST)
 #define BLE_HCI_OCF_LE_CREATE_BIG_TEST                   (0x0069)
 struct ble_hci_le_create_big_test_cp {
     uint8_t big_handle;
     uint8_t adv_handle;
-    uint8_t bis_cnt;
+    uint8_t num_bis;
     uint8_t sdu_interval[3];
     uint16_t iso_interval;
     uint8_t nse;
@@ -979,7 +979,6 @@ struct ble_hci_le_create_big_test_cp {
     uint8_t encryption;
     uint8_t broadcast_code[16];
 } __attribute__((packed));
-#endif
 
 #define BLE_HCI_OCF_LE_TERMINATE_BIG                     (0x006a)
 struct ble_hci_le_terminate_big_cp {
@@ -987,6 +986,7 @@ struct ble_hci_le_terminate_big_cp {
     uint8_t reason;
 } __attribute__((packed));
 
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_ISO)
 #define BLE_HCI_LE_BIG_CREATE_SYNC_LEN_MIN               (25)
 #define BLE_HCI_OCF_LE_BIG_CREATE_SYNC                   (0x006b)
 struct ble_hci_le_big_create_sync_cp {
@@ -1748,8 +1748,8 @@ struct ble_hci_ev_le_subev_cis_request {
     uint8_t cis_id;
 } __attribute__((packed));
 
-#define BLE_HCI_LE_SUBEV_BIG_COMP               (0x1B)
-struct ble_hci_ev_le_subev_big_complete {
+#define BLE_HCI_LE_SUBEV_CREATE_BIG_COMPLETE    (0x1B)
+struct ble_hci_ev_le_subev_create_big_complete {
     uint8_t subev_code;
     uint8_t status;
     uint8_t big_handle;

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1011,7 +1011,6 @@ struct ble_hci_le_request_peer_sca_cp {
     uint16_t conn_handle;
 } __attribute__((packed));
 
-#if MYNEWT_VAL(BLE_ISO)
 #define BLE_HCI_OCF_LE_SETUP_ISO_DATA_PATH               (0x006e)
 struct ble_hci_le_iso_setup_data_path_cp {
     uint16_t iso_handle;
@@ -1022,13 +1021,17 @@ struct ble_hci_le_iso_setup_data_path_cp {
     uint8_t codec_conf_len;
     uint8_t codec_conf[0];
 } __attribute__((packed));
+struct ble_hci_le_iso_setup_data_path_rp {
+    uint16_t iso_handle;
+} __attribute__((packed));
 
-#define BLE_HCI_LE_REMOVE_INPUT_DATA_PATH_BIT            (0x01)
-#define BLE_HCI_LE_REMOVE_OUTPUT_DATA_PATH_BIT           (0x02)
 #define BLE_HCI_OCF_LE_REMOVE_ISO_DATA_PATH              (0x006f)
 struct ble_hci_le_iso_remove_data_path_cp {
     uint16_t iso_handle;
     uint8_t direction;
+} __attribute__((packed));
+struct ble_hci_le_iso_remove_data_path_rp {
+    uint16_t iso_handle;
 } __attribute__((packed));
 
 #if MYNEWT_VAL(BLE_ISO_TEST)
@@ -1052,7 +1055,6 @@ struct ble_hci_le_iso_read_test_counters_cp {
 struct ble_hci_le_iso_test_end_cp {
     uint16_t iso_handle;
 } __attribute__((packed));
-#endif
 #endif
 
 #define BLE_HCI_OCF_LE_SET_HOST_FEAT                     (0x0074)


### PR DESCRIPTION
this is work in progress
pr is rebased on top of https://github.com/apache/mynewt-nimble/pull/1195
at the moment it allows to create working BIG with a test command
supports all values of bn, pto, irc
supports sequential and interleaved
supports only unframed (kind of)
isoal is just stubbed, BIS PDUs are filled wth some dummy data for testing