### PR TITLE
transport/usb: Enable BTH in TinyUSB stack

### DIFF
--- a/nimble/transport/usb/syscfg.yml
+++ b/nimble/transport/usb/syscfg.yml
@@ -17,3 +17,6 @@
 #
 
 syscfg.defs:
+
+syscfg.vals:
+    USBD_BTH: 1


### PR DESCRIPTION
Setting USBD_BTH to 1 is required to enable code in TinyUSB stack.
Due to newt limitation this value could not only be set target or
application.
Now USBD_BTH is defined by not set and can be set by this package.
So user can just specify USB transport and USBD_BTH will be set automatically.

This relies on https://github.com/apache/mynewt-core/pull/2834