### PR TITLE
nimble/ll: Use OTA max rx time for connection event calculations

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -227,6 +227,7 @@ struct ble_ll_conn_sm
     uint16_t rem_max_rx_time;
     uint16_t eff_max_tx_time;
     uint16_t eff_max_rx_time;
+    uint16_t ota_max_rx_time;
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
     uint16_t host_req_max_tx_time;
 #endif


### PR DESCRIPTION
Using effective max rx time for connection event calculations is not
optimal since it's possible that time to rx packet with max octets
payload is shorter that effective max rx time. Instead, we should
calculate time it takes to rx packaet with effectiva max octets payload
and use it if less than effective max rx time.