### PR TITLE
docs: Fix a few typos

### DIFF
--- a/apps/blehr/src/main.c
+++ b/apps/blehr/src/main.c
@@ -111,7 +111,7 @@ blehr_tx_hrate_stop(void)
     os_callout_stop(&blehr_tx_timer);
 }
 
-/* Reset heartrate measurment */
+/* Reset heartrate measurement */
 static void
 blehr_tx_hrate_reset(void)
 {

--- a/apps/ext_advertiser/src/main.c
+++ b/apps/ext_advertiser/src/main.c
@@ -421,7 +421,7 @@ static void start_periodic(void)
     ble_addr_t addr;
     int rc;
 
-    /* For periodic we use nstance with non-connectable advertising */
+    /* For periodic we use instance with non-connectable advertising */
     memset (&params, 0, sizeof(params));
 
     /* advertise using random addr */

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1733,7 +1733,7 @@ ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode)
      * and this can happen if we changed connection form uncoded to coded phy.
      * However, the lower bound for conn max tx time (all of them) depends on
      * current phy (uncoded/coded) but it always allows to send at least 27
-     * bytes of payload thus we alwyas return at least 27 from here.
+     * bytes of payload thus we always return at least 27 from here.
      *
      * Reference:
      * Core v5.0, Vol 6, Part B, section 4.5.10

--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -1303,7 +1303,7 @@ ble_att_svr_build_read_type_rsp(uint16_t conn_handle,
     *rxom = NULL;
     os_mbuf_adj(txom, OS_MBUF_PKTLEN(txom));
 
-    /* Allocate space for the respose base, but don't fill in the fields.  They
+    /* Allocate space for the response base, but don't fill in the fields.  They
      * get filled in at the end, when we know the value of the length field.
      */
 

--- a/nimble/host/src/ble_hs_mbuf.c
+++ b/nimble/host/src/ble_hs_mbuf.c
@@ -92,7 +92,7 @@ ble_hs_mbuf_l2cap_pkt(void)
 struct os_mbuf *
 ble_hs_mbuf_att_pkt(void)
 {
-    /* Prepare write request and response are the larget ATT commands which
+    /* Prepare write request and response are the largest ATT commands which
      * contain attribute data.
      */
      return ble_hs_mbuf_gen_pkt(BLE_HCI_DATA_HDR_SZ +

--- a/nimble/host/src/ble_hs_mbuf.c
+++ b/nimble/host/src/ble_hs_mbuf.c
@@ -95,9 +95,9 @@ ble_hs_mbuf_att_pkt(void)
     /* Prepare write request and response are the largest ATT commands which
      * contain attribute data.
      */
-     return ble_hs_mbuf_gen_pkt(BLE_HCI_DATA_HDR_SZ +
-                                BLE_L2CAP_HDR_SZ +
-                                BLE_ATT_PREP_WRITE_CMD_BASE_SZ);
+    return ble_hs_mbuf_gen_pkt(BLE_HCI_DATA_HDR_SZ +
+                               BLE_L2CAP_HDR_SZ +
+                               BLE_ATT_PREP_WRITE_CMD_BASE_SZ);
 }
 
 struct os_mbuf *

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -1222,7 +1222,7 @@ ble_sm_retrieve_ltk(uint16_t ediv, uint64_t rand, uint8_t peer_addr_type,
     struct ble_store_key_sec key_sec;
     int rc;
 
-    /* Tell applicaiton to look up LTK by peer address and ediv/rand pair. */
+    /* Tell application to look up LTK by peer address and ediv/rand pair. */
     memset(&key_sec, 0, sizeof key_sec);
     key_sec.peer_addr.type = peer_addr_type;
     memcpy(key_sec.peer_addr.val, peer_addr, 6);


### PR DESCRIPTION
There are small typos in:
- apps/blehr/src/main.c
- apps/ext_advertiser/src/main.c
- nimble/controller/src/ble_ll.c
- nimble/host/src/ble_att_svr.c
- nimble/host/src/ble_hs_mbuf.c
- nimble/host/src/ble_sm.c

Fixes:
- Should read `response` rather than `respose`.
- Should read `measurement` rather than `measurment`.
- Should read `largest` rather than `larget`.
- Should read `instance` rather than `nstance`.
- Should read `application` rather than `applicaiton`.
- Should read `always` rather than `alwyas`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md