### PR TITLE
nimble/ll: Add missing definition of min and max macros

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -60,6 +60,14 @@
 #include <controller/ble_ll_ext.h>
 #endif
 
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 /* XXX:
  *
  * 1) use the sanity task!

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -42,6 +42,14 @@
 #include "ble_ll_conn_priv.h"
 #include "ble_ll_priv.h"
 
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
 
 /* XXX: TODO

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -48,6 +48,14 @@
 #include <nimble/transport/hci_ipc.h>
 #endif
 
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #if (BLETEST_THROUGHPUT_TEST == 1)
 extern void bletest_completed_pkt(uint16_t handle);
 #endif

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -41,6 +41,14 @@
 #include "ble_ll_dtm_priv.h"
 #endif
 
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 static void ble_ll_hci_cmd_proc(struct ble_npl_event *ev);
 
 /* OS event to enqueue command */

--- a/nimble/controller/src/ble_ll_hci_vs.c
+++ b/nimble/controller/src/ble_ll_hci_vs.c
@@ -29,6 +29,14 @@
 #include "ble_ll_conn_priv.h"
 #include "ble_ll_priv.h"
 
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #if MYNEWT_VAL(BLE_LL_HCI_VS)
 
 SLIST_HEAD(ble_ll_hci_vs_list, ble_ll_hci_vs_cmd);

--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -40,6 +40,14 @@
 #include "controller/ble_ll_sync.h"
 #include "ble_ll_priv.h"
 
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #define BLE_LL_SCAN_AUX_F_AUX_ADV           0x0001
 #define BLE_LL_SCAN_AUX_F_AUX_CHAIN         0x0002
 #define BLE_LL_SCAN_AUX_F_MATCHED           0x0004

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -42,6 +42,14 @@
 
 #include "stats/stats.h"
 
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV) && MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
 
 /* defines number of events that can be lost during sync establishment

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -24,6 +24,14 @@
 #include "controller/ble_ll_tmr.h"
 #include "controller/ble_ll_utils.h"
 
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 /* 37 bits require 5 bytes */
 #define BLE_LL_CHMAP_LEN (5)
 


### PR DESCRIPTION
Those were removed from headers to avoid conflicts with C++. Until we convert codebase to MIN/MAX macros just define those where needed.

This was affecting RIOT port.