### PR TITLE
nrf5340: dont depend on mynewt.h, but only on sysinit.h

### DIFF
--- a/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
+++ b/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
@@ -19,7 +19,7 @@
 
 #include <assert.h>
 #include <string.h>
-#include <os/mynewt.h>
+#include <sysinit/sysinit.h>
 #include <nimble/ble.h>
 #include <nimble/ble_hci_trans.h>
 #include <nimble/hci_common.h>


### PR DESCRIPTION
This makes it a lot easier to port Nimble to other platforms beside Mynewt.

Tested on NRF5340 on host + controller