### PR TITLE
nimble/ll: Fix race between aux scan and scan disable

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -880,10 +880,6 @@ ble_ll_scan_sm_stop(int chk_disable)
 
     OS_ENTER_CRITICAL(sr);
 
-#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
-    scansm->connsm = NULL;
-#endif
-
     /* Disable scanning state machine */
     scansm->scan_enabled = 0;
     scansm->restart_timer_needed = 0;
@@ -893,6 +889,10 @@ ble_ll_scan_sm_stop(int chk_disable)
         ble_ll_sched_rmv_elem_type(BLE_LL_SCHED_TYPE_SCAN_AUX, ble_ll_scan_aux_sched_remove);
         scansm->ext_scanning = 0;
     }
+#endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+    scansm->connsm = NULL;
 #endif
 
     /* Update backoff if we failed to receive scan response */

--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -1237,7 +1237,10 @@ ble_ll_scan_aux_rx_isr_end(struct os_mbuf *rxpdu, uint8_t crcok)
     rxinfo = &rxhdr->rxinfo;
     rxinfo->user_data = aux;
 
-    if (!crcok) {
+    /* It's possible that we received aux while scan was just being disabled in
+     * LL task. In such case simply ignore aux.
+     */
+    if (!crcok || !ble_ll_scan_enabled()) {
         rxinfo->flags |= BLE_MBUF_HDR_F_IGNORED;
         goto done;
     }


### PR DESCRIPTION
It's possible that scheduled aux is being received while scan sm is
being disabled. In such case aux should not be processed since it cannot
be handled properly anyway.