### PR TITLE
nimble/phy/nrf: Fix build with GCC 11.1

### DIFF
--- a/nimble/drivers/nrf51/src/ble_hw.c
+++ b/nimble/drivers/nrf51/src/ble_hw.c
@@ -88,11 +88,17 @@ ble_hw_get_public_addr(ble_addr_t *addr)
 int
 ble_hw_get_static_addr(ble_addr_t *addr)
 {
+    uint32_t addr_high;
+    uint32_t addr_low;
     int rc;
 
     if ((NRF_FICR->DEVICEADDRTYPE & 1) == 1) {
-        memcpy(addr->val, (void *)&NRF_FICR->DEVICEADDR[0], 4);
-        memcpy(&addr->val[4], (void *)&NRF_FICR->DEVICEADDR[1], 2);
+        addr_low = NRF_FICR->DEVICEADDR[0];
+        addr_high = NRF_FICR->DEVICEADDR[1];
+
+        memcpy(addr->val, &addr_low, 4);
+        memcpy(&addr->val[4], &addr_high, 2);
+
         addr->val[5] |= 0xc0;
         addr->type = BLE_ADDR_RANDOM;
         rc = 0;

--- a/nimble/drivers/nrf52/src/ble_hw.c
+++ b/nimble/drivers/nrf52/src/ble_hw.c
@@ -112,11 +112,17 @@ ble_hw_get_public_addr(ble_addr_t *addr)
 int
 ble_hw_get_static_addr(ble_addr_t *addr)
 {
+    uint32_t addr_high;
+    uint32_t addr_low;
     int rc;
 
     if ((NRF_FICR->DEVICEADDRTYPE & 1) == 1) {
-        memcpy(addr->val, (void *)&NRF_FICR->DEVICEADDR[0], 4);
-        memcpy(&addr->val[4], (void *)&NRF_FICR->DEVICEADDR[1], 2);
+        addr_low = NRF_FICR->DEVICEADDR[0];
+        addr_high = NRF_FICR->DEVICEADDR[1];
+
+        memcpy(addr->val, &addr_low, 4);
+        memcpy(&addr->val[4], &addr_high, 2);
+
         addr->val[5] |= 0xc0;
         addr->type = BLE_ADDR_RANDOM;
         rc = 0;

--- a/nimble/drivers/nrf5340/src/ble_hw.c
+++ b/nimble/drivers/nrf5340/src/ble_hw.c
@@ -83,11 +83,17 @@ ble_hw_get_public_addr(ble_addr_t *addr)
 int
 ble_hw_get_static_addr(ble_addr_t *addr)
 {
+    uint32_t addr_high;
+    uint32_t addr_low;
     int rc;
 
     if ((NRF_FICR_NS->DEVICEADDRTYPE & 1) == 1) {
-        memcpy(addr->val, (void *)&NRF_FICR_NS->DEVICEADDR[0], 4);
-        memcpy(&addr->val[4], (void *)&NRF_FICR_NS->DEVICEADDR[1], 2);
+        addr_low = NRF_FICR_NS->DEVICEADDR[0];
+        addr_high = NRF_FICR_NS->DEVICEADDR[1];
+
+        memcpy(addr->val, &addr_low, 4);
+        memcpy(&addr->val[4], &addr_high, 2);
+
         addr->val[5] |= 0xc0;
         addr->type = BLE_ADDR_RANDOM;
         rc = 0;


### PR DESCRIPTION
Looks like GCC 11.1 doesn't like current code. The looks OK though...

Error: repos/apache-mynewt-nimble/nimble/drivers/nrf52/src/ble_hw.c: In
    function 'ble_hw_get_static_addr':
repos/apache-mynewt-nimble/nimble/drivers/nrf52/src/ble_hw.c:118:9: error:
    'memcpy' offset [0, 3] is out of the bounds [0, 0] [-Werror=array-bounds]
  118 |         memcpy(addr->val, (void *)&NRF_FICR->DEVICEADDR[0], 4);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
repos/apache-mynewt-nimble/nimble/drivers/nrf52/src/ble_hw.c:119:9: error:
   'memcpy' offset [0, 1] is out of the bounds [0, 0] [-Werror=array-bounds]
  119 |         memcpy(&addr->val[4], (void *)&NRF_FICR->DEVICEADDR[1], 2);