### PR TITLE
nimble/phy/nrf52: Add tx-tx transition

### DIFF
--- a/nimble/controller/include/controller/ble_phy.h
+++ b/nimble/controller/include/controller/ble_phy.h
@@ -65,6 +65,7 @@ struct os_mbuf;
 #define BLE_PHY_TRANSITION_NONE     (0)
 #define BLE_PHY_TRANSITION_RX_TX    (1)
 #define BLE_PHY_TRANSITION_TX_RX    (2)
+#define BLE_PHY_TRANSITION_TX_TX    (3)
 
 /* PHY error codes */
 #define BLE_PHY_ERR_RADIO_STATE     (1)


### PR DESCRIPTION
This adds TX-TX transition, initially supported only on nRF52 PHY.