### PR TITLE
host/sm: fix check in ble_sm_pair_req_rx

### DIFF
--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -1832,8 +1832,8 @@ ble_sm_pair_req_rx(uint16_t conn_handle, struct os_mbuf **om,
         } else if (req->max_enc_key_size > BLE_SM_PAIR_KEY_SZ_MAX) {
             res->sm_err = BLE_SM_ERR_INVAL;
             res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_INVAL);
-        } else if (MYNEWT_VAL(BLE_SM_SC_ONLY) && (req->max_enc_key_size != BLE_SM_PAIR_KEY_SZ_MAX) &&
-                   !(req->authreq & BLE_SM_PAIR_AUTHREQ_SC)) {
+        } else if (MYNEWT_VAL(BLE_SM_SC_ONLY) && ((req->max_enc_key_size != BLE_SM_PAIR_KEY_SZ_MAX) ||
+                                                  !(req->authreq & BLE_SM_PAIR_AUTHREQ_SC))) {
             /* Fail if Secure Connections Only mode is on and remote does not meet
              * key size requirements - MITM was checked in last step. Fail if SC is not supported
              * by peer.


### PR DESCRIPTION
If SC_ONLY is enabled fail pairing request if either keysize is to small
OR SC is not supported by peer. Previously it was an AND, which means
both conditions must be true to fail pairing, which is not correct.