### PR TITLE
nimble/ll: Always send assert vs event if enabled

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1742,10 +1742,10 @@ ble_ll_is_addr_empty(const uint8_t *addr)
 void
 ble_ll_assert(const char *file, unsigned line)
 {
+    ble_ll_hci_ev_send_vs_assert(file, line);
+
     if (hal_debugger_connected()) {
         __BKPT(0);
-    } else {
-        ble_ll_hci_ev_send_vs_assert(file, line); \
     }
 
     while (1);


### PR DESCRIPTION
We should always send assert vs event if enabled, regardless if we'll break due to attached debugger or not. This is useful when using monitor over RTT since using RTT means debugger is attached even though we may not actually have sw debugger running.