### PR TITLE
Compile fix nimble

### DIFF
--- a/nimble/host/src/ble_att.c
+++ b/nimble/host/src/ble_att.c
@@ -23,6 +23,15 @@
 #include "host/ble_att.h"
 
 #if NIMBLE_BLE_CONNECT
+
+#ifndef min
+#define min(a, b) ((a)<(b)?(a):(b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a)>(b)?(a):(b))
+#endif
+
 static uint16_t ble_att_preferred_mtu_val;
 
 /** Dispatch table for incoming ATT requests.  Sorted by op code. */

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -27,6 +27,14 @@
 #include "ble_hs_priv.h"
 #include "ble_gap_priv.h"
 
+#ifndef min
+#define min(a, b) ((a)<(b)?(a):(b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a)>(b)?(a):(b))
+#endif
+
 #if MYNEWT
 #include "bsp/bsp.h"
 #else

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -62,6 +62,15 @@
 #include "ble_hs_priv.h"
 
 #if NIMBLE_BLE_CONNECT
+
+#ifndef min
+#define min(a, b) ((a)<(b)?(a):(b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a)>(b)?(a):(b))
+#endif
+
 /*****************************************************************************
  * $definitions / declarations                                               *
  *****************************************************************************/

--- a/nimble/host/src/ble_hs_hci_util.c
+++ b/nimble/host/src/ble_hs_hci_util.c
@@ -22,6 +22,14 @@
 #include "host/ble_hs_hci.h"
 #include "ble_hs_priv.h"
 
+#ifndef min
+#define min(a, b) ((a)<(b)?(a):(b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a)>(b)?(a):(b))
+#endif
+
 uint16_t
 ble_hs_hci_util_handle_pb_bc_join(uint16_t handle, uint8_t pb, uint8_t bc)
 {

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -49,6 +49,15 @@
 #include "ble_hs_priv.h"
 
 #if NIMBLE_BLE_CONNECT
+
+#ifndef min
+#define min(a, b) ((a)<(b)?(a):(b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a)>(b)?(a):(b))
+#endif
+
 #if NIMBLE_BLE_SM
 
 /** Procedure timeout; 30 seconds. */

--- a/porting/nimble/include/os/os.h
+++ b/porting/nimble/include/os/os.h
@@ -26,14 +26,6 @@
 extern "C" {
 #endif
 
-#ifndef min
-#define min(a, b) ((a)<(b)?(a):(b))
-#endif
-
-#ifndef max
-#define max(a, b) ((a)>(b)?(a):(b))
-#endif
-
 #include "syscfg/syscfg.h"
 #include "nimble/nimble_npl.h"
 

--- a/porting/nimble/src/os_mbuf.c
+++ b/porting/nimble/src/os_mbuf.c
@@ -41,6 +41,14 @@
 #include <string.h>
 #include <limits.h>
 
+#ifndef min
+#define min(a, b) ((a)<(b)?(a):(b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a)>(b)?(a):(b))
+#endif
+
 /**
  * @addtogroup OSKernel
  * @{

--- a/porting/npl/linux/src/wqueue.h
+++ b/porting/npl/linux/src/wqueue.h
@@ -25,8 +25,6 @@
 #include <pthread.h>
 #include <list>
 
-using namespace std;
-
 template <typename T> class wqueue
 {
     list<T>              m_queue;


### PR DESCRIPTION
## Removes global min/max definition causing problems with other libraries
Some libraries define min/max macros too (like STL) by using templates. With these makros already defined, the compilation might fail or have an unexprected behaviour, especially while using `using namespace std;` together with anything in STL.

## Removes `using namespace std` from header file
Inlcuding `using namespace std` in a header file results in a `using namespace std` be part of any header/cpp file using this header. This might lead to unexpected behaviour and false selection of methods/functions by setting the std namespace to a global scope.