### PR TITLE
nimble/phy/nrf5x: Allow to use named pins for radio debug

### DIFF
--- a/nimble/drivers/nrf5x/src/phy_priv.h
+++ b/nimble/drivers/nrf5x/src/phy_priv.h
@@ -29,6 +29,11 @@
 #define PHY_USE_DEBUG_3     (MYNEWT_VAL(BLE_PHY_DBG_TIME_WFR_PIN) >= 0)
 #define PHY_USE_DEBUG       (PHY_USE_DEBUG_1 || PHY_USE_DEBUG_2 || PHY_USE_DEBUG_3)
 
+/* allows to use named pins for radio debug eg. LED_1 */
+#if PHY_USE_DEBUG
+#include <bsp/bsp.h>
+#endif
+
 #define PHY_USE_FEM_PA      (MYNEWT_VAL(BLE_FEM_PA) != 0)
 #define PHY_USE_FEM_LNA     (MYNEWT_VAL(BLE_FEM_LNA) != 0)
 #define PHY_USE_FEM         (PHY_USE_FEM_PA || PHY_USE_FEM_LNA)


### PR DESCRIPTION
This allows to use LED_1 etc for GPIO debug.