### PR TITLE
nimble/ll: Fix not setting TX power in HCI VS command

### DIFF
--- a/nimble/controller/src/ble_ll_hci_vs.c
+++ b/nimble/controller/src/ble_ll_hci_vs.c
@@ -128,6 +128,8 @@ ble_ll_hci_vs_set_tx_power(uint16_t ocf, const uint8_t *cmdbuf, uint8_t cmdlen,
         g_ble_ll_tx_power = ble_phy_txpower_round(cmd->tx_power);
     }
 
+    ble_phy_txpwr_set(g_ble_ll_tx_power);
+
     rsp->tx_power = g_ble_ll_tx_power;
     *rsplen = sizeof(*rsp);
 


### PR DESCRIPTION
PHY was not configured to use new TX power immediatelly. This resulted
in new TX power being used only after advertising event ended.