### PR TITLE
nimble/ll: Allow to tune time needed for scheduling next conn event

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -939,6 +939,8 @@ ble_ll_conn_get_next_sched_time(struct ble_ll_conn_sm *connsm)
     rem_us = connsm->anchor_point_usecs;
     ble_ll_tmr_add_u(&ce_end, &rem_us, connsm->conn_itvl_usecs);
 
+    ce_end -= ble_ll_tmr_u2t_up(MYNEWT_VAL(BLE_LL_CONN_EVENT_END_MARGIN));
+
     if (ble_ll_sched_next_time(&next_sched_time)) {
         if (LL_TMR_LT(next_sched_time, ce_end)) {
             ce_end = next_sched_time;

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -537,6 +537,15 @@ syscfg.defs:
         range: 1..257
         value: 32
 
+    BLE_LL_CONN_EVENT_END_MARGIN:
+        description: >
+            Extra time needed for scheduling next connection event. Setting this
+            value results in ending connection event sooner (in microseconds)
+            which gives more time to schedule next event. This value should be
+            tuned only after measuring performance as depends on various factors
+            like  build optimisation, cache, clock speed etc.
+        value: 0
+
     BLE_LL_STACK_SIZE:
         description: >
               This is the stack size for LL task.


### PR DESCRIPTION
This works by allowing to shorten connection event end time by specified number of us. This value should be tuned only after measuring performance as depends on various factors like build optimisation, cache, clock speed etc.