### PR TITLE
nimble/phy: Add support for variable T_ifs

### DIFF
--- a/nimble/controller/include/controller/ble_phy.h
+++ b/nimble/controller/include/controller/ble_phy.h
@@ -87,6 +87,11 @@ int ble_phy_init(void);
 /* Set the PHY channel */
 int ble_phy_setchan(uint8_t chan, uint32_t access_addr, uint32_t crcinit);
 
+#if MYNEWT_VAL(BLE_PHY_VARIABLE_TIFS)
+/* Set T_ifs time for next transition */
+void ble_phy_tifs_set(uint16_t tifs);
+#endif
+
 /* Set transmit start time */
 int ble_phy_tx_set_start_time(uint32_t cputime, uint8_t rem_usecs);
 

--- a/nimble/drivers/nrf52/syscfg.yml
+++ b/nimble/drivers/nrf52/syscfg.yml
@@ -17,6 +17,15 @@
 #
 
 syscfg.defs:
+    BLE_PHY_VARIABLE_TIFS:
+        description: >
+            Enables API to set custom T_ifs (inter-frame spacing) for each
+            transition. T_ifs is reset to default value after each transition.
+            When disabled, 150us is always used which enables some build-time
+            optimizations by compiler.
+        experimental: 1
+        value: 0
+
     BLE_PHY_SYSVIEW:
         description: >
             Enable SystemView tracing module for radio driver.


### PR DESCRIPTION
This enables APIs to support variable T_ifs in PHY. By default 150us is
used but this value can be changed before each transition. After
transition value is reset to default so LL does not need to care about
setting T_ifs everywhere.

This may be useful for scheduling of related events with tight timings.

Disabled by default since it allows for compile-time optimizations.