### PR TITLE
nimble/ll: Add API to read random data from controller

### DIFF
--- a/apps/bttester/src/gap.c
+++ b/apps/bttester/src/gap.c
@@ -837,7 +837,7 @@ static void auth_passkey_display(uint16_t conn_handle, unsigned int passkey)
 		return;
 	}
 
-	rc = ble_hs_hci_util_rand(&pk.passkey, sizeof(pk.passkey));
+	rc = ble_hs_hci_rand(&pk.passkey, sizeof(pk.passkey));
 	assert(rc == 0);
 	/* Max value is 999999 */
 	pk.passkey %= 1000000;

--- a/nimble/host/include/host/ble_hs_hci.h
+++ b/nimble/host/include/host/ble_hs_hci.h
@@ -87,6 +87,21 @@ int ble_hs_hci_read_chan_map(uint16_t conn_handle, uint8_t *out_chan_map);
  */
 int ble_hs_hci_set_chan_class(const uint8_t *chan_map);
 
+/**
+ * Reads random data into buffer from controller.
+ * This allows to use BLE controller as a source of true random data.
+ *
+ * @param dst                   Destination buffer.
+ * @param len                   Destination buffer length.
+ *
+ * @return                      0 on success;
+ *                              A BLE host HCI return code if the controller
+ *                                  rejected the request;
+ *                              A BLE host core return code on unexpected
+ *                                  error.
+ */
+int ble_hs_hci_rand(void *dst, int len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/nimble/host/mesh/src/glue.c
+++ b/nimble/host/mesh/src/glue.c
@@ -588,7 +588,7 @@ int
 bt_rand(void *buf, size_t len)
 {
     int rc;
-    rc = ble_hs_hci_util_rand(buf, len);
+    rc = ble_hs_hci_rand(buf, len);
     if (rc != 0) {
         return -1;
     }

--- a/nimble/host/src/ble_hs_hci_priv.h
+++ b/nimble/host/src/ble_hs_hci_priv.h
@@ -98,7 +98,6 @@ void ble_hs_hci_set_phony_ack_cb(ble_hs_hci_phony_ack_fn *cb);
 #endif
 
 int ble_hs_hci_util_read_adv_tx_pwr(int8_t *out_pwr);
-int ble_hs_hci_util_rand(void *dst, int len);
 int ble_hs_hci_util_read_rssi(uint16_t conn_handle, int8_t *out_rssi);
 int ble_hs_hci_util_set_random_addr(const uint8_t *addr);
 int ble_hs_hci_util_set_data_len(uint16_t conn_handle, uint16_t tx_octets,

--- a/nimble/host/src/ble_hs_hci_util.c
+++ b/nimble/host/src/ble_hs_hci_util.c
@@ -58,7 +58,7 @@ ble_hs_hci_util_read_adv_tx_pwr(int8_t *out_tx_pwr)
 }
 
 int
-ble_hs_hci_util_rand(void *dst, int len)
+ble_hs_hci_rand(void *dst, int len)
 {
     struct ble_hci_le_rand_rp rsp;
     uint8_t *u8ptr;

--- a/nimble/host/src/ble_hs_id.c
+++ b/nimble/host/src/ble_hs_id.c
@@ -41,7 +41,7 @@ ble_hs_id_gen_rnd(int nrpa, ble_addr_t *out_addr)
 
     out_addr->type = BLE_ADDR_RANDOM;
 
-    rc = ble_hs_hci_util_rand(out_addr->val, 6);
+    rc = ble_hs_hci_rand(out_addr->val, 6);
     if (rc != 0) {
         return rc;
     }

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -261,7 +261,7 @@ ble_sm_gen_pair_rand(uint8_t *pair_rand)
     }
 #endif
 
-    rc = ble_hs_hci_util_rand(pair_rand, 16);
+    rc = ble_hs_hci_rand(pair_rand, 16);
     if (rc != 0) {
         return rc;
     }
@@ -282,7 +282,7 @@ ble_sm_gen_ediv(struct ble_sm_master_id *master_id)
     }
 #endif
 
-    rc = ble_hs_hci_util_rand(&master_id->ediv, sizeof master_id->ediv);
+    rc = ble_hs_hci_rand(&master_id->ediv, sizeof master_id->ediv);
     if (rc != 0) {
         return rc;
     }
@@ -303,7 +303,7 @@ ble_sm_gen_master_id_rand(struct ble_sm_master_id *master_id)
     }
 #endif
 
-    rc = ble_hs_hci_util_rand(&master_id->rand_val, sizeof master_id->rand_val);
+    rc = ble_hs_hci_rand(&master_id->rand_val, sizeof master_id->rand_val);
     if (rc != 0) {
         return rc;
     }
@@ -325,7 +325,7 @@ ble_sm_gen_ltk(struct ble_sm_proc *proc, uint8_t *ltk)
     }
 #endif
 
-    rc = ble_hs_hci_util_rand(ltk, proc->key_size);
+    rc = ble_hs_hci_rand(ltk, proc->key_size);
     if (rc != 0) {
         return rc;
     }
@@ -350,7 +350,7 @@ ble_sm_gen_csrk(struct ble_sm_proc *proc, uint8_t *csrk)
     }
 #endif
 
-    rc = ble_hs_hci_util_rand(csrk, 16);
+    rc = ble_hs_hci_rand(csrk, 16);
     if (rc != 0) {
         return rc;
     }

--- a/nimble/host/src/ble_sm_alg.c
+++ b/nimble/host/src/ble_sm_alg.c
@@ -517,7 +517,7 @@ ble_sm_alg_rand(uint8_t *dst, unsigned int size)
         size -= num;
     }
 #else
-    if (ble_hs_hci_util_rand(dst, size)) {
+    if (ble_hs_hci_rand(dst, size)) {
         return 0;
     }
 #endif

--- a/nimble/host/src/ble_sm_sc.c
+++ b/nimble/host/src/ble_sm_sc.c
@@ -893,7 +893,7 @@ ble_sm_sc_oob_generate_data(struct ble_sm_sc_oob_data *oob_data)
         return rc;
     }
 
-    rc = ble_hs_hci_util_rand(oob_data->r, 16);
+    rc = ble_hs_hci_rand(oob_data->r, 16);
     if (rc) {
         return rc;
     }


### PR DESCRIPTION
This may be useful to get some random if MCU does not support trng, e.g. as on nRF5340 app core.