### PR TITLE
Fix missing includes and missing return (compiler gives error)

### DIFF
--- a/nimble/transport/include/nimble/transport/transport_ipc.h
+++ b/nimble/transport/include/nimble/transport/transport_ipc.h
@@ -20,9 +20,12 @@
 #ifndef H_NIMBLE_TRANSPORT_IPC_
 #define H_NIMBLE_TRANSPORT_IPC_
 
+#include <syscfg/syscfg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 
 /* NOTE: These APIs shall only be used by IPC transports */
 

--- a/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
+++ b/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
@@ -19,6 +19,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <syscfg/syscfg.h>
 #include <sysinit/sysinit.h>
 #include <nimble/ble.h>
 #include <ipc_nrf5340/ipc_nrf5340.h>

--- a/nimble/transport/src/transport.c
+++ b/nimble/transport/src/transport.c
@@ -287,5 +287,6 @@ ble_transport_ipc_buf_evt_type_get(void *buf)
     } else {
         assert(0);
     }
+    return 0;
 }
 #endif


### PR DESCRIPTION
This fixes the build after the recent HCI_IPC changes.

Also these changes now add a dependency from Mynewt/drivers/ipc5430 to the Nimble stack, which IMHO is a no go. This is not fixes in this request.