### PR TITLE
porting/nimble/include: Add check of macro

### DIFF
--- a/porting/nimble/include/os/endian.h
+++ b/porting/nimble/include/os/endian.h
@@ -53,6 +53,14 @@ extern "C" {
      (((x) & 0x00ff) << 8)))
 #endif
 
+#ifndef __BYTE_ORDER__ 
+#error  "Please define __BYTE_ORDER__ on complier"
+#endif
+
+#ifndef __ORDER_BIG_ENDIAN__ 
+#error  "Please define __ORDER_BIG_ENDIAN__ on complier"
+#endif
+
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
 #ifndef ntohll


### PR DESCRIPTION
There isn't macro __BYTE_ORDER__ and __ORDER_BIG_ENDIAN__ on other compiler like KEIL or IAR. In that case, the complier will complier without error, but the HCI cmd will be BIG_ENDIAN as default which is wrong on ARM Cortex-m little endian platform.