### PR TITLE
porting/npl/nuttx: fix callout_handler implement

### DIFF
--- a/porting/npl/nuttx/src/os_callout.c
+++ b/porting/npl/nuttx/src/os_callout.c
@@ -44,21 +44,23 @@ callout_handler(pthread_addr_t arg)
 {
     struct ble_npl_callout *c;
 
-    pthread_mutex_lock(&callout_mutex);
-    while (!pending_callout) {
-      pthread_cond_wait(&callout_cond, &callout_mutex);
-    }
+    while (true) {
+        pthread_mutex_lock(&callout_mutex);
+        while (!pending_callout) {
+          pthread_cond_wait(&callout_cond, &callout_mutex);
+        }
 
-    c = pending_callout;
-    pending_callout = NULL;
-    pthread_mutex_unlock(&callout_mutex);
+        c = pending_callout;
+        pending_callout = NULL;
+        pthread_mutex_unlock(&callout_mutex);
 
-    /* Invoke callback */
+        /* Invoke callback */
 
-    if (c->c_evq) {
-        ble_npl_eventq_put(c->c_evq, &c->c_ev);
-    } else {
-        c->c_ev.ev_cb(&c->c_ev);
+        if (c->c_evq) {
+            ble_npl_eventq_put(c->c_evq, &c->c_ev);
+        } else {
+            c->c_ev.ev_cb(&c->c_ev);
+        }
     }
 
     return NULL;


### PR DESCRIPTION
callout_thread is working for all timeout callout, it need
an endless loop to catch all message.