### PR TITLE
ll: Fix compiler error

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -442,7 +442,7 @@ ble_ll_scan_add_scan_rsp_adv(uint8_t *addr, uint8_t txadd,
 
     /* XXX: for now, if we dont have room, just leave */
     num_advs = g_ble_ll_scan_num_rsp_advs;
-    if (num_advs == MYNEWT_VAL(BLE_LL_NUM_SCAN_RSP_ADVS)) {
+    if (num_advs >= MYNEWT_VAL(BLE_LL_NUM_SCAN_RSP_ADVS)) {
         return;
     }
 


### PR DESCRIPTION
Fixing false possitive compiler error

/home/rymek/projects/bletiny_proj/repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_scan.c:456:12: error: array subscript <unknown> is outside array bounds of 'struct ble_ll_scan_advertisers[0]' [␛]8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Warray-bounds␇-Werror=array-bounds␛]8;;␇]
  456 |     memcpy(&adv->adv_addr, addr, BLE_DEV_ADDR_LEN);