### PR TITLE
nimble/ll: Fix not being able to get back to default DLE values

### DIFF
--- a/nimble/controller/include/controller/ble_ll_ctrl.h
+++ b/nimble/controller/include/controller/ble_ll_ctrl.h
@@ -333,7 +333,7 @@ void ble_ll_hci_ev_send_adv_set_terminated(uint8_t status, uint8_t adv_handle,
 int ble_ll_hci_ev_phy_update(struct ble_ll_conn_sm *connsm, uint8_t status);
 void ble_ll_calc_session_key(struct ble_ll_conn_sm *connsm);
 void ble_ll_ctrl_phy_update_proc_complete(struct ble_ll_conn_sm *connsm);
-void ble_ll_ctrl_initiate_dle(struct ble_ll_conn_sm *connsm);
+void ble_ll_ctrl_initiate_dle(struct ble_ll_conn_sm *connsm, bool initial);
 void ble_ll_hci_ev_send_vs_assert(const char *file, uint32_t line);
 void ble_ll_hci_ev_send_vs_llcp_trace(uint8_t type, uint16_t handle, uint16_t count,
                                       void *pdu, size_t length);

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1849,7 +1849,7 @@ ble_ll_conn_set_data_len(struct ble_ll_conn_sm *connsm,
     }
 
     if (init_dle) {
-        ble_ll_ctrl_initiate_dle(connsm);
+        ble_ll_ctrl_initiate_dle(connsm, false);
     }
 
     return 0;
@@ -2662,7 +2662,7 @@ ble_ll_conn_next_event(struct ble_ll_conn_sm *connsm)
             !ble_ll_conn_rem_feature_check(connsm, BLE_LL_FEAT_LE_CODED_PHY)) {
             ble_ll_conn_rem_feature_add(connsm, BLE_LL_FEAT_LE_CODED_PHY);
             connsm->max_rx_time = BLE_LL_CONN_SUPP_TIME_MAX_CODED;
-            ble_ll_ctrl_initiate_dle(connsm);
+            ble_ll_ctrl_initiate_dle(connsm, false);
         }
 #endif
     }

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -2081,7 +2081,7 @@ ble_ll_ctrl_rx_conn_update(struct ble_ll_conn_sm *connsm, uint8_t *dptr)
 }
 
 void
-ble_ll_ctrl_initiate_dle(struct ble_ll_conn_sm *connsm)
+ble_ll_ctrl_initiate_dle(struct ble_ll_conn_sm *connsm, bool initial)
 {
     if (!(connsm->conn_features & BLE_LL_FEAT_DATA_LEN_EXT)) {
         return;
@@ -2090,12 +2090,15 @@ ble_ll_ctrl_initiate_dle(struct ble_ll_conn_sm *connsm)
     /*
      * Section 4.5.10 Vol 6 PART B. If the max tx/rx time or octets
      * exceeds the minimum, data length procedure needs to occur
+     * "at the earliest practical opportunity".
      */
-    if ((connsm->max_tx_octets <= BLE_LL_CONN_SUPP_BYTES_MIN) &&
-        (connsm->max_rx_octets <= BLE_LL_CONN_SUPP_BYTES_MIN) &&
-        (connsm->max_tx_time <= BLE_LL_CONN_SUPP_TIME_MIN) &&
-        (connsm->max_rx_time <= BLE_LL_CONN_SUPP_TIME_MIN)) {
-        return;
+    if (initial) {
+        if ((connsm->max_tx_octets <= BLE_LL_CONN_SUPP_BYTES_MIN) &&
+            (connsm->max_rx_octets <= BLE_LL_CONN_SUPP_BYTES_MIN) &&
+            (connsm->max_tx_time <= BLE_LL_CONN_SUPP_TIME_MIN) &&
+            (connsm->max_rx_time <= BLE_LL_CONN_SUPP_TIME_MIN)) {
+            return;
+        }
     }
 
     ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_DATA_LEN_UPD, NULL);
@@ -3048,7 +3051,7 @@ ll_ctrl_send_rsp:
 
     if (connsm->csmflags.cfbit.pending_initiate_dle) {
         connsm->csmflags.cfbit.pending_initiate_dle = 0;
-        ble_ll_ctrl_initiate_dle(connsm);
+        ble_ll_ctrl_initiate_dle(connsm, true);
     }
 
     return rc;


### PR DESCRIPTION
If new DLE parameters were matching default values DLE update procedure was not started.