### PR TITLE
nimble/phy/nrf: Add PA/LNA turn-on time configuration

### DIFF
--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -414,6 +414,10 @@ syscfg.defs:
             GPIO pin number to control PA. Pin is set to high state when PA
             should be enabled.
         value: -1
+    BLE_LL_PA_TURN_ON_US:
+        description: >
+            Time required for PA to turn on, in microseconds.
+        value: 1
     BLE_LL_LNA:
         description: Enable LNA support
         value: 0
@@ -422,6 +426,10 @@ syscfg.defs:
             GPIO pin number to control LNA. Pin is set to high state when LNA
             should be enabled.
         value: -1
+    BLE_LL_LNA_TURN_ON_US:
+        description: >
+            Time required for LNA to turn on, in microseconds.
+        value: 1
 
     BLE_LL_SYSINIT_STAGE:
         description: >

--- a/nimble/drivers/nrf5340/src/ble_phy.c
+++ b/nimble/drivers/nrf5340/src/ble_phy.c
@@ -392,6 +392,21 @@ ble_phy_plna_disable_lna(void)
 #endif
 }
 
+static void
+ble_phy_plna_force_disable(void)
+{
+#if PLNA_SINGLE_GPIO
+    NRF_GPIOTE_NS->TASKS_CLR[plna_idx] = 1;
+#else
+#if MYNEWT_VAL(BLE_LL_PA)
+    NRF_GPIOTE_NS->TASKS_CLR[plna_pa_idx] = 1;
+#endif
+#if MYNEWT_VAL(BLE_LL_LNA)
+    NRF_GPIOTE_NS->TASKS_CLR[plna_lna_idx] = 1;
+#endif
+#endif
+}
+
 int
 ble_phy_get_cur_phy(void)
 {
@@ -1973,7 +1988,7 @@ ble_phy_disable(void)
 
     ble_phy_stop_usec_timer();
     ble_phy_disable_irq_and_ppi();
-
+    ble_phy_plna_force_disable();
     ble_phy_dbg_clear_pins();
 }
 

--- a/nimble/drivers/nrf5340/src/ble_phy.c
+++ b/nimble/drivers/nrf5340/src/ble_phy.c
@@ -1386,6 +1386,7 @@ ble_phy_init(void)
     /* Toggle peripheral power to reset (just in case) */
     NRF_RADIO_NS->POWER = 0;
     NRF_RADIO_NS->POWER = 1;
+    *(volatile uint32_t *)(NRF_RADIO_NS_BASE + 0x774) = (*(volatile uint32_t* )(NRF_RADIO_NS_BASE + 0x774) & 0xfffffffe) | 0x01000000;
 
     /* Errata 16 - RADIO: POWER register is not functional
      * Workaround: Reset all RADIO registers in firmware.


### PR DESCRIPTION
This allows to define PA/LNA turn-on time which allows it to fully turn
on before actual rx/tx. Currently only supported by nRF53 PHY.