### PR TITLE
apps/peripheral: Fix not saving conn_handle after connection

### DIFF
--- a/apps/peripheral/src/main.c
+++ b/apps/peripheral/src/main.c
@@ -50,6 +50,7 @@ adv_event(struct ble_gap_event *event, void *arg)
         MODLOG_DFLT(INFO, "connection %s; status=%d\n",
                     event->connect.status == 0 ? "established" : "failed",
                     event->connect.status);
+        conn_handle = event->connect.conn_handle;
         break;
     case BLE_GAP_EVENT_CONN_UPDATE_REQ:
         /* connected device requests update of connection parameters,


### PR DESCRIPTION
Even though conn_handle is defined and later used in
connection params update request event callback, it was
never initialized with a proper value.