### PR TITLE
nimble/ll: Add dummy FEM option

### DIFF
--- a/nimble/controller/include/controller/ble_ll_fem.h
+++ b/nimble/controller/include/controller/ble_ll_fem.h
@@ -27,15 +27,27 @@ extern "C" {
 #include "syscfg/syscfg.h"
 
 #if MYNEWT_VAL(BLE_LL_FEM_PA)
+#if MYNEWT_VAL(BLE_LL_FEM_DUMMY)
+static inline void ble_ll_fem_pa_init(void) {}
+static inline void ble_ll_fem_pa_enable(void) {}
+static inline void ble_ll_fem_pa_disable(void) {}
+#else
 void ble_ll_fem_pa_init(void);
 void ble_ll_fem_pa_enable(void);
 void ble_ll_fem_pa_disable(void);
 #endif
+#endif
 
 #if MYNEWT_VAL(BLE_LL_FEM_LNA)
+#if MYNEWT_VAL(BLE_LL_FEM_DUMMY)
+static inline void ble_ll_fem_lna_init(void) {}
+static inline void ble_ll_fem_lna_enable(void) {}
+static inline void ble_ll_fem_lna_disable(void) {}
+#else
 void ble_ll_fem_lna_init(void);
 void ble_ll_fem_lna_enable(void);
 void ble_ll_fem_lna_disable(void);
+#endif
 #endif
 
 #if MYNEWT_VAL(BLE_LL_FEM_ANTENNA)

--- a/nimble/controller/pkg.yml
+++ b/nimble/controller/pkg.yml
@@ -29,9 +29,9 @@ pkg.req_apis:
     - ble_driver
     - ble_transport
     - stats
-pkg.req_apis.BLE_LL_FEM_PA:
+pkg.req_apis.'BLE_LL_FEM_PA && !BLE_LL_FEM_DUMMY':
     - ble_ll_fem_pa
-pkg.req_apis.BLE_LL_FEM_LNA:
+pkg.req_apis.'BLE_LL_FEM_LNA && !BLE_LL_FEM_DUMMY':
     - ble_ll_fem_lna
 pkg.req_apis.BLE_LL_FEM_ANTENNA:
     - ble_ll_fem_antenna

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -434,6 +434,11 @@ syscfg.defs:
         description: >
             Enable support for runtime antenna selection in FEM.
         value: 0
+    BLE_LL_FEM_DUMMY:
+        description: >
+            Enable dummy FEM APIs. This enables FEM code but witout using actual
+            FEM driver, i.e. only PA/LNA-enable lines are active.
+        value: 0
 
     BLE_LL_SYSINIT_STAGE:
         description: >


### PR DESCRIPTION
Dummy FEM stubs PA and/or LNA APIs so it's possible to test FEM code with out actualy FEM driver. Only PA/LNA-enable lines are active.