### PR TITLE
host/ble_att_srv: fix ble_att_svr_check_perms for SC Only mode

### DIFF
--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -289,12 +289,18 @@ ble_att_svr_check_perms(uint16_t conn_handle, int is_read,
      * require it on level 4
      */
     if (MYNEWT_VAL(BLE_SM_SC_ONLY)) {
-        if (sec_state.key_size != 16 ||
-            !sec_state.authenticated ||
+        if (!sec_state.authenticated ||
             !sec_state.encrypted) {
-            return BLE_ATT_ERR_INSUFFICIENT_KEY_SZ;
+            *out_att_err = BLE_ATT_ERR_INSUFFICIENT_AUTHEN;
+            return BLE_HS_ATT_ERR(*out_att_err);
+        } else if (sec_state.authenticated &&
+                   sec_state.encrypted &&
+                   sec_state.key_size != 16) {
+            *out_att_err = BLE_ATT_ERR_INSUFFICIENT_KEY_SZ;
+            return BLE_HS_ATT_ERR(*out_att_err);
         }
     }
+
     if ((enc || authen) && !sec_state.encrypted) {
         ble_hs_lock();
         conn = ble_hs_conn_find(conn_handle);


### PR DESCRIPTION
If security is not good enough, return BLE_ATT_ERR_INSUFFICIENT_AUTHEN.
If security is enabled, but key is to short, return
BLE_ATT_ERR_INSUFFICIENT_KEY_SZ