### PR TITLE
nimble/drivers/fem: Add support for nRF21540

### DIFF
--- a/nimble/drivers/fem/nrf21540/include/nrf21540/nrf21540.h
+++ b/nimble/drivers/fem/nrf21540/include/nrf21540/nrf21540.h
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#ifndef _NRF21540_H
+#define _NRF21540_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int nrf21540_mode_set(uint8_t mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NRF21540_H */

--- a/nimble/drivers/fem/nrf21540/pkg.yml
+++ b/nimble/drivers/fem/nrf21540/pkg.yml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: nimble/drivers/fem/nrf21540
+pkg.description: Driver for nRF21540 front-end module
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "https://mynewt.apache.org/"
+pkg.apis:
+    - ble_fem_pa
+    - ble_fem_lna
+    - ble_fem_antenna
+
+pkg.init:
+    nrf21540_init: 999

--- a/nimble/drivers/fem/nrf21540/src/nrf21540.c
+++ b/nimble/drivers/fem/nrf21540/src/nrf21540.c
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <syscfg/syscfg.h>
+#include <nrf21540/nrf21540.h>
+#include <hal/hal_gpio.h>
+#include <controller/ble_fem.h>
+
+static void
+nrf21540_pdn_set(int state)
+{
+    int pin;
+
+    pin = MYNEWT_VAL(NRF21540_PIN_PDN);
+    hal_gpio_write(pin, state);
+}
+
+int
+nrf21540_mode_set(uint8_t mode)
+{
+#ifdef MYNEWT_VAL_NRF21540_PIN_MODE
+    int pin;
+
+    pin = MYNEWT_VAL(NRF21540_PIN_MODE);
+    hal_gpio_init_out(pin, mode);
+
+    return 0;
+#else
+    return -1;
+#endif
+}
+
+void
+ble_fem_pa_init(void)
+{
+    nrf21540_pdn_set(0);
+}
+
+void
+ble_fem_pa_enable(void)
+{
+    nrf21540_pdn_set(1);
+}
+
+void
+ble_fem_pa_disable(void)
+{
+    nrf21540_pdn_set(0);
+}
+
+void
+ble_fem_lna_init(void)
+{
+}
+
+void
+ble_fem_lna_enable(void)
+{
+    nrf21540_pdn_set(1);
+}
+
+void
+ble_fem_lna_disable(void)
+{
+    nrf21540_pdn_set(0);
+}
+
+int
+ble_fem_antenna(uint8_t port)
+{
+#ifdef MYNEWT_VAL_NRF21540_PIN_ANT_SEL
+    int pin;
+
+    pin = MYNEWT_VAL(NRF21540_PIN_ANT_SEL);
+    switch (port) {
+    case 0:
+    case 1:
+        hal_gpio_write(pin, 0);
+        break;
+    case 2:
+        hal_gpio_write(pin, 1);
+        break;
+    default:
+        return -1;
+    }
+
+    return 0;
+#else
+    return -1;
+#endif
+}
+
+void
+nrf21540_init(void)
+{
+    int pin;
+
+    pin = MYNEWT_VAL(NRF21540_PIN_PDN);
+    assert(pin >= 0);
+    hal_gpio_init_out(pin, 0);
+
+#ifdef MYNEWT_VAL_NRF21540_PIN_ANT_SEL
+    pin = MYNEWT_VAL(NRF21540_PIN_ANT_SEL);
+    assert(pin >= 0);
+    switch (MYNEWT_VAL(NRF21540_ANTENNA_PORT)) {
+    case 1:
+        hal_gpio_init_out(pin, 0);
+        break;
+    case 2:
+        hal_gpio_init_out(pin, 1);
+        break;
+    default:
+        assert(0);
+    }
+#endif
+
+#ifdef MYNEWT_VAL_NRF21540_PIN_MODE
+    pin = MYNEWT_VAL(NRF21540_PIN_MODE);
+    assert(pin >= 0);
+    if (MYNEWT_VAL_CHOICE(NRF21540_TX_GAIN_PRESET, POUTB)) {
+        hal_gpio_init_out(pin, 1);
+    } else {
+        hal_gpio_init_out(pin, 0);
+    }
+#endif
+}

--- a/nimble/drivers/fem/nrf21540/syscfg.yml
+++ b/nimble/drivers/fem/nrf21540/syscfg.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    NRF21540_PIN_PDN:
+        description: >
+            GPIO pin number to control PDN signal.
+        value:
+        restrictions: $notnull
+    NRF21540_PIN_ANT_SEL:
+        description: >
+            GPIO pin number to control ANT_SEL signal.
+        value:
+    NRF21540_PIN_MODE:
+        description: >
+            GPIO pin number to control MODE signal.
+        value:
+    NRF21540_ANTENNA_PORT:
+        description: >
+            Selects antenna port, valid only if ANT_SEL pin is configured.
+        range: 1, 2
+        value: 1
+    NRF21540_TX_GAIN_PRESET:
+        description: >
+            Selects TX gain preset, valid only if MODE pin is configured.
+        choices:
+            - none
+            - POUTA
+            - POUTB
+        value: none

--- a/nimble/drivers/nrf5x/src/nrf53/phy.c
+++ b/nimble/drivers/nrf5x/src/nrf53/phy.c
@@ -112,6 +112,7 @@ phy_fem_init()
     NRF_DPPIC->CHENSET = DPPI_CH_MASK_FEM;
 }
 
+#if PHY_USE_FEM_PA
 void
 phy_fem_enable_pa(void)
 {
@@ -125,7 +126,9 @@ phy_fem_enable_pa(void)
         DPPI_CH_SUB(TIMER0_EVENTS_COMPARE_2);
 #endif
 }
+#endif
 
+#if PHY_USE_FEM_LNA
 void
 phy_fem_enable_lna(void)
 {
@@ -139,6 +142,7 @@ phy_fem_enable_lna(void)
         DPPI_CH_SUB(TIMER0_EVENTS_COMPARE_2);
 #endif
 }
+#endif
 
 void
 phy_fem_disable(void)


### PR DESCRIPTION
This adds support for nRF21540 FEM.
FEM is controlled via GPIOs, there's no support for SPI.