### PR TITLE
nimble/ll: Require 257 bytes HCI events when enabling fake dual-mode

### DIFF
--- a/nimble/controller/syscfg.hbd.yml
+++ b/nimble/controller/syscfg.hbd.yml
@@ -23,3 +23,5 @@ syscfg.defs:
             device. It can be initialized and used by Windows 10 to some
             extent.
         value: 0
+        restrictions:
+           - '(BLE_TRANSPORT_EVT_SIZE == 257) if 1'


### PR DESCRIPTION
Some BR/EDR commands eg. Read Local Name command have fixed (max allowed HCI event size) return values. If event size is smaller it results in assert.