### PR TITLE
L2CAP COC: fix RX endpoint sdus allocation

### DIFF
--- a/apps/blestress/src/stress.c
+++ b/apps/blestress/src/stress.c
@@ -167,11 +167,13 @@ stress_l2cap_coc_accept(uint16_t peer_mtu, struct ble_l2cap_chan *chan)
     console_printf("LE CoC accepting, chan: 0x%08lx, peer_mtu %d\n",
                    (uint32_t) chan, peer_mtu);
 
-    sdu_rx = os_msys_get_pkthdr(STRESS_COC_MTU, 0);
-    assert(sdu_rx != NULL);
+    for (int i = 0; i < MYNEWT_VAL(BLE_L2CAP_COC_SDU_BUFF_COUNT); i++) {
+        sdu_rx = os_msys_get_pkthdr(STRESS_COC_MTU, 0);
+        assert(sdu_rx != NULL);
 
-    rc = ble_l2cap_recv_ready(chan, sdu_rx);
-    assert(rc == 0);
+        rc = ble_l2cap_recv_ready(chan, sdu_rx);
+        assert(rc == 0);
+    }
 }
 
 void

--- a/apps/blestress/syscfg.yml
+++ b/apps/blestress/syscfg.yml
@@ -67,6 +67,9 @@ syscfg.vals:
     #
     BLE_L2CAP_COC_MAX_NUM: 2
 
+    # L2CAP COC SDU buffers in RX endpoint
+    BLE_L2CAP_COC_SDU_BUFF_COUNT: 1
+
     # Enable 2M PHY
     BLE_LL_CFG_FEAT_LE_2M_PHY: 1
 

--- a/apps/btshell/src/main.c
+++ b/apps/btshell/src/main.c
@@ -2224,19 +2224,25 @@ btshell_l2cap_coc_recv(struct ble_l2cap_chan *chan, struct os_mbuf *sdu)
 
 static int
 btshell_l2cap_coc_accept(uint16_t conn_handle, uint16_t peer_mtu,
-                           struct ble_l2cap_chan *chan)
+                         struct ble_l2cap_chan *chan)
 {
     struct os_mbuf *sdu_rx;
+    int rc;
 
     console_printf("LE CoC accepting, chan: 0x%08lx, peer_mtu %d\n",
                    (uint32_t) chan, peer_mtu);
 
-    sdu_rx = os_mbuf_get_pkthdr(&sdu_os_mbuf_pool, 0);
-    if (!sdu_rx) {
-        return BLE_HS_ENOMEM;
+    for (int i = 0; i < MYNEWT_VAL(BLE_L2CAP_COC_SDU_BUFF_COUNT); i++) {
+        sdu_rx = os_mbuf_get_pkthdr(&sdu_os_mbuf_pool, 0);
+        if (!sdu_rx) {
+            return BLE_HS_ENOMEM;
+        }
+
+        rc = ble_l2cap_recv_ready(chan, sdu_rx);
+        assert(rc == 0);
     }
 
-    return ble_l2cap_recv_ready(chan, sdu_rx);
+    return rc;
 }
 
 static void

--- a/apps/btshell/syscfg.yml
+++ b/apps/btshell/syscfg.yml
@@ -41,5 +41,8 @@ syscfg.vals:
     # Whether to save data to sys/config, or just keep it in RAM.
     BLE_STORE_CONFIG_PERSIST: 0
 
+    # L2CAP COC SDU buffers in RX endpoint
+    BLE_L2CAP_COC_SDU_BUFF_COUNT: 1
+
 syscfg.vals.BLE_MESH:
     MSYS_1_BLOCK_COUNT: 16

--- a/nimble/host/src/ble_l2cap_coc.c
+++ b/nimble/host/src/ble_l2cap_coc.c
@@ -604,7 +604,8 @@ ble_l2cap_coc_recv_ready(struct ble_l2cap_chan *chan, struct os_mbuf *sdu_rx)
     }
 
     if (chan->coc_rx.sdus[0] != NULL &&
-        chan->coc_rx.next_sdu_alloc_idx == chan->coc_rx.current_sdu_idx) {
+        chan->coc_rx.next_sdu_alloc_idx == chan->coc_rx.current_sdu_idx &&
+        BLE_L2CAP_SDU_BUFF_CNT != 1) {
         return BLE_HS_EBUSY;
     }
 


### PR DESCRIPTION
1. fix one rx endpoint sdu case
2. updated btshell and blestress to support setting number of sdus

@sjanc  