### PR TITLE
nimble/phy/nrf: Fix setting -3dBm power on nRF5340

### DIFF
--- a/nimble/drivers/nrf5340/src/ble_phy.c
+++ b/nimble/drivers/nrf5340/src/ble_phy.c
@@ -1817,7 +1817,7 @@ ble_phy_txpower_round(int dbm)
     }
 
     if (dbm >= (int8_t)RADIO_TXPOWER_TXPOWER_Neg3dBm) {
-        return (int8_t)RADIO_TXPOWER_TXPOWER_Neg4dBm;
+        return (int8_t)RADIO_TXPOWER_TXPOWER_Neg3dBm;
     }
 
     if (dbm >= (int8_t)RADIO_TXPOWER_TXPOWER_Neg4dBm) {


### PR DESCRIPTION
There was a typo which would result in -4 dBm being set instead.