### PR TITLE
nimble/ll/css: Add vs event to indicate slot change

### DIFF
--- a/nimble/controller/include/controller/ble_ll_ctrl.h
+++ b/nimble/controller/include/controller/ble_ll_ctrl.h
@@ -350,6 +350,11 @@ void ble_ll_hci_ev_sca_update(struct ble_ll_conn_sm *connsm,
 void ble_ll_hci_ev_subrate_change(struct ble_ll_conn_sm *connsm, uint8_t status);
 #endif
 
+#if MYNEWT_VAL(BLE_LL_HCI_VS_CONN_STRICT_SCHED)
+void ble_ll_hci_ev_send_vs_css_slot_changed(uint16_t conn_handle,
+                                            uint16_t slot_idx);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -2496,6 +2496,11 @@ ble_ll_conn_next_event(struct ble_ll_conn_sm *connsm)
                 ble_ll_sched_css_set_conn_anchor(connsm);
                 anchor_calc_for_css = 0;
             }
+
+#if MYNEWT_VAL(BLE_LL_HCI_VS_CONN_STRICT_SCHED)
+            ble_ll_hci_ev_send_vs_css_slot_changed(connsm->conn_handle,
+                                                   connsm->css_slot_idx);
+#endif
         }
 #endif
 

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1126,6 +1126,16 @@ struct ble_hci_vs_css_set_conn_slot_cp {
     uint16_t conn_handle;
     uint16_t slot_idx;
 } __attribute__((packed));
+#define BLE_HCI_VS_CSS_OP_READ_CONN_SLOT                0x05
+struct ble_hci_vs_css_read_conn_slot_cp {
+    uint8_t opcode;
+    uint16_t conn_handle;
+} __attribute__((packed));
+struct ble_hci_vs_css_read_conn_slot_rp {
+    uint8_t opcode;
+    uint16_t conn_handle;
+    uint16_t slot_idx;
+} __attribute__((packed));
 
 #define BLE_HCI_OCF_LE_ENH_READ_TRANSMIT_POWER_LEVEL     (0x0076)
 struct ble_hci_le_enh_read_transmit_power_level_cp {

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1555,11 +1555,18 @@ struct ble_hci_ev_auth_pyld_tmo {
 
 #define BLE_HCI_EVCODE_SAM_STATUS_CHG       (0x58)
 
-#define BLE_HCI_EVCODE_VS_DEBUG             (0xFF)
-struct ble_hci_ev_vs_debug {
+#define BLE_HCI_EVCODE_VS                   (0xff)
+struct ble_hci_ev_vs {
     uint8_t id;
     uint8_t data[0];
 } __attribute__((packed));
+
+#define BLE_HCI_VS_SUBEV_ID_ASSERT              (0x01)
+#define BLE_HCI_VS_SUBEV_ID_CSS_SLOT_CHANGED    (0x02)
+struct ble_hci_ev_vs_css_slot_changed {
+    uint16_t conn_handle;
+    uint16_t slot_idx;
+};
 
 /* LE sub-event codes */
 #define BLE_HCI_LE_SUBEV_CONN_COMPLETE          (0x01)


### PR DESCRIPTION
If hci_vs support is enabled for CSS, an event will be sent every time
slot chanes for a connection. Event is also sent after connection is
created (after conn complete and csa events).