### PR TITLE
ble_conn: fix auth_pyld_timer memleak

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1991,10 +1991,6 @@ ble_ll_conn_sm_new(struct ble_ll_conn_sm *connsm)
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_PING)
     connsm->auth_pyld_tmo = BLE_LL_CONN_DEF_AUTH_PYLD_TMO;
     CONN_F_LE_PING_SUPP(connsm) = 1;
-    ble_npl_callout_init(&connsm->auth_pyld_timer,
-                    &g_ble_ll_data.ll_evq,
-                    ble_ll_conn_auth_pyld_timer_cb,
-                    connsm);
 #endif
 
     /* Add to list of active connections */

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -241,6 +241,7 @@ int ble_ll_conn_hci_subrate_req(const uint8_t *cmdbuf, uint8_t len,
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_PING)
 void ble_ll_conn_auth_pyld_timer_start(struct ble_ll_conn_sm *connsm);
+void ble_ll_conn_auth_pyld_timer_cb(struct ble_npl_event *ev);
 #else
 #define ble_ll_conn_auth_pyld_timer_start(x)
 #endif

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -3224,5 +3224,10 @@ ble_ll_ctrl_init_conn_sm(struct ble_ll_conn_sm *connsm)
 {
     ble_npl_callout_init(&connsm->ctrl_proc_rsp_timer, &g_ble_ll_data.ll_evq,
                          ble_ll_ctrl_proc_rsp_timer_cb, connsm);
+
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_PING)
+    ble_npl_callout_init(&connsm->auth_pyld_timer, &g_ble_ll_data.ll_evq,
+                         ble_ll_conn_auth_pyld_timer_cb, connsm);
+#endif
 }
 #endif


### PR DESCRIPTION
Every time a connection is made, the  ble_npl_callout_init() is done.
This causes a timer creation in some NPL cases (eg. FreeRTOS).
The alloc behaviour of auth_pyld_timer is now in sync with ctrl_proc_rsp_timer
that lives in the same struct.