### PR TITLE
nimble/transport/nrf53: Fix slow reads from IPC

### DIFF
--- a/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
+++ b/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
@@ -93,15 +93,14 @@ nrf5340_ble_hci_frame_cb(uint8_t pkt_type, void *data)
 static void
 nrf5340_ble_hci_trans_rx(int channel, void *user_data)
 {
-    uint8_t byte;
-    int rlen;
+    uint8_t *buf;
+    int len;
 
-    while (ipc_nrf5340_available(channel) > 0) {
-        rlen = ipc_nrf5340_read(channel, &byte, 1);
-        assert(rlen == 1);
-
-        rlen = hci_h4_sm_rx(&hci_nrf5340_h4sm, &byte, 1);
-        assert(rlen == 1);
+    len = ipc_nrf5340_available_buf(channel, (void **)&buf);
+    while (len > 0) {
+        len = hci_h4_sm_rx(&hci_nrf5340_h4sm, buf, len);
+        ipc_nrf5340_consume(channel, len);
+        len = ipc_nrf5340_available_buf(channel, (void **)&buf);
     }
 }
 


### PR DESCRIPTION
Reading byte-by-byte from IPC to H4 is terribly slow, we should use new
API that can return pointer to an IPC buffer and read directly from
there.