### PR TITLE
minor fixes

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -476,9 +476,6 @@ struct ble_ll_acad_channel_map_update_ind {
 } __attribute__((packed));
 
 /*--- External API ---*/
-/* Initialize the Link Layer */
-void ble_ll_init(void);
-
 /* Reset the Link Layer */
 int ble_ll_reset(void);
 

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -47,6 +47,7 @@
 #include "ble_ll_conn_priv.h"
 #include "ble_ll_hci_priv.h"
 #include "ble_ll_priv.h"
+#include "hal/hal_system.h"
 
 #if MYNEWT_VAL(BLE_LL_DTM)
 #include "ble_ll_dtm_priv.h"
@@ -1788,7 +1789,7 @@ ble_ll_assert(const char *file, unsigned line)
  *
  * @return int
  */
-void
+static void
 ble_ll_init(void)
 {
     int rc;

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <assert.h>
+#include <stdlib.h>
 
 #include "syscfg/syscfg.h"
 


### PR DESCRIPTION
- ble_ll needs to include hal_system.h for hal_debugger_connected()
- ble_ll_sync needs stdlib.h for abs()
- ble_ll_init() can be static/private