### PR TITLE
nimble/ll: Add HCI Reset to supported commands

### DIFF
--- a/nimble/controller/src/ble_ll_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_supp_cmd.c
@@ -36,7 +36,12 @@
 
 /* Octet 5 */
 #define BLE_SUPP_CMD_SET_EVENT_MASK         (1 << 6)
-#define BLE_LL_SUPP_CMD_OCTET_5             (BLE_SUPP_CMD_SET_EVENT_MASK)
+#define BLE_SUPP_CMD_RESET                  (1 << 7)
+#define BLE_LL_SUPP_CMD_OCTET_5             \
+(                                           \
+    BLE_SUPP_CMD_SET_EVENT_MASK |           \
+    BLE_SUPP_CMD_RESET                      \
+)
 
 /* Octet 10 */
 #define BLE_SUPP_CMD_RD_TX_PWR              (0 << 2)


### PR DESCRIPTION
Looks like bit for HCI Reset was not set in supported commands bitmask.