### PR TITLE
nimble/host: Add host callback to provide security keys

### DIFF
--- a/nimble/host/include/host/ble_hs.h
+++ b/nimble/host/include/host/ble_hs.h
@@ -276,6 +276,9 @@ struct ble_hs_cfg {
      */
     ble_hs_sync_fn *sync_cb;
 
+    /** Callback to handle generation of security keys */
+    ble_store_gen_key_fn *store_gen_key_cb;
+
     /* XXX: These need to go away. Instead, the nimble host package should
      * require the host-store API (not yet implemented)..
      */

--- a/nimble/host/include/host/ble_store.h
+++ b/nimble/host/include/host/ble_store.h
@@ -178,6 +178,42 @@ struct ble_store_status_event {
     };
 };
 
+/* Generate LTK, EDIT and Rand */
+#define BLE_STORE_GEN_KEY_LTK       0x01
+/* Generate IRK */
+#define BLE_STORE_GEN_KEY_IRK       0x02
+/* Generate CSRK */
+#define BLE_STORE_GEN_KEY_CSRK      0x03
+
+struct ble_store_gen_key {
+    union {
+        uint8_t ltk_periph[16];
+        uint8_t irk[16];
+        uint8_t csrk[16];
+    };
+    uint16_t ediv;
+    uint64_t rand;
+};
+
+/**
+ * Generates key required by security module.
+ * This can be used to use custom routines to generate keys instead of simply
+ * randomizing them.
+ *
+ * \p conn_handle is set to \p BLE_HS_CONN_HANDLE_NONE if key is not requested
+ * for a specific connection (e.g. an IRK).
+ *
+ * @param key                   Key that shall be generated.
+ * @param gen_key               Storage for generated key.
+ * @param conn_handle           Connection handle for which keys are generated.
+ *
+ * @return                      0 if keys were generated successfully
+ *                              Other nonzero on error.
+ */
+typedef int ble_store_gen_key_fn(uint8_t key,
+                                 struct ble_store_gen_key *gen_key,
+                                 uint16_t conn_handle);
+
 /**
  * Searches the store for an object matching the specified criteria.  If a
  * match is found, it is read from the store and the dst parameter is populated

--- a/nimble/host/src/ble_hs_startup.c
+++ b/nimble/host/src/ble_hs_startup.c
@@ -318,6 +318,7 @@ ble_hs_startup_reset_tx(void)
 int
 ble_hs_startup_go(void)
 {
+    struct ble_store_gen_key gen_key;
     int rc;
 
     rc = ble_hs_startup_reset_tx();
@@ -372,7 +373,20 @@ ble_hs_startup_go(void)
         return rc;
     }
 
-    ble_hs_pvcy_set_our_irk(NULL);
+    if (ble_hs_cfg.store_gen_key_cb) {
+        memset(&gen_key, 0, sizeof(gen_key));
+        rc = ble_hs_cfg.store_gen_key_cb(BLE_STORE_GEN_KEY_IRK, &gen_key,
+                                         BLE_HS_CONN_HANDLE_NONE);
+        if (rc == 0) {
+            ble_hs_pvcy_set_our_irk(gen_key.irk);
+        }
+    } else {
+        rc = -1;
+    }
+
+    if (rc != 0) {
+        ble_hs_pvcy_set_our_irk(NULL);
+    }
 
     /* If flow control is enabled, configure the controller to use it. */
     ble_hs_flow_startup();


### PR DESCRIPTION
Application can use new callback to generate keys for new pairing prior to keys distribution. This allows keys to be derived from some other source (e.g. as in Vol 3, Part H, appendix B) instead of just being randomized.