### PR TITLE
nimble/ll: Make sane slot reservation for aux scan

### DIFF
--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -165,7 +165,8 @@ int ble_ll_sched_aux_scan(struct ble_mbuf_hdr *ble_hdr,
                           struct ble_ll_aux_data *aux_scan);
 
 int ble_ll_sched_scan_aux(struct ble_ll_sched_item *sch, uint32_t pdu_time,
-                          uint8_t pdu_time_rem, uint32_t offset_us);
+                          uint8_t pdu_time_rem, uint32_t offset_us,
+                          uint32_t max_aux_time_us);
 #endif
 
 /* Stop the scheduler */

--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -746,6 +746,7 @@ ble_ll_scan_aux_sched(struct ble_ll_scan_aux_data *aux, uint32_t pdu_time,
                       uint8_t pdu_time_rem, uint32_t aux_ptr)
 {
     uint32_t offset_us;
+    uint32_t max_aux_time_us;
     int rc;
 
     rc = ble_ll_scan_aux_parse_aux_ptr(aux, aux_ptr, &offset_us);
@@ -753,7 +754,11 @@ ble_ll_scan_aux_sched(struct ble_ll_scan_aux_data *aux, uint32_t pdu_time,
         return -1;
     }
 
-    rc = ble_ll_sched_scan_aux(&aux->sch, pdu_time, pdu_time_rem, offset_us);
+    max_aux_time_us = ble_ll_pdu_tx_time_get(BLE_LL_MAX_PAYLOAD_LEN,
+                                             ble_ll_phy_to_phy_mode(aux->sec_phy, 0));
+
+    rc = ble_ll_sched_scan_aux(&aux->sch, pdu_time, pdu_time_rem, offset_us,
+                               max_aux_time_us);
     if (rc < 0) {
         return -1;
     }

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -1099,7 +1099,8 @@ ble_ll_sched_next_time(uint32_t *next_event_time)
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 int
 ble_ll_sched_scan_aux(struct ble_ll_sched_item *sch, uint32_t pdu_time,
-                      uint8_t pdu_time_rem, uint32_t offset_us)
+                      uint8_t pdu_time_rem, uint32_t offset_us,
+                      uint32_t max_aux_time_us)
 {
     uint32_t offset_ticks;
     os_sr_t sr;
@@ -1108,10 +1109,10 @@ ble_ll_sched_scan_aux(struct ble_ll_sched_item *sch, uint32_t pdu_time,
     offset_us += pdu_time_rem;
     offset_ticks = ble_ll_tmr_u2t(offset_us);
 
-    sch->start_time = pdu_time + offset_ticks - g_ble_ll_sched_offset_ticks;
+    sch->start_time = pdu_time + offset_ticks;
     sch->remainder = offset_us - ble_ll_tmr_t2u(offset_ticks);
-    /* TODO: make some sane slot reservation */
-    sch->end_time = sch->start_time + ble_ll_tmr_u2t(5000);
+    sch->end_time = sch->start_time + ble_ll_tmr_u2t_up(max_aux_time_us);
+    sch->start_time -= g_ble_ll_sched_offset_ticks;
 
     OS_ENTER_CRITICAL(sr);
 


### PR DESCRIPTION
We always reserved 5ms slot for aux scan which is way too long for
either 1M or 2M scan. As a result we are sometimes not able to scan
complete chains if there are many concurrent instances being scanned.

Instead, reserve slot for max pdu possible on secondary phy.