### PR TITLE
 nimble/ll: Add support for non-LL items in scheduler

### DIFF
--- a/nimble/controller/include/controller/ble_ll.h
+++ b/nimble/controller/include/controller/ble_ll.h
@@ -237,6 +237,9 @@ extern STATS_SECT_DECL(ble_ll_stats) ble_ll_stats;
 #if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER) && MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 #define BLE_LL_STATE_SCAN_AUX       (7)
 #endif
+#if MYNEWT_VAL(BLE_LL_EXT)
+#define BLE_LL_STATE_EXTERNAL       (8)
+#endif
 
 /* LL Features */
 #define BLE_LL_FEAT_LE_ENCRYPTION       (0x0000000001)

--- a/nimble/controller/include/controller/ble_ll_ext.h
+++ b/nimble/controller/include/controller/ble_ll_ext.h
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BLE_LL_EXT_
+#define H_BLE_LL_EXT_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if MYNEWT_VAL(BLE_LL_EXT)
+
+/* Quickstart guide:
+ * - create scheduling item with sched_type set to BLE_LL_SCHED_EXTERNAL
+ * - use sched_ext_type to differentiate between different types of custom items
+ * - insert into scheduler using ble_ll_sched_insert()
+ * - set LL state to BLE_LL_STATE_EXTERNAL when item is being executed
+ * - set LL state back to BLE_LL_STATE_IDLE when item is done
+ */
+
+struct ble_ll_sched_item;
+
+/* Called when LL is in "external" state and PHY starts to receive a PDU */
+int ble_ll_ext_rx_isr_start(uint8_t pdu_type, struct ble_mbuf_hdr *rxhdr);
+/* Called when LL is in "external" state and PHY finished to receive a PDU */
+int ble_ll_ext_rx_isr_end(uint8_t *rxbuf, struct ble_mbuf_hdr *rxhdr);
+/* Called when PDU received in "external" state reaches LL */
+void ble_ll_ext_rx_pkt_in(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *rxhdr);
+/* Called when LL is in "external" state and was preempted */
+void ble_ll_ext_halt(void);
+/* Called when LL is in "external" state and PHY failed to receive a PDU */
+void ble_ll_ext_wfr_timer_exp(void);
+/* Called when an "external" scheduling item was removed from scheduler queue */
+void ble_ll_ext_sched_removed(struct ble_ll_sched_item *sch);
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* H_BLE_LL_EXT_ */

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -70,6 +70,9 @@ extern uint8_t g_ble_ll_sched_offset_ticks;
 #define BLE_LL_SCHED_TYPE_PERIODIC  (6)
 #define BLE_LL_SCHED_TYPE_SYNC      (7)
 #define BLE_LL_SCHED_TYPE_SCAN_AUX  (8)
+#if MYNEWT_VAL(BLE_LL_EXT)
+#define BLE_LL_SCHED_TYPE_EXTERNAL  (255)
+#endif
 
 /* Return values for schedule callback. */
 #define BLE_LL_SCHED_STATE_RUNNING  (0)
@@ -79,6 +82,10 @@ extern uint8_t g_ble_ll_sched_offset_ticks;
 struct ble_ll_sched_item;
 typedef int (*sched_cb_func)(struct ble_ll_sched_item *sch);
 typedef void (*sched_remove_cb_func)(struct ble_ll_sched_item *sch);
+
+typedef int (* ble_ll_sched_preempt_cb_t)(struct ble_ll_sched_item *sch,
+                                          struct ble_ll_sched_item *item);
+
 
 /*
  * Schedule item
@@ -91,6 +98,9 @@ typedef void (*sched_remove_cb_func)(struct ble_ll_sched_item *sch);
 struct ble_ll_sched_item
 {
     uint8_t         sched_type;
+#if MYNEWT_VAL(BLE_LL_EXT)
+    uint8_t         sched_ext_type;
+#endif
     uint8_t         enqueued;
     uint8_t         remainder;
     uint32_t        start_time;
@@ -102,6 +112,10 @@ struct ble_ll_sched_item
 
 /* Initialize the scheduler */
 int ble_ll_sched_init(void);
+
+int ble_ll_sched_insert(struct ble_ll_sched_item *sch, uint32_t max_delay,
+                        ble_ll_sched_preempt_cb_t preempt_cb);
+void ble_ll_sched_restart(void);
 
 /* Remove item(s) from schedule */
 int ble_ll_sched_rmv_elem(struct ble_ll_sched_item *sch);

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -44,6 +44,9 @@
 #include "controller/ble_ll_trace.h"
 #include "controller/ble_ll_sync.h"
 #include "controller/ble_fem.h"
+#if MYNEWT_VAL(BLE_LL_EXT_SCHED)
+#include "controller/ble_ll_ext.h"
+#endif
 #include "ble_ll_conn_priv.h"
 #include "ble_ll_hci_priv.h"
 #include "ble_ll_priv.h"
@@ -801,6 +804,11 @@ ble_ll_wfr_timer_exp(void *arg)
             ble_ll_dtm_wfr_timer_exp();
             break;
 #endif
+#if MYNEWT_VAL(BLE_LL_EXT_SCHED)
+        case BLE_LL_STATE_EXTERNAL:
+            ble_ll_ext_wfr_timer_exp();
+            break;
+#endif
         default:
             break;
         }
@@ -976,6 +984,11 @@ ble_ll_rx_pkt_in(void)
             ble_ll_dtm_rx_pkt_in(m, ble_hdr);
             break;
 #endif
+#if MYNEWT_VAL(BLE_LL_EXT_SCHED)
+        case BLE_LL_STATE_EXTERNAL:
+            ble_ll_ext_rx_pkt_in(m, ble_hdr);
+            break;
+#endif
         default:
             /* Any other state should never occur */
             STATS_INC(ble_ll_stats, bad_ll_state);
@@ -1122,6 +1135,11 @@ ble_ll_rx_start(uint8_t *rxbuf, uint8_t chan, struct ble_mbuf_hdr *rxhdr)
         rc = ble_ll_dtm_rx_isr_start(rxhdr, ble_phy_access_addr_get());
         break;
 #endif
+#if MYNEWT_VAL(BLE_LL_EXT_SCHED)
+    case BLE_LL_STATE_EXTERNAL:
+        rc = ble_ll_ext_rx_isr_start(pdu_type, rxhdr);
+        break;
+#endif
     default:
         /* Should not be in this state! */
         rc = -1;
@@ -1164,6 +1182,13 @@ ble_ll_rx_end(uint8_t *rxbuf, struct ble_mbuf_hdr *rxhdr)
 
     ble_ll_trace_u32x3(BLE_LL_TRACE_ID_RX_END, pdu_type, len,
                        rxhdr->rxinfo.flags);
+
+#if MYNEWT_VAL(BLE_LL_EXT_SCHED)
+    if (BLE_MBUF_HDR_RX_STATE(rxhdr) == BLE_LL_STATE_EXTERNAL) {
+        rc = ble_ll_ext_rx_isr_end(rxbuf, rxhdr);
+        return rc;
+    }
+#endif
 
 #if MYNEWT_VAL(BLE_LL_DTM)
     if (BLE_MBUF_HDR_RX_STATE(rxhdr) == BLE_LL_STATE_DTM) {

--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -1120,6 +1120,11 @@ ble_ll_scan_event_proc(struct ble_npl_event *ev)
         start_scan = false;
         break;
 #endif
+#if MYNEWT_VAL(BLE_LL_EXT_SCHED)
+    case BLE_LL_STATE_EXTERNAL:
+        start_scan = false;
+        break;
+#endif
     case BLE_LL_STATE_SCANNING:
         /* Must disable PHY since we will move to a new channel */
         ble_phy_disable();

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -484,6 +484,12 @@ syscfg.defs:
             while rfmgmt is active.
         value: -1
 
+    BLE_LL_EXT:
+        description: >
+            Enables API to support external (i.e. non-native to LL) state for
+            NimBLE LL and scheduler. See ble_ll_ext.h.
+        experimental: 1
+        value: 0
 # Below settings allow to change scheduler timings. These should be left at
 # default values unless you know what you are doing!
     BLE_LL_SCHED_AUX_MAFS_DELAY:


### PR DESCRIPTION
This adds support for scheduling custom items in NimBLE scheduler.

Custom items shall use BLE_LL_SCHED_EXTERNAL type and set LL state to
BLE_LL_STATE_EXTERNAL when executing. When in that state, LL will call
appropriate callbacks as for any other built-in state which shall be
implemented by application. If different types of custom items are used,
they can be differentiated by sched_ext_type field which can have an
arbitrary value set by application.

Note that this featuer is marked as experimental as API is subject to
change.