### PR TITLE
nimble/ll: Fix own address type check during scan

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -1333,7 +1333,8 @@ ble_ll_scan_rx_filter(uint8_t own_addr_type, uint8_t scan_filt_policy,
             }
 
             /* Ignore if not directed to us */
-            if (!ble_ll_is_our_devaddr(addrd->targeta, addrd->targeta_type)) {
+            if ((addrd->targeta_type != (own_addr_type & 0x01)) ||
+                !ble_ll_is_our_devaddr(addrd->targeta, addrd->targeta_type)) {
                 return -1;
             }
             break;
@@ -1347,7 +1348,8 @@ ble_ll_scan_rx_filter(uint8_t own_addr_type, uint8_t scan_filt_policy,
 #else
     /* Ignore if not directed to us */
     if (addrd->targeta &&
-        !ble_ll_is_our_devaddr(addrd->targeta, addrd->targeta_type)) {
+        ((addrd->targeta_type != (own_addr_type & 0x01)) ||
+         !ble_ll_is_our_devaddr(addrd->targeta, addrd->targeta_type))) {
         return -1;
     }
 


### PR DESCRIPTION
We did not check own address type requested for scan when filtering so
we matched random address even if public address was requested and vv.

This fixes LL/DDI/SCN/BV-71-C.