### PR TITLE
porting/examples: Fix build error on linux

### DIFF
--- a/porting/npl/linux/src/wqueue.h
+++ b/porting/npl/linux/src/wqueue.h
@@ -27,7 +27,7 @@
 
 template <typename T> class wqueue
 {
-    list<T>              m_queue;
+    std::list<T>         m_queue;
     pthread_mutex_t      m_mutex;
     pthread_mutexattr_t  m_mutex_attr;
     pthread_cond_t       m_condv;


### PR DESCRIPTION
Since 'using namespace std' was removed from public header it is needed to explicitly use it when using std::list