### PR TITLE
nimble/ll: Optimize BLE_LL_ASSERT

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -41,14 +41,12 @@ extern "C" {
 #ifdef NDEBUG
 #define BLE_LL_ASSERT(cond) (void(0))
 #else
+void ble_ll_assert(const char *file, unsigned line) __attribute((noreturn));
+#define BLE_LL_FILE  (__builtin_strrchr(__FILE__, '/') ? \
+                      __builtin_strrchr (__FILE__, '/') + 1 : __FILE__)
 #define BLE_LL_ASSERT(cond) \
     if (!(cond)) { \
-        if (hal_debugger_connected()) { \
-            assert(0);\
-        } else {\
-            ble_ll_hci_ev_send_vs_assert(__FILE__, __LINE__); \
-            while(1) {}\
-        }\
+        ble_ll_assert(BLE_LL_FILE, __LINE__); \
     }
 #endif
 #else

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1764,6 +1764,20 @@ ble_ll_is_addr_empty(const uint8_t *addr)
     return memcmp(addr, BLE_ADDR_ANY, BLE_DEV_ADDR_LEN) == 0;
 }
 
+#if MYNEWT_VAL(BLE_LL_HCI_VS_EVENT_ON_ASSERT)
+void
+ble_ll_assert(const char *file, unsigned line)
+{
+    if (hal_debugger_connected()) {
+        __BKPT(0);
+    } else {
+        ble_ll_hci_ev_send_vs_assert(file, line); \
+    }
+
+    while (1);
+}
+#endif
+
 /**
  * Initialize the Link Layer. Should be called only once
  *


### PR DESCRIPTION
BLE_LL_ASSERT() now calls ble_ll_assert() which decides whether to break
or send hci_vs event. This significantly reduces code size since there's
no need to include all the branches and calls for each BLE_LL_ASSERT.

Also for hci_vs we only need base file name (i.e. without path) so we
can strip it - __buildiin_strrchr is evaluated during compilation.

This reduces code size for debug build with all features enabled by 5K.