### PR TITLE
nimble/ll: Fix continuation events handling

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -310,7 +310,8 @@ struct ble_ll_conn_sm
     uint16_t subrate_base_event;
     uint16_t subrate_factor;
     uint16_t cont_num;
-    uint16_t last_pdu_event;
+    uint16_t cont_num_left;
+    uint8_t has_nonempty_pdu;
 
     union {
         struct ble_ll_conn_subrate_params subrate_trans;


### PR DESCRIPTION
Continuation events shall be only applied if the next event is not a
subrated event. Also the event counter shall be also updated only for
events with non-empty PDUs received.

This fixes LL/CON/PER/BV-143-C and LL/CON/CEN/BV-145-C.