### PR TITLE
nimble/ll: Fix aux scan timing

### DIFF
--- a/nimble/controller/include/controller/ble_ll_scan.h
+++ b/nimble/controller/include/controller/ble_ll_scan.h
@@ -235,11 +235,6 @@ void ble_ll_scan_wfr_timer_exp(void);
 /* Called when scan could be interrupted  */
 void ble_ll_scan_interrupted(struct ble_ll_scan_sm *scansm);
 
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-/* Called to parse extended advertising*/
-void ble_ll_scan_end_adv_evt(struct ble_ll_aux_data *aux_data);
-#endif
-
 /* Called to halt currently running scan */
 void ble_ll_scan_halt(void);
 

--- a/nimble/controller/include/controller/ble_ll_scan_aux.h
+++ b/nimble/controller/include/controller/ble_ll_scan_aux.h
@@ -29,8 +29,8 @@ extern "C" {
 struct ble_ll_scan_aux_data;
 
 void ble_ll_scan_aux_init(void);
-int ble_ll_scan_aux_sched(struct ble_ll_scan_aux_data *aux, uint32_t pdu_time,
-                          uint8_t pdu_time_rem, uint32_t aux_ptr);
+int ble_ll_scan_aux_sched(struct ble_ll_scan_aux_data *aux, uint32_t pdu_ticks,
+                          uint8_t pdu_rem_us, uint32_t aux_ptr);
 int ble_ll_scan_aux_rx_isr_start(uint8_t pdu_type, struct ble_mbuf_hdr *rxhdr);
 int ble_ll_scan_aux_rx_isr_end(struct os_mbuf *rxpdu, uint8_t crcok);
 void ble_ll_scan_aux_rx_pkt_in(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *rxhdr);

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -172,12 +172,6 @@ int ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm * connsm);
 int ble_ll_sched_next_time(uint32_t *next_event_time);
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-struct ble_ll_scan_sm;
-struct ble_ll_aux_data;
-int ble_ll_sched_aux_scan(struct ble_mbuf_hdr *ble_hdr,
-                          struct ble_ll_scan_sm *scansm,
-                          struct ble_ll_aux_data *aux_scan);
-
 int ble_ll_sched_scan_aux(struct ble_ll_sched_item *sch, uint32_t pdu_time,
                           uint8_t pdu_time_rem, uint32_t offset_us,
                           uint32_t max_aux_time_us);

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -172,9 +172,7 @@ int ble_ll_sched_conn_reschedule(struct ble_ll_conn_sm * connsm);
 int ble_ll_sched_next_time(uint32_t *next_event_time);
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-int ble_ll_sched_scan_aux(struct ble_ll_sched_item *sch, uint32_t pdu_time,
-                          uint8_t pdu_time_rem, uint32_t offset_us,
-                          uint32_t max_aux_time_us);
+int ble_ll_sched_scan_aux(struct ble_ll_sched_item *sch);
 #endif
 
 /* Stop the scheduler */

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -362,11 +362,6 @@ ble_ll_scan_get_ext_adv_report(struct ext_adv_report *copy_from)
 
     return hci_ev;
 }
-
-void
-ble_ll_scan_end_adv_evt(struct ble_ll_aux_data *aux_data)
-{
-}
 #endif
 
 void

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -1119,21 +1119,10 @@ ble_ll_sched_next_time(uint32_t *next_event_time)
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 int
-ble_ll_sched_scan_aux(struct ble_ll_sched_item *sch, uint32_t pdu_time,
-                      uint8_t pdu_time_rem, uint32_t offset_us,
-                      uint32_t max_aux_time_us)
+ble_ll_sched_scan_aux(struct ble_ll_sched_item *sch)
 {
-    uint32_t offset_ticks;
     os_sr_t sr;
     int rc;
-
-    offset_us += pdu_time_rem;
-    offset_ticks = ble_ll_tmr_u2t(offset_us);
-
-    sch->start_time = pdu_time + offset_ticks;
-    sch->remainder = offset_us - ble_ll_tmr_t2u(offset_ticks);
-    sch->end_time = sch->start_time + ble_ll_tmr_u2t_up(max_aux_time_us);
-    sch->start_time -= g_ble_ll_sched_offset_ticks;
 
     OS_ENTER_CRITICAL(sr);
 


### PR DESCRIPTION
We should include clock drift due to sleep clock accuracy and jitter
when calculating aux scan start time (Core 5.3, Vol 6, Part B, 4.2.2).

Slot duration calculation should also include the above and possible
drift due to offset accuracy.