### PR TITLE
nimble/ll: Update manufacturer id settings

### DIFF
--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -1867,7 +1867,7 @@ ble_ll_ctrl_version_ind_make(struct ble_ll_conn_sm *connsm, uint8_t *pyld)
 
     /* Fill out response */
     pyld[0] = BLE_HCI_VER_BCS;
-    put_le16(pyld + 1, MYNEWT_VAL(BLE_LL_MFRG_ID));
+    put_le16(pyld + 1, MYNEWT_VAL(BLE_LL_MANUFACTURER_ID));
     put_le16(pyld + 3, BLE_LL_SUB_VERS_NR);
 }
 

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -211,7 +211,7 @@ ble_ll_hci_rd_local_version(uint8_t *rspbuf, uint8_t *rsplen)
     rsp->hci_ver = BLE_HCI_VER_BCS;
     rsp->hci_rev = 0;
     rsp->lmp_ver = BLE_LMP_VER_BCS;
-    rsp->manufacturer = htole16(MYNEWT_VAL(BLE_LL_MFRG_ID));
+    rsp->manufacturer = htole16(MYNEWT_VAL(BLE_LL_MANUFACTURER_ID));
     rsp->lmp_subver = 0;
 
     *rsplen = sizeof(*rsp);

--- a/nimble/controller/syscfg.defunct.yml
+++ b/nimble/controller/syscfg.defunct.yml
@@ -42,6 +42,10 @@ syscfg.defs:
         description: use BLE_LL_SCAN_AUX_SEGMENT_CNT
         value: 0
         deprecated: 1
+    BLE_LL_MFRG_ID:
+        description: use BLE_LL_MANUFACTURER_ID
+        value: 0x0B65
+        deprecated: 1
 
 # defunct settings (to be removed eventually)
     BLE_DEVICE:

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -75,10 +75,10 @@ syscfg.defs:
             number of completed packets event to the host. Rate is in milliseconds.
         value: 2000
 
-    BLE_LL_MFRG_ID:
+    BLE_LL_MANUFACTURER_ID:
         description: >
-            Manufacturer ID. Should be set to unique ID per manufacturer.
-        value: '0xFFFF'
+            Manufacturer ID, as assigned by Bluetooth SIG
+        value: MYNEWT_VAL(BLE_LL_MFRG_ID)
 
     # Configuration items for the number of duplicate advertisers and the
     # number of advertisers from which we have heard a scan response.


### PR DESCRIPTION
Rename BLE_LL_MFRG_ID to more readable BLE_LL_MANUFACTURER_ID and change
default value to id assigned to Apache Foundation (0x0B65).