### PR TITLE
nimble/host: Add missing legacy scan response event type.

### DIFF
--- a/nimble/host/src/ble_hs_hci_evt.c
+++ b/nimble/host/src/ble_hs_hci_evt.c
@@ -501,20 +501,21 @@ ble_hs_hci_evt_le_rd_rem_used_feat_complete(uint8_t subevent, const void *data,
 static int
 ble_hs_hci_decode_legacy_type(uint16_t evt_type)
 {
-     switch (evt_type) {
-     case BLE_HCI_LEGACY_ADV_EVTYPE_ADV_IND:
-         return BLE_HCI_ADV_RPT_EVTYPE_ADV_IND;
-     case BLE_HCI_LEGACY_ADV_EVTYPE_ADV_DIRECT_IND:
-         return BLE_HCI_ADV_RPT_EVTYPE_DIR_IND;
-     case BLE_HCI_LEGACY_ADV_EVTYPE_ADV_SCAN_IND:
-         return BLE_HCI_ADV_RPT_EVTYPE_SCAN_IND;
-     case BLE_HCI_LEGACY_ADV_EVTYPE_ADV_NONCON_IND:
-         return BLE_HCI_ADV_RPT_EVTYPE_NONCONN_IND;
-     case BLE_HCI_LEGACY_ADV_EVTYPE_SCAN_RSP_ADV_IND:
-         return BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP;
-     default:
-         return -1;
-     }
+    switch (evt_type) {
+    case BLE_HCI_LEGACY_ADV_EVTYPE_ADV_IND:
+        return BLE_HCI_ADV_RPT_EVTYPE_ADV_IND;
+    case BLE_HCI_LEGACY_ADV_EVTYPE_ADV_DIRECT_IND:
+        return BLE_HCI_ADV_RPT_EVTYPE_DIR_IND;
+    case BLE_HCI_LEGACY_ADV_EVTYPE_ADV_SCAN_IND:
+        return BLE_HCI_ADV_RPT_EVTYPE_SCAN_IND;
+    case BLE_HCI_LEGACY_ADV_EVTYPE_ADV_NONCON_IND:
+        return BLE_HCI_ADV_RPT_EVTYPE_NONCONN_IND;
+    case BLE_HCI_LEGACY_ADV_EVTYPE_SCAN_RSP_ADV_IND:
+    case BLE_HCI_LEGACY_ADV_EVTYPE_SCAN_RSP_ADV_SCAN_IND:
+        return BLE_HCI_ADV_RPT_EVTYPE_SCAN_RSP;
+    default:
+        return -1;
+    }
 }
 #endif
 


### PR DESCRIPTION
This adds a missing event type in the extended advertising legacy type decoding.
Without this, scan responses would be missed if the PDU was ADV_SCAN_IND.