### PR TITLE
nimble/phy/nrf5x: Fix tx-tx transition

### DIFF
--- a/nimble/drivers/nrf5x/src/ble_phy.c
+++ b/nimble/drivers/nrf5x/src/ble_phy.c
@@ -1047,11 +1047,11 @@ ble_phy_tx_end_isr(void)
     }
 #endif
 
+    transition = g_ble_phy_data.phy_transition;
+
     if (g_ble_phy_data.txend_cb) {
         g_ble_phy_data.txend_cb(g_ble_phy_data.txend_arg);
     }
-
-    transition = g_ble_phy_data.phy_transition;
 
     if (transition == BLE_PHY_TRANSITION_TX_RX) {
 #if (BLE_LL_BT5_PHY_SUPPORTED == 1)


### PR DESCRIPTION
We need to store current transition before calling txend callback. This is important in case of tx-tx transition since txend callback will call ble_phy_tx which overwrites current transition.