### PR TITLE
nimble/ll: Fix privacy handling when connecting to a new device

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -1275,17 +1275,17 @@ ble_ll_scan_rx_filter(uint8_t own_addr_type, uint8_t scan_filt_policy,
 
     switch (ble_ll_addr_subtype(addrd->adva, addrd->adva_type)) {
     case BLE_LL_ADDR_SUBTYPE_RPA:
-        if (addrd->rpa_index < 0) {
+        if (addrd->rpa_index >= 0) {
+            addrd->adva_resolved = 1;
+
+            /* Use resolved identity address as advertiser address */
+            rl = &g_ble_ll_resolv_list[addrd->rpa_index];
+            addrd->adv_addr = rl->rl_identity_addr;
+            addrd->adv_addr_type = rl->rl_addr_type;
             break;
         }
 
-        addrd->adva_resolved = 1;
-
-        /* Use resolved identity address as advertiser address */
-        rl = &g_ble_ll_resolv_list[addrd->rpa_index];
-        addrd->adv_addr = rl->rl_identity_addr;
-        addrd->adv_addr_type = rl->rl_addr_type;
-        break;
+        /* fall-through */
     case BLE_LL_ADDR_SUBTYPE_IDENTITY:
         /* If AdvA is an identity address, we need to check if that device was
          * added to RL in order to use proper privacy mode.


### PR DESCRIPTION
Using LL Privacy to initiate a connection to a new device (i.e. use 0x02
or 0x03 as own address type, peer is using an RPA) requires host to add
peer RPA and our IRK to resolving list. In this case we should allow to
match that RPA as an identity address on resolving list so we can use
proper privacy settings.

Note that this is a bit of an unspecified behavior, i.e. HCI LE Add
Device To Resolving List command parameters indicates that only identity
addresses shall be added to resolving list, but this does not seem to be
specified anywhere and there is no handling for non-identity address
specified. So basically we allow RPA-as-an-identity to be added to
resolving list, then if AdvA RPA does not match resolving list we just
fall through to see if corresponding entry in resolving list exists and
use it as identity address.