### PR TITLE
apps/blehci: Allow log/full implementation in syscfg

### DIFF
--- a/apps/blehci/pkg.yml
+++ b/apps/blehci/pkg.yml
@@ -24,7 +24,7 @@ pkg.keywords:
 
 pkg.deps:
     - "@apache-mynewt-core/sys/console"
-    - "@apache-mynewt-core/sys/log/stub"
+    - "@apache-mynewt-core/sys/log"
     - "@apache-mynewt-core/sys/stats/full"
     - "@apache-mynewt-core/kernel/os"
     - nimble/transport

--- a/apps/blehci/syscfg.yml
+++ b/apps/blehci/syscfg.yml
@@ -21,6 +21,7 @@ syscfg.vals:
     OS_MAIN_STACK_SIZE: 64
     # Stub console
     CONSOLE_MODE: stub
+    LOG_IMPLEMENTATION: stub
 
 syscfg.vals.'!BLE_TRANSPORT_NETCORE':
     # Use UART by default if not built on netcore


### PR DESCRIPTION
blehci had log/stub hardwired in application.
Now it can be swtiched to log/full in target if needed.