### PR TITLE
nimble/ll/css: Fix window offset for 1st connection event

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -2817,20 +2817,6 @@ ble_ll_conn_event_end(struct ble_npl_event *ev)
     /* Better be a connection state machine! */
     connsm = (struct ble_ll_conn_sm *)ble_npl_event_get_arg(ev);
     BLE_LL_ASSERT(connsm);
-    if (connsm->conn_state == BLE_LL_CONN_STATE_IDLE) {
-        /* That should not happen. If it does it means connection
-         * is already closed.
-         * Make sure LL state machine is in idle
-         */
-        STATS_INC(ble_ll_conn_stats, sched_end_in_idle);
-        BLE_LL_ASSERT(0);
-
-        /* Just in case */
-        ble_ll_state_set(BLE_LL_STATE_STANDBY);
-
-        ble_ll_scan_chk_resume();
-        return;
-    }
 
     /* Log event end */
     ble_ll_trace_u32x2(BLE_LL_TRACE_ID_CONN_EV_END, connsm->conn_handle,

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -516,9 +516,17 @@ ble_ll_sched_conn_central_new(struct ble_ll_conn_sm *connsm,
             max_delay = 0;
         }
 
-        ble_ll_sched_css_set_conn_anchor(connsm);
+        /* It's possible that calculated anchor point in current period has
+         * already passed, so just move to next period and recalculate.
+         */
+        connsm->css_period_idx--;
+        do {
+            connsm->css_period_idx++;
+            ble_ll_sched_css_set_conn_anchor(connsm);
+            sch->start_time =
+                    connsm->anchor_point - g_ble_ll_sched_offset_ticks;
+        } while (LL_TMR_LT(sch->start_time, orig_start_time));
 
-        sch->start_time = connsm->anchor_point - g_ble_ll_sched_offset_ticks;
         sch->end_time = connsm->anchor_point;
         sch->remainder = connsm->anchor_point_usecs;
 


### PR DESCRIPTION
Depending on timing, connection anchor point calculated for current
period and requested slot might have already passed at the time
advertising PDU is received and this causes window offset to be
calculated incorrectly. In such case we just move connection to next
period and recalculate anchor point again.