### PR TITLE
nimble/ll: Move global channel map out of ble_ll_conn

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -91,6 +91,8 @@ void ble_ll_assert(const char *file, unsigned line) __attribute((noreturn));
 /* Packet queue header definition */
 STAILQ_HEAD(ble_ll_pkt_q, os_mbuf_pkthdr);
 
+#define BLE_LL_CHAN_MAP_LEN (5)
+
 /*
  * Global Link Layer data object. There is only one Link Layer data object
  * per controller although there may be many instances of the link layer state
@@ -103,6 +105,10 @@ struct ble_ll_obj
 
     /* Current Link Layer state */
     uint8_t ll_state;
+
+    /* Global channel map */
+    uint8_t chan_map_num_used;
+    uint8_t chan_map[BLE_LL_CHAN_MAP_LEN];
 
 #if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL) || MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
     /* Number of ACL data packets supported */

--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -24,6 +24,7 @@
 #include "nimble/ble.h"
 #include "nimble/hci_common.h"
 #include "nimble/nimble_npl.h"
+#include "controller/ble_ll.h"
 #include "controller/ble_ll_sched.h"
 #include "controller/ble_ll_ctrl.h"
 #include "controller/ble_phy.h"
@@ -46,9 +47,6 @@ extern "C" {
 #define BLE_LL_CONN_STATE_IDLE          (0)
 #define BLE_LL_CONN_STATE_CREATED       (1)
 #define BLE_LL_CONN_STATE_ESTABLISHED   (2)
-
-/* Channel map size */
-#define BLE_LL_CONN_CHMAP_LEN           (5)
 
 /* Definition for RSSI when the RSSI is unknown */
 #define BLE_LL_CONN_UNKNOWN_RSSI        (127)
@@ -240,8 +238,8 @@ struct ble_ll_conn_sm
 #endif
 
     /* Used to calculate data channel index for connection */
-    uint8_t chanmap[BLE_LL_CONN_CHMAP_LEN];
-    uint8_t req_chanmap[BLE_LL_CONN_CHMAP_LEN];
+    uint8_t chanmap[BLE_LL_CHAN_MAP_LEN];
+    uint8_t req_chanmap[BLE_LL_CHAN_MAP_LEN];
     uint16_t chanmap_instant;
     uint16_t channel_id; /* TODO could be union with hop and last chan used */
     uint8_t hop_inc;

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1640,6 +1640,10 @@ ble_ll_reset(void)
     g_ble_ll_data.ll_pref_tx_phys = phy_mask;
     g_ble_ll_data.ll_pref_rx_phys = phy_mask;
 
+    /* Enable all channels in channel map */
+    g_ble_ll_data.chan_map_num_used = BLE_PHY_NUM_DATA_CHANS;
+    memset(g_ble_ll_data.chan_map, 0xff, BLE_LL_CHAN_MAP_LEN);
+
 #if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
     /* Reset connection module */
     ble_ll_conn_module_reset();

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -162,7 +162,7 @@ struct ble_ll_adv_sm
     uint8_t periodic_sync_active : 1;
     uint8_t periodic_sync_index : 1;
     uint8_t periodic_num_used_chans;
-    uint8_t periodic_chanmap[BLE_LL_CONN_CHMAP_LEN];
+    uint8_t periodic_chanmap[BLE_LL_CHAN_MAP_LEN];
     uint32_t periodic_adv_itvl_ticks;
     uint8_t periodic_adv_itvl_rem_usec;
     uint8_t periodic_adv_event_start_time_remainder;
@@ -1372,8 +1372,8 @@ ble_ll_adv_aux_calculate(struct ble_ll_adv_sm *advsm,
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CSA2)
     aux->chan = ble_ll_utils_dci_csa2(advsm->event_cntr++,
                                       advsm->channel_id,
-                                      g_ble_ll_conn_params.num_used_chans,
-                                      g_ble_ll_conn_params.central_chan_map);
+                                      g_ble_ll_data.chan_map_num_used,
+                                      g_ble_ll_data.chan_map);
 #else
     aux->chan = ble_ll_utils_remapped_channel(ble_ll_rand() % BLE_PHY_NUM_DATA_CHANS,
                                               g_ble_ll_conn_params.central_chan_map);
@@ -2545,9 +2545,8 @@ ble_ll_adv_sm_start_periodic(struct ble_ll_adv_sm *advsm)
     advsm->periodic_adv_active = 1;
 
     /* keep channel map since we cannot change it later on */
-    memcpy(advsm->periodic_chanmap, g_ble_ll_conn_params.central_chan_map,
-           BLE_LL_CONN_CHMAP_LEN);
-    advsm->periodic_num_used_chans = g_ble_ll_conn_params.num_used_chans;
+    memcpy(advsm->periodic_chanmap, g_ble_ll_data.chan_map, BLE_LL_CHAN_MAP_LEN);
+    advsm->periodic_num_used_chans = g_ble_ll_data.chan_map_num_used;
     advsm->periodic_event_cntr = 0;
     /* for chaining we start with random counter as we share access addr */
     advsm->periodic_chain_event_cntr = ble_ll_rand();

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -1386,9 +1386,9 @@ ble_ll_conn_hci_rd_chan_map(const uint8_t *cmdbuf, uint8_t len,
         memset(rsp->chan_map, 0, sizeof(rsp->chan_map));
     } else {
         if (connsm->csmflags.cfbit.chanmap_update_scheduled) {
-            memcpy(rsp->chan_map, connsm->req_chanmap, BLE_LL_CONN_CHMAP_LEN);
+            memcpy(rsp->chan_map, connsm->req_chanmap, BLE_LL_CHAN_MAP_LEN);
         } else {
-            memcpy(rsp->chan_map, connsm->chanmap, BLE_LL_CONN_CHMAP_LEN);
+            memcpy(rsp->chan_map, connsm->chanmap, BLE_LL_CHAN_MAP_LEN);
         }
         rc = BLE_ERR_SUCCESS;
     }

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -66,8 +66,6 @@ extern "C" {
 /* Global Link Layer connection parameters */
 struct ble_ll_conn_global_params
 {
-    uint8_t central_chan_map[BLE_LL_CONN_CHMAP_LEN];
-    uint8_t num_used_chans;
 #if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL) || MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL)
     uint8_t supp_max_tx_octets;
     uint8_t supp_max_rx_octets;

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -1868,12 +1868,12 @@ static void
 ble_ll_ctrl_chanmap_req_make(struct ble_ll_conn_sm *connsm, uint8_t *pyld)
 {
     /* Copy channel map that host desires into request */
-    memcpy(pyld, g_ble_ll_conn_params.central_chan_map, BLE_LL_CONN_CHMAP_LEN);
-    memcpy(connsm->req_chanmap, pyld, BLE_LL_CONN_CHMAP_LEN);
+    memcpy(pyld, g_ble_ll_data.chan_map, BLE_LL_CHAN_MAP_LEN);
+    memcpy(connsm->req_chanmap, pyld, BLE_LL_CHAN_MAP_LEN);
 
     /* Place instant into request */
     connsm->chanmap_instant = connsm->event_cntr + connsm->periph_latency + 6 + 1;
-    put_le16(pyld + BLE_LL_CONN_CHMAP_LEN, connsm->chanmap_instant);
+    put_le16(pyld + BLE_LL_CHAN_MAP_LEN, connsm->chanmap_instant);
 
     /* Set scheduled flag */
     connsm->csmflags.cfbit.chanmap_update_scheduled = 1;
@@ -2393,13 +2393,13 @@ ble_ll_ctrl_rx_chanmap_req(struct ble_ll_conn_sm *connsm, uint8_t *dptr)
 #endif
 
     /* If instant is in the past, we have to end the connection */
-    instant = get_le16(dptr + BLE_LL_CONN_CHMAP_LEN);
+    instant = get_le16(dptr + BLE_LL_CHAN_MAP_LEN);
     conn_events = (instant - connsm->event_cntr) & 0xFFFF;
     if (conn_events >= 32767) {
         ble_ll_conn_timeout(connsm, BLE_ERR_INSTANT_PASSED);
     } else {
         connsm->chanmap_instant = instant;
-        memcpy(connsm->req_chanmap, dptr, BLE_LL_CONN_CHMAP_LEN);
+        memcpy(connsm->req_chanmap, dptr, BLE_LL_CHAN_MAP_LEN);
         connsm->csmflags.cfbit.chanmap_update_scheduled = 1;
     }
 


### PR DESCRIPTION
Global channels map is also used by adv code. This fixes build without
central/peripheral roles enabled.