### PR TITLE
nimble/phy: Make private functions static

### DIFF
--- a/nimble/controller/include/controller/ble_phy.h
+++ b/nimble/controller/include/controller/ble_phy.h
@@ -107,9 +107,6 @@ typedef uint8_t (*ble_phy_tx_pducb_t)(uint8_t *dptr, void *pducb_arg,
 /* Place the PHY into transmit mode */
 int ble_phy_tx(ble_phy_tx_pducb_t pducb, void *pducb_arg, uint8_t end_trans);
 
-/* Place the PHY into receive mode */
-int ble_phy_rx(void);
-
 /* Copies the received PHY buffer into the allocated pdu */
 void ble_phy_rxpdu_copy(uint8_t *dptr, struct os_mbuf *rxpdu);
 
@@ -211,14 +208,9 @@ void ble_phy_resolv_list_disable(void);
 #define BLE_PHY_IDX_CODED           (2)
 
 #if (MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_2M_PHY) || MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY))
-uint32_t ble_phy_mode_pdu_start_off(int phy);
 void ble_phy_mode_set(uint8_t tx_phy_mode, uint8_t rx_phy_mode);
-#else
-#define ble_phy_mode_pdu_start_off(phy)     (40)
-
 #endif
 
-int ble_phy_get_cur_phy(void);
 static inline int ble_ll_phy_to_phy_mode(int phy, int phy_options)
 {
     int phy_mode;

--- a/nimble/drivers/dialog_cmac/src/ble_phy.c
+++ b/nimble/drivers/dialog_cmac/src/ble_phy.c
@@ -310,6 +310,7 @@ static bool ble_phy_rx_start_isr(void);
 static void ble_phy_rx_setup_fields(void);
 static void ble_phy_rx_setup_xcvr(void);
 static void ble_phy_mode_apply(uint8_t phy_mode);
+static int ble_phy_get_cur_phy(void);
 
 void
 FIELD_IRQHandler(void)
@@ -1012,7 +1013,7 @@ ble_phy_mode_set(uint8_t tx_phy_mode, uint8_t rx_phy_mode)
     g_ble_phy_data.frame_offset_rxtx = g_ble_phy_frame_offset_rxtx[rxtx];
 }
 
-int
+static int
 ble_phy_get_cur_phy(void)
 {
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
@@ -1327,7 +1328,7 @@ ble_phy_rx_setup_xcvr(void)
     g_ble_phy_data.phy_rx_started = 0;
 }
 
-int
+static int
 ble_phy_rx(void)
 {
     MCU_DIAG_SER('R');

--- a/nimble/drivers/nrf51/src/ble_phy.c
+++ b/nimble/drivers/nrf51/src/ble_phy.c
@@ -47,6 +47,12 @@
 #error LE Coded PHY cannot be enabled on nRF51
 #endif
 
+static uint32_t
+ble_phy_mode_pdu_start_off(int phy_mode)
+{
+    return 40;
+}
+
 /* XXX: 4) Make sure RF is higher priority interrupt than schedule */
 
 /*

--- a/nimble/drivers/nrf5x/src/ble_phy.c
+++ b/nimble/drivers/nrf5x/src/ble_phy.c
@@ -152,7 +152,7 @@ struct ble_phy_obj
     uint16_t tifs;
 #endif
 };
-struct ble_phy_obj g_ble_phy_data;
+static struct ble_phy_obj g_ble_phy_data;
 
 /* XXX: if 27 byte packets desired we can make this smaller */
 /* Global transmit/receive buffer */
@@ -314,7 +314,7 @@ STATS_NAME_END(ble_phy_stats)
 //#define NRF_ENC_SCRATCH_WORDS (((MYNEWT_VAL(BLE_LL_MAX_PKT_SIZE) + 16) + 3) / 4)
 #define NRF_ENC_SCRATCH_WORDS   (67)
 
-uint32_t g_nrf_encrypt_scratchpad[NRF_ENC_SCRATCH_WORDS];
+static uint32_t g_nrf_encrypt_scratchpad[NRF_ENC_SCRATCH_WORDS];
 
 struct nrf_ccm_data
 {
@@ -331,7 +331,7 @@ struct nrf_ccm_data g_nrf_ccm_data;
 
 /* Packet start offset (in usecs). This is the preamble plus access address.
  * For LE Coded PHY this also includes CI and TERM1. */
-uint32_t
+static uint32_t
 ble_phy_mode_pdu_start_off(int phy_mode)
 {
     return g_ble_phy_mode_pkt_start_off[phy_mode];
@@ -429,9 +429,15 @@ ble_phy_mode_set(uint8_t tx_phy_mode, uint8_t rx_phy_mode)
     g_ble_phy_data.phy_tx_phy_mode = tx_phy_mode;
     g_ble_phy_data.phy_rx_phy_mode = rx_phy_mode;
 }
+#else
+static uint32_t
+ble_phy_mode_pdu_start_off(int phy_mode)
+{
+    return 40;
+}
 #endif
 
-int
+static int
 ble_phy_get_cur_phy(void)
 {
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)
@@ -1610,7 +1616,7 @@ ble_phy_init(void)
  *
  * @return int 0: success; BLE Phy error code otherwise
  */
-int
+static int
 ble_phy_rx(void)
 {
     /*


### PR DESCRIPTION
Some functions are never used by LL and can be considered private so let's make them static.