### PR TITLE
nimble/ll: Add init and reset for external code

### DIFF
--- a/nimble/controller/include/controller/ble_ll_ext.h
+++ b/nimble/controller/include/controller/ble_ll_ext.h
@@ -36,6 +36,10 @@ extern "C" {
 
 struct ble_ll_sched_item;
 
+/* Called when LL package is initialized (before ll_task is started) */
+void ble_ll_ext_init(void);
+/* Called when LL is reset (i.e. HCI_Reset) */
+void ble_ll_ext_reset(void);
 /* Called when LL is in "external" state and PHY starts to receive a PDU */
 int ble_ll_ext_rx_isr_start(uint8_t pdu_type, struct ble_mbuf_hdr *rxhdr);
 /* Called when LL is in "external" state and PHY finished to receive a PDU */

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -56,6 +56,10 @@
 #include "ble_ll_dtm_priv.h"
 #endif
 
+#if MYNEWT_VAL(BLE_LL_EXT)
+#include <controller/ble_ll_ext.h>
+#endif
+
 /* XXX:
  *
  * 1) use the sanity task!
@@ -1605,6 +1609,10 @@ ble_ll_reset(void)
     ble_ll_rfmgmt_reset();
     OS_EXIT_CRITICAL(sr);
 
+#if MYNEWT_VAL(BLE_LL_EXT)
+    ble_ll_ext_reset();
+#endif
+
 #if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
     /* Stop any advertising */
     ble_ll_adv_reset();
@@ -1979,6 +1987,10 @@ ble_ll_init(void)
 
 #if MYNEWT_VAL(BLE_LL_HCI_VS)
     ble_ll_hci_vs_init();
+#endif
+
+#if MYNEWT_VAL(BLE_LL_EXT)
+    ble_ll_ext_init();
 #endif
 
 #if MYNEWT


### PR DESCRIPTION
This adds init and reset calls for external code so it can be initialized and reset properly in sync with LL.