### PR TITLE
nimble/host: Enabled LE Power control event mask if feature is enabled

### DIFF
--- a/nimble/host/src/ble_hs_startup.c
+++ b/nimble/host/src/ble_hs_startup.c
@@ -250,6 +250,17 @@ ble_hs_startup_le_set_evmask_tx(void)
     }
 #endif
 
+#if MYNEWT_VAL(BLE_POWER_CONTROL)
+    if (version >= BLE_HCI_VER_BCS_5_2) {
+        /**
+         * Enable the following LE events:
+         * 0x0000000080000000 LE Path Loss Threshold event
+         * 0x0000000100000000 LE Transmit Power Reporting event
+         */
+        mask |= 0x0000000180000000;
+    }
+#endif
+
     cmd.event_mask = htole64(mask);
 
     rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,


### PR DESCRIPTION
If LE Power Control feature is enabled, then host should get relevant events. This PR enables event mask associated with Power control feature. 