### PR TITLE
nimble/ll: Simplify DTM RX test

### DIFF
--- a/nimble/controller/src/ble_ll_dtm.c
+++ b/nimble/controller/src/ble_ll_dtm.c
@@ -195,16 +195,6 @@ ble_ll_dtm_ev_tx_resched_cb(struct ble_npl_event *evt) {
     BLE_LL_ASSERT(rc == 0);
 }
 
-static int ble_ll_dtm_rx_start(void);
-
-static void
-ble_ll_dtm_ev_rx_restart_cb(struct ble_npl_event *evt) {
-    if (ble_ll_dtm_rx_start() != 0) {
-        ble_ll_event_add(&g_ble_ll_dtm_ctx.evt);
-        STATS_INC(ble_ll_dtm_stats, rx_failed);
-    }
-}
-
 static void
 ble_ll_dtm_tx_done(void *arg)
 {
@@ -402,7 +392,7 @@ ble_ll_dtm_rx_start(void)
 #endif
 
     OS_ENTER_CRITICAL(sr);
-    rc = ble_phy_rx_set_start_time(ble_ll_tmr_get(), 0);
+    rc = ble_phy_rx_set_start_time(ble_ll_rfmgmt_enable_now(), 0);
     OS_EXIT_CRITICAL(sr);
     if (rc && rc != BLE_PHY_ERR_RX_LATE) {
         return rc;
@@ -414,21 +404,8 @@ ble_ll_dtm_rx_start(void)
 }
 
 static int
-ble_ll_dtm_rx_sched_cb(struct ble_ll_sched_item *sch)
-{
-    if (ble_ll_dtm_rx_start() != 0) {
-        ble_ll_event_add(&g_ble_ll_dtm_ctx.evt);
-        STATS_INC(ble_ll_dtm_stats, rx_failed);
-        return BLE_LL_SCHED_STATE_DONE;
-    }
-
-    return BLE_LL_SCHED_STATE_RUNNING;
-}
-
-static int
 ble_ll_dtm_rx_create_ctx(uint8_t rf_channel, uint8_t phy_mode)
 {
-    struct ble_ll_sched_item *sch = &g_ble_ll_dtm_ctx.sch;
     int rc;
 
     g_ble_ll_dtm_ctx.phy_mode = phy_mode;
@@ -436,16 +413,8 @@ ble_ll_dtm_rx_create_ctx(uint8_t rf_channel, uint8_t phy_mode)
 
     STATS_CLEAR(ble_ll_dtm_stats, rx_count);
 
-    ble_npl_event_init(&g_ble_ll_dtm_ctx.evt, ble_ll_dtm_ev_rx_restart_cb,
-                       NULL);
-
-    sch->sched_cb = ble_ll_dtm_rx_sched_cb;
-    sch->cb_arg = &g_ble_ll_dtm_ctx;
-    sch->sched_type = BLE_LL_SCHED_TYPE_DTM;
-    sch->start_time =  ble_ll_rfmgmt_enable_now();
-
-    rc = ble_ll_sched_dtm(sch);
-    BLE_LL_ASSERT(rc == 0);
+    rc = ble_ll_dtm_rx_start();
+    assert(rc == 0);
 
     ble_phy_enable_dtm();
 
@@ -665,10 +634,7 @@ ble_ll_dtm_rx_pkt_in(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *hdr)
         STATS_INC(ble_ll_dtm_stats, rx_count);
     }
 
-    if (ble_ll_dtm_rx_start() != 0) {
-        ble_ll_event_add(&g_ble_ll_dtm_ctx.evt);
-        STATS_INC(ble_ll_dtm_stats, rx_failed);
-    }
+    ble_phy_restart_rx();
 }
 
 int


### PR DESCRIPTION
DTM test uses fixed frequency and PHY mode so there is no need to re-configure those after every packet reception. It is enough to just restart scanning.