### PR TITLE
nimble/transport: Remove unused syscfg

### DIFF
--- a/nimble/transport/emspi/syscfg.yml
+++ b/nimble/transport/emspi/syscfg.yml
@@ -28,16 +28,6 @@ syscfg.defs:
             # This is a host-only transport.
             - BLE_HOST
 
-    BLE_HCI_ACL_OUT_COUNT:
-        description: >
-            This count is used in creating a pool of elements used by the
-            code to enqueue various elements. In the case of the controller
-            only HCI, this number should be equal to the number of mbufs in
-            the msys pool. For host only, it is really dependent on the
-            number of ACL buffers that the controller tells the host it
-            has.
-        value: 12
-
     BLE_HCI_EMSPI_SPI_NUM:
         description: The index of the SPI device to use for HCI.
         value: 5

--- a/nimble/transport/usb/syscfg.yml
+++ b/nimble/transport/usb/syscfg.yml
@@ -17,12 +17,3 @@
 #
 
 syscfg.defs:
-    BLE_HCI_ACL_OUT_COUNT:
-        description: >
-            This count is used in creating a pool of elements used by the
-            code to enqueue various elements. In the case of the controller
-            only HCI, this number should be equal to the number of mbufs in
-            the msys pool. For host only, it is really dependent on the
-            number of ACL buffers that the controller tells the host it
-            has.
-        value: 12


### PR DESCRIPTION
No longer used in new transport architecture.