### PR TITLE
nimble/ll: Add option to define maximum allowed TX power

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1376,7 +1376,8 @@ ble_ll_task(void *arg)
     ble_phy_init();
 
     /* Set output power to default */
-    g_ble_ll_tx_power = ble_ll_tx_power_round(MYNEWT_VAL(BLE_LL_TX_PWR_DBM));
+    g_ble_ll_tx_power = ble_ll_tx_power_round(min(MYNEWT_VAL(BLE_LL_TX_PWR_DBM),
+                                                  MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)));
     ble_ll_tx_power_set(g_ble_ll_tx_power);
 
     /* Tell the host that we are ready to receive packets */
@@ -1623,7 +1624,8 @@ ble_ll_reset(void)
     g_ble_ll_rx_power_compensation = 0;
 
     /* Set output power to default */
-    g_ble_ll_tx_power = ble_ll_tx_power_round(MYNEWT_VAL(BLE_LL_TX_PWR_DBM));
+    g_ble_ll_tx_power = ble_ll_tx_power_round(min(MYNEWT_VAL(BLE_LL_TX_PWR_DBM),
+                                                  MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)));
     ble_ll_tx_power_set(g_ble_ll_tx_power);
 
     /* FLush all packets from Link layer queues */

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -3528,7 +3528,8 @@ ble_ll_adv_ext_set_param(const uint8_t *cmdbuf, uint8_t len,
         /* no preference */
         advsm->tx_power = ble_ll_tx_power_round(g_ble_ll_tx_power - g_ble_ll_tx_power_compensation);
     } else {
-        advsm->tx_power = ble_ll_tx_power_round(cmd->tx_power - g_ble_ll_tx_power_compensation);
+        advsm->tx_power = ble_ll_tx_power_round(min(cmd->tx_power, MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)) -
+                                                g_ble_ll_tx_power_compensation);
     }
 
     /* we can always store as those are validated and used only when needed */

--- a/nimble/controller/src/ble_ll_hci_vs.c
+++ b/nimble/controller/src/ble_ll_hci_vs.c
@@ -124,9 +124,13 @@ ble_ll_hci_vs_set_tx_power(uint16_t ocf, const uint8_t *cmdbuf, uint8_t cmdlen,
 
     if (cmd->tx_power == 127) {
         /* restore reset default */
-        g_ble_ll_tx_power = ble_ll_tx_power_round(MYNEWT_VAL(BLE_LL_TX_PWR_DBM)  - g_ble_ll_tx_power_compensation);
+        g_ble_ll_tx_power = ble_ll_tx_power_round(min(MYNEWT_VAL(BLE_LL_TX_PWR_DBM),
+                                                      MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)) -
+                                                  g_ble_ll_tx_power_compensation);
     } else {
-        g_ble_ll_tx_power = ble_ll_tx_power_round(cmd->tx_power - g_ble_ll_tx_power_compensation);
+        g_ble_ll_tx_power = ble_ll_tx_power_round(min(cmd->tx_power,
+                                                      MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)) -
+                                                  g_ble_ll_tx_power_compensation);
     }
 
     ble_ll_tx_power_set(g_ble_ll_tx_power);

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -69,6 +69,14 @@ syscfg.defs:
             may be rounded up or down depending on used radio.
         value: '0'
 
+    BLE_LL_TX_PWR_MAX_DBM:
+        description: >
+            Maximum allowed transmit power level (in dBm). This limits maximum
+            power to specified value (including FEM and/or host compensation).
+            Useful for ensuring selected power class of device. Defaults to
+            maximum allowed by specification (Power Class 1).
+        value: '20'
+
     BLE_LL_NUM_COMP_PKT_ITVL_MS:
         description: >
             Determines the interval at which the controller will send the


### PR DESCRIPTION
This allows to limit (clip) maximum allowed TX power to meet requirements for selected LE PHY power class.