### PR TITLE
nimble/ll: Add DTM extension for unmodulated carrier

### DIFF
--- a/nimble/controller/include/controller/ble_phy.h
+++ b/nimble/controller/include/controller/ble_phy.h
@@ -232,6 +232,9 @@ static inline int ble_ll_phy_to_phy_mode(int phy, int phy_options)
 #if MYNEWT_VAL(BLE_LL_DTM)
 void ble_phy_enable_dtm(void);
 void ble_phy_disable_dtm(void);
+#if MYNEWT_VAL(BLE_LL_DTM_EXTENSIONS)
+int ble_phy_test_carrier(uint8_t rf_channel);
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/nimble/drivers/dialog_cmac/src/ble_phy.c
+++ b/nimble/drivers/dialog_cmac/src/ble_phy.c
@@ -1786,4 +1786,12 @@ ble_phy_disable_dtm(void)
 {
     g_ble_phy_data.phy_whitening = 1;
 }
+
+#if MYNEWT_VAL(BLE_LL_DTM_EXTENSIONS)
+int
+ble_phy_test_carrier(uint8_t rf_channel)
+{
+    return 1;
+}
+#endif
 #endif

--- a/nimble/drivers/nrf5x/src/ble_phy.c
+++ b/nimble/drivers/nrf5x/src/ble_phy.c
@@ -2191,6 +2191,22 @@ void ble_phy_disable_dtm(void)
     /* Enable whitening */
     NRF_RADIO->PCNF1 |= RADIO_PCNF1_WHITEEN_Msk;
 }
+
+#if MYNEWT_VAL(BLE_LL_DTM_EXTENSIONS)
+int
+ble_phy_test_carrier(uint8_t rf_channel)
+{
+    /* based on Nordic DTM sample */
+    ble_phy_disable();
+    ble_phy_enable_dtm();
+    ble_phy_mode_apply(BLE_PHY_MODE_1M);
+    nrf_radio_shorts_enable(NRF_RADIO, NRF_RADIO_SHORT_READY_START_MASK);
+    NRF_RADIO->FREQUENCY = g_ble_phy_chan_freq[rf_channel];
+    nrf_radio_task_trigger(NRF_RADIO, NRF_RADIO_TASK_TXEN);
+
+    return 0;
+}
+#endif
 #endif
 
 void


### PR DESCRIPTION
This may be useful for HW validation. Implemented for nRF5x driver based on Nordic DTM sample.