### PR TITLE
nimble/ll: Fix ext adv report status when failed to schedule chain scan

### DIFF
--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -564,6 +564,8 @@ ble_ll_hci_ev_send_ext_adv_report(struct os_mbuf *rxpdu,
             } else {
                 report->evt_type |= BLE_HCI_ADV_DATA_STATUS_TRUNCATED;
             }
+        } else if (rxinfo->flags & BLE_MBUF_HDR_F_AUX_PTR_FAILED) {
+            report->evt_type |= BLE_HCI_ADV_DATA_STATUS_TRUNCATED;
         }
 
         switch (report->evt_type & BLE_HCI_ADV_DATA_STATUS_MASK) {
@@ -1662,6 +1664,7 @@ ble_ll_scan_aux_rx_pkt_in(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *rxhdr)
                                    aux->aux_ptr);
         if (rc < 0) {
             rxinfo->flags &= ~BLE_MBUF_HDR_F_AUX_PTR_WAIT;
+            rxinfo->flags |= BLE_MBUF_HDR_F_AUX_PTR_FAILED;
         }
     }
 

--- a/nimble/include/nimble/ble.h
+++ b/nimble/include/nimble/ble.h
@@ -101,7 +101,7 @@ struct ble_mbuf_hdr_rxinfo
 #define BLE_MBUF_HDR_F_EXT_ADV          (0x0800)
 #define BLE_MBUF_HDR_F_RESOLVED         (0x0400)
 #define BLE_MBUF_HDR_F_AUX_PTR_WAIT     (0x0200)
-#define BLE_MBUF_HDR_F_AUX_INVALID      (0x0100)
+#define BLE_MBUF_HDR_F_AUX_PTR_FAILED   (0x0100)
 #define BLE_MBUF_HDR_F_CRC_OK           (0x0080)
 #define BLE_MBUF_HDR_F_DEVMATCH         (0x0040)
 #define BLE_MBUF_HDR_F_MIC_FAILURE      (0x0020)
@@ -145,9 +145,6 @@ struct ble_mbuf_hdr
 
 #define BLE_MBUF_HDR_SCAN_RSP_RXD(hdr) \
     (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_SCAN_RSP_RXD))
-
-#define BLE_MBUF_HDR_AUX_INVALID(hdr) \
-    (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_AUX_INVALID))
 
 #define BLE_MBUF_HDR_WAIT_AUX(hdr)      \
     (!!((hdr)->rxinfo.flags & BLE_MBUF_HDR_F_AUX_PTR_WAIT))


### PR DESCRIPTION
If aux chain scan failed to schedule, we simply remove aux ptr flag
which results in "complete" event being sent instead of "truncated". We
should mark PDU accordingly and send "truncated" if this is last aux
chain scanned, but there were more to come.

This fixes LL/DDI/SCN/BV-62-C.