### PR TITLE
nimble/ll: Add fake dual mode option

### DIFF
--- a/nimble/controller/syscfg.hbd.yml
+++ b/nimble/controller/syscfg.hbd.yml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    BLE_LL_HBD_FAKE_DUAL_MODE:
+        description: >
+            This enables hacks to allow initialize controler as dual-mode
+            device. It can be initialized and used by Windows 10 to some
+            extent.
+        value: 0

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -559,3 +559,7 @@ syscfg.restrictions:
     - BLE_LL_PUBLIC_DEV_ADDR <= 0xffffffffffff
     - BLE_LL_PA == 0 || BLE_LL_PA_GPIO >= 0
     - BLE_LL_LNA == 0 || BLE_LL_LNA_GPIO >= 0
+
+$import:
+    # "Here be dragons" settings
+    - "@apache-mynewt-nimble/nimble/controller/syscfg.hbd.yml"


### PR DESCRIPTION
This adds option to enable some hacks to allow controller to be
initialized by dual-mode host. It basically fakes some HCI command that
we do not support since they are not relevant for BR/EDR, but it allows
for NimBLE controller to be used as a Bluetooth controller e.g. in
Windows 10, at least to some extent.

This option is not intended to be used for production setup, it should
be only used for testing purposes.