### PR TITLE
nimble/ll: Fix syscfg restrictions

### DIFF
--- a/nimble/transport/syscfg.yml
+++ b/nimble/transport/syscfg.yml
@@ -93,5 +93,5 @@ $import:
     - "@apache-mynewt-nimble/nimble/transport/syscfg.monitor.yml"
     - "@apache-mynewt-nimble/nimble/transport/syscfg.defunct.yml"
 
-syscfg.vals."BLE_EXT_ADV || BLE_LL_CFG_FEAT_LL_EXT_ADV":
+syscfg.vals.'BLE_EXT_ADV || BLE_LL_CFG_FEAT_LL_EXT_ADV':
     BLE_TRANSPORT_EVT_SIZE: 257


### PR DESCRIPTION
syscfg conditions should use single quotes