### PR TITLE
nimble/ll: Adjust periodic sync HCI commands to 5.3

### DIFF
--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -2038,9 +2038,13 @@ ble_ll_set_sync_transfer_params(const uint8_t *cmdbuf, uint8_t len,
         goto done;
     }
 
-    if (cmd->mode > 0x02) {
-        rc = BLE_ERR_INV_HCI_CMD_PARMS;
-        goto done;
+    if ((MYNEWT_VAL(BLE_VERSION) >= 53 ) && (cmd->mode == 0x03)) {
+        /* We do not support ADI in periodic advertising thus cannot enable
+         * duplicate filtering.
+         */
+        return BLE_ERR_UNSUPPORTED;
+    } else if (cmd->mode > 0x02) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
     }
 
     skip = le16toh(cmd->skip);
@@ -2091,7 +2095,12 @@ ble_ll_set_default_sync_transfer_params(const uint8_t *cmdbuf, uint8_t len)
         return BLE_ERR_INV_HCI_CMD_PARMS;
     }
 
-    if (cmd->mode > 0x02) {
+    if ((MYNEWT_VAL(BLE_VERSION) >= 53 ) && (cmd->mode == 0x03)) {
+        /* We do not support ADI in periodic advertising thus cannot enable
+         * duplicate filtering.
+         */
+        return BLE_ERR_UNSUPPORTED;
+    } else if (cmd->mode > 0x02) {
         return BLE_ERR_INV_HCI_CMD_PARMS;
     }
 

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -709,6 +709,7 @@ struct ble_hci_le_ext_create_conn_cp {
 
 #define BLE_HCI_LE_PERIODIC_ADV_CREATE_SYNC_OPT_FILTER      0x01
 #define BLE_HCI_LE_PERIODIC_ADV_CREATE_SYNC_OPT_DISABLED    0x02
+#define BLE_HCI_LE_PERIODIC_ADV_CREATE_SYNC_OPT_DUPLICATES  0x04
 
 #define BLE_HCI_OCF_LE_PERIODIC_ADV_CREATE_SYNC          (0x0044)
 struct ble_hci_le_periodic_adv_create_sync_cp {


### PR DESCRIPTION
There are some new parameter values added in 5.3 to control duplicate
filtering. Since we do not support ADI in periodic advertising, we
simply return a proper error. Note that error is defined only for
HCI_LE_Periodic_Advertising_Create_Sync but we add the same behavior for
other commands also, as otherwise that would not make any sense.