### PR TITLE
controller: use OS specific PRNG for RIOT builds

### DIFF
--- a/nimble/controller/src/ble_ll_rand.c
+++ b/nimble/controller/src/ble_ll_rand.c
@@ -33,6 +33,10 @@
 #include "trng/trng.h"
 #endif
 
+#ifdef RIOT_VERSION
+#include "random.h"
+#endif
+
 #if BABBLESIM
 extern void tm_tick(void);
 #endif
@@ -134,6 +138,7 @@ ble_ll_rand_data_get(uint8_t *buf, uint8_t len)
 uint32_t
 ble_ll_rand(void)
 {
+#ifndef RIOT_VERSION
     static unsigned short xsubi[3];
     static bool init = true;
 
@@ -143,6 +148,9 @@ ble_ll_rand(void)
     }
 
     return (uint32_t) jrand48(xsubi);
+#else
+    return random_uint32();
+#endif
 }
 
 /**


### PR DESCRIPTION
Currently the controller is using jrand48() to generate pseudo
random numbers. For RIOT builds this commit switches to the RIOT
build-in PRNG API, as this has two benefits: i) it saves 500bytes
of flash and ii) jrand48() internally uses malloc, which has been
source to runtime failures in the past.