### PR TITLE
nimble/ll: Fix direct addr type for ext adv reports

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -701,6 +701,14 @@ ble_ll_scan_send_adv_report(uint8_t pdu_type,
     }
     if (BLE_MBUF_HDR_TARGETA_RESOLVED(hdr)) {
         inita_type += 2;
+    } else {
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+        if (scansm->ext_scanning) {
+            if (ble_ll_is_rpa(inita, inita_type)) {
+                inita_type = 0xfe;
+            }
+        }
+#endif
     }
 #endif
 

--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -270,6 +270,8 @@ ble_ll_hci_ev_alloc_ext_adv_report_for_aux(struct ble_ll_scan_addr_data *addrd,
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PRIVACY)
         if (addrd->targeta_resolved) {
             report->dir_addr_type += 2;
+        } else if (ble_ll_is_rpa(addrd->targeta, addrd->targeta_type)) {
+            report->dir_addr_type = 0xfe;
         }
 #endif
     }
@@ -451,7 +453,12 @@ ble_ll_hci_ev_update_ext_adv_report_from_ext(struct ble_hci_ev *hci_ev,
             report->dir_addr_type = (ble_ll_scan_get_own_addr_type() & 1) + 2;
             memcpy(report->dir_addr, ble_ll_scan_aux_get_own_addr(), 6);
         } else {
-            report->dir_addr_type = !!(pdu_hdr & BLE_ADV_PDU_HDR_RXADD_MASK);
+            if (ble_ll_is_rpa(eh_data, pdu_hdr & BLE_ADV_PDU_HDR_RXADD_MASK)) {
+                report->dir_addr_type = 0xfe;
+            } else {
+                report->dir_addr_type = !!(pdu_hdr &
+                                           BLE_ADV_PDU_HDR_RXADD_MASK);
+            }
             memcpy(report->dir_addr, eh_data, 6);
         }
 #else


### PR DESCRIPTION
If direct address was an RPA and controller was not able to resolve it,
the direct address type in extended advertising report shall be set to
0xFE.

This fixes LL/SCN/DDI/BV-71-C.