### PR TITLE
nimble/host: Fix host event buffer count

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -30,7 +30,8 @@
 #include "nimble/nimble_port.h"
 #endif
 
-#define BLE_HS_HCI_EVT_COUNT    MYNEWT_VAL(BLE_TRANSPORT_EVT_COUNT)
+#define BLE_HS_HCI_EVT_COUNT    (MYNEWT_VAL(BLE_TRANSPORT_EVT_COUNT) + \
+                                 MYNEWT_VAL(BLE_TRANSPORT_EVT_DISCARDABLE_COUNT))
 
 static void ble_hs_event_rx_hci_ev(struct ble_npl_event *ev);
 #if NIMBLE_BLE_CONNECT


### PR DESCRIPTION
Fixes the problem of not putting events such as, for example ble_hs_hci_evt_le_scan_timeout to the queue.