### PR TITLE
Adjusting SC pairing

### DIFF
--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -2500,7 +2500,7 @@ ble_att_svr_rx_notify(uint16_t conn_handle, struct os_mbuf **rxom)
     /* All indications shall be confirmed, but only these with required
      * security established shall be pass to application
      */
-    if (MYNEWT_VAL(BLE_SM_SC_LVL) >= 2 && !sec_state.encrypted) {
+    if (MYNEWT_VAL(BLE_SM_LVL) >= 2 && !sec_state.encrypted) {
         return 0;
     }
 
@@ -2591,7 +2591,7 @@ ble_att_svr_rx_indicate(uint16_t conn_handle, struct os_mbuf **rxom)
     /* All indications shall be confirmed, but only these with required
      * security established shall be pass to application
      */
-    if (MYNEWT_VAL(BLE_SM_SC_LVL) >= 2 && !sec_state.encrypted) {
+    if (MYNEWT_VAL(BLE_SM_LVL) >= 2 && !sec_state.encrypted) {
         goto done;
     }
 

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -1832,10 +1832,12 @@ ble_sm_pair_req_rx(uint16_t conn_handle, struct os_mbuf **om,
         } else if (req->max_enc_key_size > BLE_SM_PAIR_KEY_SZ_MAX) {
             res->sm_err = BLE_SM_ERR_INVAL;
             res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_INVAL);
-        } else if (MYNEWT_VAL(BLE_SM_SC_ONLY) && (req->max_enc_key_size != BLE_SM_PAIR_KEY_SZ_MAX)) {
+        } else if (MYNEWT_VAL(BLE_SM_SC_ONLY) && (req->max_enc_key_size != BLE_SM_PAIR_KEY_SZ_MAX) &&
+                   !(req->authreq & BLE_SM_PAIR_AUTHREQ_SC)) {
             /* Fail if Secure Connections Only mode is on and remote does not meet
-            * key size requirements - MITM was checked in last step
-            */
+             * key size requirements - MITM was checked in last step. Fail if SC is not supported
+             * by peer.
+             */
             res->sm_err = BLE_SM_ERR_ENC_KEY_SZ;
             res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_ENC_KEY_SZ);
         } else if (!ble_sm_verify_auth_requirements(req->authreq)) {

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -1737,10 +1737,10 @@ ble_sm_verify_auth_requirements(uint8_t cmd)
             return false;
         }
     }
-    /* Fail if Secure Connections level forces MITM protection and remote does not
+    /* Fail if security level forces MITM protection and remote does not
      * support it
      */
-    if (MYNEWT_VAL(BLE_SM_SC_LVL) >= 3 && !(cmd & BLE_SM_PAIR_AUTHREQ_MITM)) {
+    if (MYNEWT_VAL(BLE_SM_LVL) >= 3 && !(cmd & BLE_SM_PAIR_AUTHREQ_MITM)) {
         return false;
     }
     return true;
@@ -1823,7 +1823,7 @@ ble_sm_pair_req_rx(uint16_t conn_handle, struct os_mbuf **om,
         if (conn->bhc_flags & BLE_HS_CONN_F_MASTER) {
             res->sm_err = BLE_SM_ERR_CMD_NOT_SUPP;
             res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_CMD_NOT_SUPP);
-        } else if (MYNEWT_VAL(BLE_SM_SC_LVL) == 1) {
+        } else if (MYNEWT_VAL(BLE_SM_LVL) == 1) {
             res->sm_err = BLE_SM_ERR_CMD_NOT_SUPP;
             res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_CMD_NOT_SUPP);
         } else if (req->max_enc_key_size < BLE_SM_PAIR_KEY_SZ_MIN) {

--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -108,7 +108,7 @@ syscfg.defs:
             - 'BLE_SM_SC if 1'
             - '!BLE_SM_LEGACY if 1'
 
-    BLE_SM_SC_LVL:
+    BLE_SM_LVL:
         description: >
           Force global Secure Connections mode 1 level. This level
           describes requirements for pairing response/request received
@@ -117,7 +117,8 @@ syscfg.defs:
                 authentication requirements is granted
           - 2 - allow to pair despite MITM being on or off
           - 3 - allow to pair only when MITM protection is on
-          - 4 - allow to pair only when 128 bit key is used and MITM is on
+          - 4 - allow to pair only with Secure Connections and
+                when 128 bit key is used and MITM is on
           When set to 0 level is no forced and pairing is allowed for all
           requests/responses with valid values (for example pairing will be
           rejected with key longer than 128 bits). Successful pairing with

--- a/porting/examples/linux/include/syscfg/syscfg.h
+++ b/porting/examples/linux/include/syscfg/syscfg.h
@@ -823,8 +823,8 @@
 #define MYNEWT_VAL_BLE_SM_SC_DEBUG_KEYS (0)
 #endif
 
-#ifndef MYNEWT_VAL_BLE_SM_SC_LVL
-#define MYNEWT_VAL_BLE_SM_SC_LVL (0)
+#ifndef MYNEWT_VAL_BLE_SM_LVL
+#define MYNEWT_VAL_BLE_SM_LVL (0)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_SM_SC_ONLY

--- a/porting/examples/linux_blemesh/include/syscfg/syscfg.h
+++ b/porting/examples/linux_blemesh/include/syscfg/syscfg.h
@@ -826,8 +826,8 @@
 #define MYNEWT_VAL_BLE_SM_SC_DEBUG_KEYS (0)
 #endif
 
-#ifndef MYNEWT_VAL_BLE_SM_SC_LVL
-#define MYNEWT_VAL_BLE_SM_SC_LVL (0)
+#ifndef MYNEWT_VAL_BLE_SM_LVL
+#define MYNEWT_VAL_BLE_SM_LVL (0)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_SM_SC_ONLY

--- a/porting/examples/nuttx/include/syscfg/syscfg.h
+++ b/porting/examples/nuttx/include/syscfg/syscfg.h
@@ -825,8 +825,8 @@
 #define MYNEWT_VAL_BLE_SM_SC_DEBUG_KEYS (0)
 #endif
 
-#ifndef MYNEWT_VAL_BLE_SM_SC_LVL
-#define MYNEWT_VAL_BLE_SM_SC_LVL (0)
+#ifndef MYNEWT_VAL_BLE_SM_LVL
+#define MYNEWT_VAL_BLE_SM_LVL (0)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_SM_SC_ONLY

--- a/porting/nimble/include/syscfg/syscfg.h
+++ b/porting/nimble/include/syscfg/syscfg.h
@@ -822,8 +822,8 @@
 #define MYNEWT_VAL_BLE_SM_SC_DEBUG_KEYS (0)
 #endif
 
-#ifndef MYNEWT_VAL_BLE_SM_SC_LVL
-#define MYNEWT_VAL_BLE_SM_SC_LVL (0)
+#ifndef MYNEWT_VAL_BLE_SM_LVL
+#define MYNEWT_VAL_BLE_SM_LVL (0)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_SM_SC_ONLY

--- a/porting/npl/riot/include/syscfg/syscfg.h
+++ b/porting/npl/riot/include/syscfg/syscfg.h
@@ -1584,8 +1584,8 @@
 #define MYNEWT_VAL_BLE_SM_SC_DEBUG_KEYS (0)
 #endif
 
-#ifndef MYNEWT_VAL_BLE_SM_SC_LVL
-#define MYNEWT_VAL_BLE_SM_SC_LVL (0)
+#ifndef MYNEWT_VAL_BLE_SM_LVL
+#define MYNEWT_VAL_BLE_SM_LVL (0)
 #endif
 
 #ifndef MYNEWT_VAL_BLE_SM_SC_ONLY


### PR DESCRIPTION
This contains 2 commits:
1. rename BLE_SM_SC_LVL to BLE_SM_LVL - this is not SC only setting, but legacy one too
2. Check for SC in pairing request when in SC Only mode