### PR TITLE
fixed bug of find cli with CONTAINER_OF() in bt_mesh_proxy_addr_add

### DIFF
--- a/nimble/host/mesh/src/adv.c
+++ b/nimble/host/mesh/src/adv.c
@@ -135,7 +135,7 @@ static void bt_mesh_scan_cb(const bt_addr_le_t *addr, int8_t rssi,
 
 		switch (type) {
 		case BLE_HS_ADV_TYPE_MESH_MESSAGE:
-			bt_mesh_net_recv(buf, rssi, BT_MESH_NET_IF_ADV);
+			bt_mesh_net_recv(&buf, rssi, BT_MESH_NET_IF_ADV);
 			break;
 #if MYNEWT_VAL(BLE_MESH_PB_ADV)
 		case BLE_HS_ADV_TYPE_MESH_PROV:

--- a/nimble/host/mesh/src/net.c
+++ b/nimble/host/mesh/src/net.c
@@ -809,7 +809,7 @@ int bt_mesh_net_decode(struct os_mbuf *in, enum bt_mesh_net_if net_if,
 	return 0;
 }
 
-void bt_mesh_net_recv(struct os_mbuf *data, int8_t rssi,
+void bt_mesh_net_recv(struct os_mbuf **data, int8_t rssi,
 		      enum bt_mesh_net_if net_if)
 {
 	struct os_mbuf *buf = NET_BUF_SIMPLE(BT_MESH_NET_MAX_PDU_LEN);
@@ -823,7 +823,7 @@ void bt_mesh_net_recv(struct os_mbuf *data, int8_t rssi,
 		goto done;
 	}
 
-	if (bt_mesh_net_decode(data, net_if, &rx, buf)) {
+	if (bt_mesh_net_decode(*data, net_if, &rx, buf)) {
 		goto done;
 	}
 
@@ -835,7 +835,7 @@ void bt_mesh_net_recv(struct os_mbuf *data, int8_t rssi,
 
 	if ((MYNEWT_VAL(BLE_MESH_GATT_PROXY)) &&
 	    net_if == BT_MESH_NET_IF_PROXY) {
-		bt_mesh_proxy_addr_add(data, rx.ctx.addr);
+		bt_mesh_proxy_addr_add(*data, rx.ctx.addr);
 
 		if (bt_mesh_gatt_proxy_get() == BT_MESH_GATT_PROXY_DISABLED &&
 		    !rx.local_match) {

--- a/nimble/host/mesh/src/net.h
+++ b/nimble/host/mesh/src/net.h
@@ -293,7 +293,7 @@ int bt_mesh_net_decode(struct os_mbuf *in, enum bt_mesh_net_if net_if,
 int bt_mesh_net_send(struct bt_mesh_net_tx *tx, struct os_mbuf *buf,
 		     const struct bt_mesh_send_cb *cb, void *cb_data);
 
-void bt_mesh_net_recv(struct os_mbuf *data, int8_t rssi,
+void bt_mesh_net_recv(struct os_mbuf **data, int8_t rssi,
 		      enum bt_mesh_net_if net_if);
 
 void bt_mesh_net_loopback_clear(uint16_t net_idx);

--- a/nimble/host/mesh/src/proxy.h
+++ b/nimble/host/mesh/src/proxy.h
@@ -43,7 +43,7 @@ void bt_mesh_proxy_identity_start(struct bt_mesh_subnet *sub);
 void bt_mesh_proxy_identity_stop(struct bt_mesh_subnet *sub);
 
 bool bt_mesh_proxy_relay(struct os_mbuf *buf, uint16_t dst);
-void bt_mesh_proxy_addr_add(struct os_mbuf *buf, uint16_t addr);
+void bt_mesh_proxy_addr_add(struct os_mbuf **buf, uint16_t addr);
 
 int ble_mesh_proxy_gap_event(struct ble_gap_event *event, void *arg);
 int bt_mesh_proxy_init(void);

--- a/nimble/host/mesh/src/proxy_srv.c
+++ b/nimble/host/mesh/src/proxy_srv.c
@@ -284,7 +284,7 @@ static void proxy_msg_recv(struct bt_mesh_proxy_role *role)
 	switch (role->msg_type) {
 	case BT_MESH_PROXY_NET_PDU:
 		BT_DBG("Mesh Network PDU");
-		bt_mesh_net_recv(role->buf, 0, BT_MESH_NET_IF_PROXY);
+		bt_mesh_net_recv(&(role->buf), 0, BT_MESH_NET_IF_PROXY);
 		break;
 	case BT_MESH_PROXY_BEACON:
 		BT_DBG("Mesh Beacon PDU");
@@ -716,7 +716,7 @@ int bt_mesh_proxy_gatt_disable(void)
 	return 0;
 }
 
-void bt_mesh_proxy_addr_add(struct os_mbuf *buf, uint16_t addr)
+void bt_mesh_proxy_addr_add(struct os_mbuf **buf, uint16_t addr)
 {
 	struct bt_mesh_proxy_client *client;
 	struct bt_mesh_proxy_role *cli =

--- a/version.yml
+++ b/version.yml
@@ -19,4 +19,4 @@
 
 # Newt uses this file to determine the version of a checked out repo.
 # This should always be 0.0.0 in the master branch.
-repo.version: 0.0.0
+repo.version: 0.0.1


### PR DESCRIPTION
the ptr of CONTAINER_OF() macro should be field position address of type,
so, the buf parameter of bt_mesh_proxy_addr_add should be position address.