### PR TITLE
fix init ordering

### DIFF
--- a/nimble/transport/pkg.yml
+++ b/nimble/transport/pkg.yml
@@ -52,9 +52,7 @@ pkg.deps.BLE_MONITOR_RTT:
 
 pkg.init:
     ble_transport_init: 250
-    ble_transport_hs_init:
-        - $after:ble_transport_init
-        - $before:ble_transport_ll_init
+    ble_transport_hs_init: 251
     ble_transport_ll_init:
         - $after:ble_transport_hs_init
 


### PR DESCRIPTION
When building an application (eg btshell),

ble_svc_gap_init() is at stage 301
ble_transport_hs_init() happens at the end after 1000

But ble_svc_gap_init calls (through ble_gatts_add_svcs) ble_hs_lock() that uses
the ble_hs_mutex. This mutex is only initialized in ble_hs_init() (via ble_transport_hs_init),
so this must be called first