### PR TITLE
porting: fix npl to allow NimBLE version bump in RIOT

### DIFF
--- a/nimble/drivers/nrf51/src/ble_phy.c
+++ b/nimble/drivers/nrf51/src/ble_phy.c
@@ -22,6 +22,8 @@
 #include <assert.h>
 #include "syscfg/syscfg.h"
 #include "os/os.h"
+/* Keep os_cputime explicitly to enable build on non-Mynewt platforms */
+#include "os/os_cputime.h"
 #include "ble/xcvr.h"
 #include "nimble/ble.h"
 #include "nimble/nimble_opt.h"

--- a/nimble/drivers/nrf52/src/ble_phy.c
+++ b/nimble/drivers/nrf52/src/ble_phy.c
@@ -2239,7 +2239,7 @@ void ble_phy_disable_dtm(void)
 void
 ble_phy_rfclk_enable(void)
 {
-#if MYNEWT
+#if MYNEWT || defined(RIOT_VERSION)
     nrf52_clock_hfxo_request();
 #else
     nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTART);
@@ -2249,7 +2249,7 @@ ble_phy_rfclk_enable(void)
 void
 ble_phy_rfclk_disable(void)
 {
-#if MYNEWT
+#if MYNEWT || defined(RIOT_VERSION)
     nrf52_clock_hfxo_release();
 #else
     nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTOP);

--- a/nimble/transport/include/nimble/transport.h
+++ b/nimble/transport/include/nimble/transport.h
@@ -29,6 +29,9 @@ extern "C" {
 
 struct os_mbuf;
 
+/* Initialization */
+void ble_transport_init(void);
+
 /* Allocators for supported data types */
 void *ble_transport_alloc_cmd(void);
 void *ble_transport_alloc_evt(int discardable);

--- a/nimble/transport/include/nimble/transport/monitor.h
+++ b/nimble/transport/include/nimble/transport/monitor.h
@@ -35,6 +35,8 @@ int ble_monitor_log(int level, const char *fmt, ...);
 static inline int
 ble_monitor_log(int level, const char *fmt, ...)
 {
+    (void)level;
+    (void)fmt;
     return 0;
 }
 

--- a/porting/nimble/include/hal/hal_system.h
+++ b/porting/nimble/include/hal/hal_system.h
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * @addtogroup HAL
+ * @{
+ *   @defgroup HALSystem HAL System
+ *   @{
+ */
+
+#ifndef H_HAL_SYSTEM_
+#define H_HAL_SYSTEM_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * System reset.
+ */
+void hal_system_reset(void) __attribute((noreturn));
+
+/**
+ * Called by bootloader to start loaded program.
+ */
+void hal_system_start(void *img_start) __attribute((noreturn));
+
+/**
+ * Called by split app loader to start the app program.
+ */
+void hal_system_restart(void *img_start) __attribute((noreturn));
+
+/**
+ * Returns non-zero if there is a HW debugger attached.
+ */
+int hal_debugger_connected(void);
+
+/**
+ * Reboot reason
+ */
+enum hal_reset_reason {
+    /** Power on Reset */
+    HAL_RESET_POR = 1,
+    /** Caused by Reset Pin */
+    HAL_RESET_PIN = 2,
+    /** Caused by Watchdog */
+    HAL_RESET_WATCHDOG = 3,
+    /** Soft reset, either system reset or crash */
+    HAL_RESET_SOFT = 4,
+    /** Low supply voltage */
+    HAL_RESET_BROWNOUT = 5,
+    /** Restart due to user request */
+    HAL_RESET_REQUESTED = 6,
+    /** System Off, wakeup on external interrupt*/
+    HAL_RESET_SYS_OFF_INT = 7,
+    /** Restart due to DFU */
+    HAL_RESET_DFU = 8,
+};
+
+/**
+ * Return the reboot reason
+ *
+ * @return A reboot reason
+ */
+enum hal_reset_reason hal_reset_cause(void);
+
+/**
+ * Return the reboot reason as a string
+ *
+ * @return String describing previous reset reason
+ */
+const char *hal_reset_cause_str(void);
+
+/**
+ * Starts clocks needed by system
+ */
+void hal_system_clock_start(void);
+
+/**
+ * Reset callback to be called before an reset happens inside hal_system_reset()
+ */
+void hal_system_reset_cb(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_HAL_SYSTEM_ */
+
+/**
+ *   @} HALSystem
+ * @} HAL
+ */

--- a/porting/nimble/include/os/os_mbuf.h
+++ b/porting/nimble/include/os/os_mbuf.h
@@ -132,12 +132,13 @@ struct os_mqueue {
     ((__om)->om_pkthdr_len >= sizeof (struct os_mbuf_pkthdr))
 
 /** Get a packet header pointer given an mbuf pointer */
-#define OS_MBUF_PKTHDR(__om) ((struct os_mbuf_pkthdr *)     \
-    (void *)((uint8_t *)&(__om)->om_data + sizeof(struct os_mbuf)))
+#define OS_MBUF_PKTHDR(__om) ((struct os_mbuf_pkthdr *)(uintptr_t)  \
+                              (void *)((uint8_t *)&(__om)->om_data  \
+                              + sizeof(struct os_mbuf)))
 
 /** Given a mbuf packet header pointer, return a pointer to the mbuf */
 #define OS_MBUF_PKTHDR_TO_MBUF(__hdr)   \
-     (struct os_mbuf *)(void *)((uint8_t *)(__hdr) - sizeof(struct os_mbuf))
+    (struct os_mbuf *)(uintptr_t)((uint8_t *)(__hdr) - sizeof(struct os_mbuf))
 
 /**
  * Gets the length of an entire mbuf chain.  The specified mbuf must have a

--- a/porting/nimble/src/nimble_port.c
+++ b/porting/nimble/src/nimble_port.c
@@ -24,7 +24,7 @@
 #include "nimble/nimble_port.h"
 #if NIMBLE_CFG_CONTROLLER
 #include "controller/ble_ll.h"
-#include "transport/ram/ble_hci_ram.h"
+#include "nimble/transport.h"
 #endif
 
 static struct ble_npl_eventq g_eventq_dflt;
@@ -46,7 +46,6 @@ nimble_port_init(void)
     ble_transport_hs_init();
 
 #if NIMBLE_CFG_CONTROLLER
-    ble_hci_ram_init();
 #ifndef RIOT_VERSION
     hal_timer_init(5, NULL);
     os_cputime_init(32768);


### PR DESCRIPTION
This PR is a collection of small fixes to NimBLEs porting layer to allow bumping the NimBLE version in RIOT to the newest NimBLE master.

The main changes are composed of:
- fixing the NimBLE porting initialization in `nimble_port.c` by adapting to the changes in the transport structure 
- add `hal_system.h`, as this file is required by the NimBLE controller now
- used the `nrf52_clock_x()` functions in `ble_phy.c` also for the RIOT port
- supress -Wcast-align compiler warnings in `os_mbuf.h` directly (instead of needing to patch the file in RIOT, which we did so far)