### PR TITLE
apps/btshell: Add default own_addr_type check

### DIFF
--- a/apps/btshell/src/btshell.h
+++ b/apps/btshell/src/btshell.h
@@ -184,7 +184,7 @@ int btshell_l2cap_reconfig(uint16_t conn_handle, uint16_t mtu,
 
 int btshell_gap_event(struct ble_gap_event *event, void *arg);
 void btshell_sync_stats(uint16_t handle);
-
+uint8_t btshell_get_default_own_addr_type(void);
 /** GATT server. */
 #define GATT_SVR_SVC_ALERT_UUID               0x1811
 #define GATT_SVR_CHR_SUP_NEW_ALERT_CAT_UUID   0x2A47

--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -260,7 +260,7 @@ cmd_advertise_configure(int argc, char **argv)
 
     params.own_addr_type = parse_arg_kv_dflt("own_addr_type",
                                              cmd_own_addr_types,
-                                             BLE_OWN_ADDR_PUBLIC, &rc);
+                                             btshell_get_default_own_addr_type(), &rc);
     if (rc != 0) {
         console_printf("invalid 'own_addr_type' parameter\n");
         return rc;
@@ -473,7 +473,7 @@ static const struct shell_param advertise_configure_params[] = {
     {"directed", "directed advertising, usage: =[0-1], default: 0"},
     {"peer_addr_type", "usage: =[public|random|public_id|random_id], default: public"},
     {"peer_addr", "usage: =[XX:XX:XX:XX:XX:XX]"},
-    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public"},
+    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public if available, otherwise random"},
     {"channel_map", "usage: =[0x00-0xff], default: 0"},
     {"filter", "usage: =[none|scan|conn|both], default: none"},
     {"interval_min", "usage: =[0-UINT32_MAX], default: 0"},
@@ -615,7 +615,7 @@ cmd_advertise(int argc, char **argv)
     }
 
     own_addr_type = parse_arg_kv_dflt("own_addr_type", cmd_own_addr_types,
-                                      BLE_OWN_ADDR_PUBLIC, &rc);
+                                      btshell_get_default_own_addr_type(), &rc);
     if (rc != 0) {
         console_printf("invalid 'own_addr_type' parameter\n");
         return rc;
@@ -676,7 +676,7 @@ static const struct shell_param advertise_params[] = {
     {"discov", "discoverable mode, usage: =[non|ltd|gen], default: gen"},
     {"peer_addr_type", "usage: =[public|random|public_id|random_id], default: public"},
     {"peer_addr", "usage: =[XX:XX:XX:XX:XX:XX]"},
-    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public"},
+    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public if available, otherwise random"},
     {"channel_map", "usage: =[0x00-0xff], default: 0"},
     {"filter", "usage: =[none|scan|conn|both], default: none"},
     {"interval_min", "usage: =[0-UINT16_MAX], default: 0"},
@@ -752,7 +752,7 @@ cmd_connect(int argc, char **argv)
     }
 
     own_addr_type = parse_arg_kv_dflt("own_addr_type", cmd_own_addr_types,
-                                      BLE_OWN_ADDR_PUBLIC, &rc);
+                                      btshell_get_default_own_addr_type(), &rc);
     if (rc != 0) {
         console_printf("invalid 'own_addr_type' parameter\n");
         return rc;
@@ -969,7 +969,7 @@ static const struct shell_param connect_params[] = {
     {"extended", "usage: =[none|1M|coded|both|all], default: none"},
     {"peer_addr_type", "usage: =[public|random|public_id|random_id], default: public"},
     {"peer_addr", "usage: =[XX:XX:XX:XX:XX:XX]"},
-    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public"},
+    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public if available, otherwise random"},
     {"duration", "usage: =[1-INT32_MAX], default: 0"},
     {"scan_interval", "usage: =[0-UINT16_MAX], default: 0x0010"},
     {"scan_window", "usage: =[0-UINT16_MAX], default: 0x0010"},
@@ -1268,7 +1268,7 @@ cmd_scan(int argc, char **argv)
     }
 
     own_addr_type = parse_arg_kv_dflt("own_addr_type", cmd_own_addr_types,
-                                      BLE_OWN_ADDR_PUBLIC, &rc);
+                                      btshell_get_default_own_addr_type(), &rc);
     if (rc != 0) {
         console_printf("invalid 'own_addr_type' parameter\n");
         return rc;
@@ -1361,7 +1361,7 @@ static const struct shell_param scan_params[] = {
     {"window", "usage: =[0-UINT16_MAX], default: 0"},
     {"filter", "usage: =[no_wl|use_wl|no_wl_inita|use_wl_inita], default: no_wl"},
     {"nodups", "usage: =[0-1], default: 0"},
-    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public"},
+    {"own_addr_type", "usage: =[public|random|rpa_pub|rpa_rnd], default: public if available, otherwise random"},
     {"extended_duration", "usage: =[0-UINT16_MAX], default: 0"},
     {"extended_period", "usage: =[0-UINT16_MAX], default: 0"},
     {"longrange_interval", "usage: =[0-UINT16_MAX], default: 0"},

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -76,6 +76,8 @@
 bssnz_t struct btshell_conn btshell_conns[MYNEWT_VAL(BLE_MAX_CONNECTIONS)];
 int btshell_num_conns;
 
+static uint8_t default_own_addr_type;
+
 static os_membuf_t btshell_svc_mem[
     OS_MEMPOOL_SIZE(BTSHELL_MAX_SVCS, sizeof(struct btshell_svc))
 ];
@@ -2131,6 +2133,8 @@ btshell_on_sync(void)
         console_printf("Failed to set identity address\n");
     }
 
+    ble_hs_id_infer_auto(0, &default_own_addr_type);
+
 #if MYNEWT_VAL(BLE_SM_SC)
     int rc;
 
@@ -2567,6 +2571,12 @@ btshell_init_ext_adv_restart(void)
         ext_adv_restart[i].conn_handle = BLE_HS_CONN_HANDLE_NONE;
     }
 #endif
+}
+
+uint8_t
+btshell_get_default_own_addr_type(void)
+{
+    return default_own_addr_type;
 }
 
 /**


### PR DESCRIPTION
On default the application has taken "public" as own address type. Now the application checks if public addres is available on the device and if not, on default it uses "random" as own addres type.
It prevents advertising, scanning and connecting errors if the user won't change own address type in console, while working with a device, which has no public address available.