### PR TITLE
nimble/fem: Add runtime default antenna selection to SKY66112

### DIFF
--- a/nimble/drivers/fem/sky66112/include/sky66112/sky66112.h
+++ b/nimble/drivers/fem/sky66112/include/sky66112/sky66112.h
@@ -30,6 +30,11 @@ extern "C" {
 void sky66112_tx_hp_mode(uint8_t enabled);
 void sky66112_rx_bypass(uint8_t enabled);
 void sky66112_tx_bypass(uint8_t enabled);
+
+#if MYNEWT_VAL_CHOICE(SKY66112_ANTENNA_PORT, runtime)
+uint8_t sky66112_default_antenna_get(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/nimble/drivers/fem/sky66112/syscfg.yml
+++ b/nimble/drivers/fem/sky66112/syscfg.yml
@@ -58,11 +58,14 @@ syscfg.defs:
         value: 0
     SKY66112_ANTENNA_PORT:
         description: >
-            Selects which antenna port should be enabled:
-             1 for ANT1 port enabled
-             2 for ANT2 port enabled
-        range: 1, 2
-        value: 1
+            Selects which antenna port should be enabled. If 'runtime' is
+            selected sky66112_default_antenna_get() (see sky66112/sky66112.h)
+            shall be implemeneted by application.
+        choices:
+            - ANT1
+            - ANT2
+            - runtime
+        value: ANT1
 
 syscfg.vals.!BLE_FEM_PA:
     # Enable TX bypass by default if PA is disabled


### PR DESCRIPTION
This allows to configure default antenna at runtime.