### PR TITLE
nimble/ll: Use MIN/MAX macros from ble_ll_utils.h

### DIFF
--- a/nimble/controller/include/controller/ble_ll_utils.h
+++ b/nimble/controller/include/controller/ble_ll_utils.h
@@ -24,7 +24,7 @@
 #define INT16_LTE(_a, _b) ((int16_t)((_a) - (_b)) <= 0)
 
 #define MIN(_a, _b) ((_a) < (_b) ? (_a) : (_b))
-#define MAX(_a, _b) ((_a) < (_b) ? (_a) : (_b))
+#define MAX(_a, _b) ((_a) > (_b) ? (_a) : (_b))
 #define CLAMP(_n, _min, _max) (MAX(_min, MIN(_n, _max)))
 #define IN_RANGE(_n, _min, _max) (((_n) >= (_min)) && ((_n) <= (_max)))
 

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -29,6 +29,7 @@
 #include "nimble/nimble_opt.h"
 #include "nimble/hci_common.h"
 #include "nimble/transport.h"
+#include "controller/ble_ll_utils.h"
 #include "controller/ble_hw.h"
 #include "controller/ble_phy.h"
 #include "controller/ble_phy_trace.h"
@@ -1362,7 +1363,7 @@ ble_ll_task(void *arg)
     ble_phy_init();
 
     /* Set output power to default */
-    g_ble_ll_tx_power = ble_ll_tx_power_round(min(MYNEWT_VAL(BLE_LL_TX_PWR_DBM),
+    g_ble_ll_tx_power = ble_ll_tx_power_round(MIN(MYNEWT_VAL(BLE_LL_TX_PWR_DBM),
                                                   MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)));
     ble_ll_tx_power_set(g_ble_ll_tx_power);
 
@@ -1614,7 +1615,7 @@ ble_ll_reset(void)
     g_ble_ll_rx_power_compensation = 0;
 
     /* Set output power to default */
-    g_ble_ll_tx_power = ble_ll_tx_power_round(min(MYNEWT_VAL(BLE_LL_TX_PWR_DBM),
+    g_ble_ll_tx_power = ble_ll_tx_power_round(MIN(MYNEWT_VAL(BLE_LL_TX_PWR_DBM),
                                                   MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)));
     ble_ll_tx_power_set(g_ble_ll_tx_power);
 
@@ -1727,7 +1728,7 @@ ble_ll_pdu_max_tx_octets_get(uint32_t usecs, int phy_mode)
     }
 
     /* see comment at the beginning */
-    return max(27, octets);
+    return MAX(27, octets);
 }
 
 static inline bool

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -1438,7 +1438,7 @@ ble_ll_adv_aux_calculate_payload(struct ble_ll_adv_sm *advsm, uint16_t props,
     }
 
     /* AdvData */
-    data_len = min(BLE_LL_MAX_PAYLOAD_LEN - ext_hdr_len, rem_data_len);
+    data_len = MIN(BLE_LL_MAX_PAYLOAD_LEN - ext_hdr_len, rem_data_len);
 
     /* AuxPtr if there are more AdvData remaining that we can fit here */
     if (chainable && (rem_data_len > data_len)) {
@@ -2329,7 +2329,7 @@ ble_ll_adv_sync_calculate(struct ble_ll_adv_sm *advsm,
     }
 
     /* AdvData always */
-    sync->data_len = min(BLE_LL_MAX_PAYLOAD_LEN - ext_hdr_len, rem_data_len);
+    sync->data_len = MIN(BLE_LL_MAX_PAYLOAD_LEN - ext_hdr_len, rem_data_len);
 
     /* AuxPtr if there are more AdvData remaining that we can fit here */
     if ((rem_data_len > sync->data_len)) {
@@ -3529,7 +3529,7 @@ ble_ll_adv_ext_set_param(const uint8_t *cmdbuf, uint8_t len,
         /* no preference */
         advsm->tx_power = ble_ll_tx_power_round(g_ble_ll_tx_power - g_ble_ll_tx_power_compensation);
     } else {
-        advsm->tx_power = ble_ll_tx_power_round(min(cmd->tx_power, MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)) -
+        advsm->tx_power = ble_ll_tx_power_round(MIN(cmd->tx_power, MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)) -
                                                 g_ble_ll_tx_power_compensation);
     }
 
@@ -3827,7 +3827,7 @@ ble_ll_adv_sync_get_pdu_len(uint16_t data_len, uint16_t *data_offset,
     }
 
     /* AdvData always */
-    data_len = min(BLE_LL_MAX_PAYLOAD_LEN - hdr_len, rem_data_len);
+    data_len = MIN(BLE_LL_MAX_PAYLOAD_LEN - hdr_len, rem_data_len);
 
     /* AuxPtr if there are more AdvData remaining that we can fit here */
     if (rem_data_len > data_len) {

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1824,8 +1824,8 @@ ble_ll_conn_set_data_len(struct ble_ll_conn_sm *connsm,
 
     /* If peer does not support coded, we cannot use value larger than 2120us */
     if (!ble_ll_conn_rem_feature_check(connsm, BLE_LL_FEAT_LE_CODED_PHY)) {
-        tx_time = min(tx_time, BLE_LL_CONN_SUPP_TIME_MAX_UNCODED);
-        rx_time = min(rx_time, BLE_LL_CONN_SUPP_TIME_MAX_UNCODED);
+        tx_time = MIN(tx_time, BLE_LL_CONN_SUPP_TIME_MAX_UNCODED);
+        rx_time = MIN(rx_time, BLE_LL_CONN_SUPP_TIME_MAX_UNCODED);
     }
 #endif
 
@@ -2086,10 +2086,10 @@ ble_ll_conn_update_eff_data_len(struct ble_ll_conn_sm *connsm)
     send_event = 0;
 
     /* See if effective times have changed */
-    eff_time = min(connsm->rem_max_tx_time, connsm->max_rx_time);
+    eff_time = MIN(connsm->rem_max_tx_time, connsm->max_rx_time);
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
     if (connsm->phy_data.cur_rx_phy == BLE_PHY_CODED) {
-        eff_time = max(eff_time, BLE_LL_CONN_SUPP_TIME_MIN_CODED);
+        eff_time = MAX(eff_time, BLE_LL_CONN_SUPP_TIME_MIN_CODED);
     }
 #endif
     if (eff_time != connsm->eff_max_rx_time) {
@@ -2097,23 +2097,23 @@ ble_ll_conn_update_eff_data_len(struct ble_ll_conn_sm *connsm)
         ota_max_rx_time_calc = 1;
         send_event = 1;
     }
-    eff_time = min(connsm->rem_max_rx_time, connsm->max_tx_time);
+    eff_time = MIN(connsm->rem_max_rx_time, connsm->max_tx_time);
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
     if (connsm->phy_data.cur_tx_phy == BLE_PHY_CODED) {
-        eff_time = max(eff_time, BLE_LL_CONN_SUPP_TIME_MIN_CODED);
+        eff_time = MAX(eff_time, BLE_LL_CONN_SUPP_TIME_MIN_CODED);
     }
 #endif
     if (eff_time != connsm->eff_max_tx_time) {
         connsm->eff_max_tx_time = eff_time;
         send_event = 1;
     }
-    eff_bytes = min(connsm->rem_max_tx_octets, connsm->max_rx_octets);
+    eff_bytes = MIN(connsm->rem_max_tx_octets, connsm->max_rx_octets);
     if (eff_bytes != connsm->eff_max_rx_octets) {
         connsm->eff_max_rx_octets = eff_bytes;
         ota_max_rx_time_calc = 1;
         send_event = 1;
     }
-    eff_bytes = min(connsm->rem_max_rx_octets, connsm->max_tx_octets);
+    eff_bytes = MIN(connsm->rem_max_rx_octets, connsm->max_tx_octets);
     if (eff_bytes != connsm->eff_max_tx_octets) {
         connsm->eff_max_tx_octets = eff_bytes;
         send_event = 1;
@@ -2132,7 +2132,7 @@ ble_ll_conn_update_eff_data_len(struct ble_ll_conn_sm *connsm)
         phy_mode = BLE_PHY_MODE_1M;
 #endif
         ota_time = ble_ll_pdu_us(connsm->eff_max_rx_octets, phy_mode);
-        connsm->ota_max_rx_time = min(ota_time, connsm->eff_max_rx_time);
+        connsm->ota_max_rx_time = MIN(ota_time, connsm->eff_max_rx_time);
     }
 
     if (send_event) {
@@ -4290,15 +4290,15 @@ ble_ll_conn_subrate_req_llcp(struct ble_ll_conn_sm *connsm,
         return -EINVAL;
     }
 
-    connsm->subrate_trans.subrate_factor = min(connsm->acc_subrate_max,
+    connsm->subrate_trans.subrate_factor = MIN(connsm->acc_subrate_max,
                                                srp->subrate_max);
     connsm->subrate_trans.subrate_base_event = connsm->event_cntr;
-    connsm->subrate_trans.periph_latency = min(connsm->acc_max_latency,
+    connsm->subrate_trans.periph_latency = MIN(connsm->acc_max_latency,
                                                srp->max_latency);
-    connsm->subrate_trans.cont_num = min(max(connsm->acc_cont_num,
+    connsm->subrate_trans.cont_num = MIN(MAX(connsm->acc_cont_num,
                                              srp->cont_num),
                                          connsm->subrate_trans.subrate_factor - 1);
-    connsm->subrate_trans.supervision_tmo = min(connsm->supervision_tmo,
+    connsm->subrate_trans.supervision_tmo = MIN(connsm->supervision_tmo,
                                                 srp->supervision_tmo);
 
     ble_ll_ctrl_proc_start(connsm, BLE_LL_CTRL_PROC_SUBRATE_UPDATE, NULL);
@@ -4392,7 +4392,7 @@ ble_ll_conn_module_reset(void)
     /* Configure the global LL parameters */
     conn_params = &g_ble_ll_conn_params;
 
-    maxbytes = min(MYNEWT_VAL(BLE_LL_SUPP_MAX_RX_BYTES), max_phy_pyld);
+    maxbytes = MIN(MYNEWT_VAL(BLE_LL_SUPP_MAX_RX_BYTES), max_phy_pyld);
     conn_params->supp_max_rx_octets = maxbytes;
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
     conn_params->supp_max_rx_time = MAX_TIME_CODED(maxbytes);
@@ -4400,7 +4400,7 @@ ble_ll_conn_module_reset(void)
     conn_params->supp_max_rx_time = MAX_TIME_UNCODED(maxbytes);
 #endif
 
-    maxbytes = min(MYNEWT_VAL(BLE_LL_SUPP_MAX_TX_BYTES), max_phy_pyld);
+    maxbytes = MIN(MYNEWT_VAL(BLE_LL_SUPP_MAX_TX_BYTES), max_phy_pyld);
     conn_params->supp_max_tx_octets = maxbytes;
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
     conn_params->supp_max_tx_time = MAX_TIME_CODED(maxbytes);
@@ -4408,7 +4408,7 @@ ble_ll_conn_module_reset(void)
     conn_params->supp_max_tx_time = MAX_TIME_UNCODED(maxbytes);
 #endif
 
-    maxbytes = min(MYNEWT_VAL(BLE_LL_CONN_INIT_MAX_TX_BYTES), max_phy_pyld);
+    maxbytes = MIN(MYNEWT_VAL(BLE_LL_CONN_INIT_MAX_TX_BYTES), max_phy_pyld);
     conn_params->conn_init_max_tx_octets = maxbytes;
     conn_params->conn_init_max_tx_time = MAX_TIME_UNCODED(maxbytes);
     conn_params->conn_init_max_tx_time_uncoded = MAX_TIME_UNCODED(maxbytes);

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -24,6 +24,7 @@
 #include "nimble/ble.h"
 #include "nimble/nimble_opt.h"
 #include "nimble/hci_common.h"
+#include "controller/ble_ll_utils.h"
 #include "controller/ble_ll.h"
 #include "controller/ble_ll_hci.h"
 #include "controller/ble_ll_ctrl.h"
@@ -2122,13 +2123,13 @@ ble_ll_ctrl_update_features(struct ble_ll_conn_sm *connsm, uint8_t *feat)
          */
         if (ble_ll_conn_rem_feature_check(connsm, BLE_LL_FEAT_LE_CODED_PHY)) {
             if (connsm->host_req_max_tx_time) {
-                connsm->max_tx_time = max(connsm->max_tx_time,
+                connsm->max_tx_time = MAX(connsm->max_tx_time,
                                           connsm->host_req_max_tx_time);
             } else {
                 connsm->max_tx_time = g_ble_ll_conn_params.conn_init_max_tx_time_coded;
             }
             if (connsm->host_req_max_rx_time) {
-                connsm->max_rx_time = max(connsm->max_rx_time,
+                connsm->max_rx_time = MAX(connsm->max_rx_time,
                                           connsm->host_req_max_rx_time);
             } else {
                 connsm->max_rx_time = BLE_LL_CONN_SUPP_TIME_MAX_CODED;

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -24,6 +24,7 @@
 #include "nimble/ble.h"
 #include "nimble/nimble_opt.h"
 #include "nimble/hci_common.h"
+#include "controller/ble_ll_utils.h"
 #include "controller/ble_hw.h"
 #include "controller/ble_ll_adv.h"
 #include "controller/ble_ll_scan.h"
@@ -487,9 +488,9 @@ ble_ll_hci_le_wr_sugg_data_len(const uint8_t *cmdbuf, uint8_t len)
      * in which case we just use our max.
      */
     g_ble_ll_conn_params.conn_init_max_tx_octets =
-        min(tx_octets, g_ble_ll_conn_params.supp_max_tx_octets);
+        MIN(tx_octets, g_ble_ll_conn_params.supp_max_tx_octets);
     g_ble_ll_conn_params.conn_init_max_tx_time =
-        min(tx_time, g_ble_ll_conn_params.supp_max_tx_time);
+        MIN(tx_time, g_ble_ll_conn_params.supp_max_tx_time);
 
     /*
      * Use the same for coded and uncoded defaults. These are used when PHY
@@ -497,7 +498,7 @@ ble_ll_hci_le_wr_sugg_data_len(const uint8_t *cmdbuf, uint8_t len)
      * host. Make sure we do not exceed max supported time on uncoded.
      */
     g_ble_ll_conn_params.conn_init_max_tx_time_uncoded =
-        min(BLE_LL_CONN_SUPP_TIME_MAX_UNCODED,
+        MIN(BLE_LL_CONN_SUPP_TIME_MAX_UNCODED,
             g_ble_ll_conn_params.conn_init_max_tx_time);
     g_ble_ll_conn_params.conn_init_max_tx_time_coded =
         g_ble_ll_conn_params.conn_init_max_tx_time;

--- a/nimble/controller/src/ble_ll_hci_vs.c
+++ b/nimble/controller/src/ble_ll_hci_vs.c
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include "syscfg/syscfg.h"
+#include "controller/ble_ll_utils.h"
 #include "controller/ble_ll.h"
 #include "controller/ble_ll_hci.h"
 #include "controller/ble_ll_sync.h"
@@ -74,11 +75,11 @@ ble_ll_hci_vs_set_tx_power(uint16_t ocf, const uint8_t *cmdbuf, uint8_t cmdlen,
 
     if (cmd->tx_power == 127) {
         /* restore reset default */
-        g_ble_ll_tx_power = ble_ll_tx_power_round(min(MYNEWT_VAL(BLE_LL_TX_PWR_DBM),
+        g_ble_ll_tx_power = ble_ll_tx_power_round(MIN(MYNEWT_VAL(BLE_LL_TX_PWR_DBM),
                                                       MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)) -
                                                   g_ble_ll_tx_power_compensation);
     } else {
-        g_ble_ll_tx_power = ble_ll_tx_power_round(min(cmd->tx_power,
+        g_ble_ll_tx_power = ble_ll_tx_power_round(MIN(cmd->tx_power,
                                                       MYNEWT_VAL(BLE_LL_TX_PWR_MAX_DBM)) -
                                                   g_ble_ll_tx_power_compensation);
     }

--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -28,6 +28,7 @@
 #include "os/os.h"
 #include "nimble/ble.h"
 #include "nimble/hci_common.h"
+#include "controller/ble_ll_utils.h"
 #include "controller/ble_phy.h"
 #include "controller/ble_hw.h"
 #include "controller/ble_ll.h"
@@ -533,7 +534,7 @@ ble_ll_hci_ev_send_ext_adv_report(struct os_mbuf *rxpdu,
 
         report->rssi = rxinfo->rssi - ble_ll_rx_gain();
 
-        report->data_len = min(max_data_len, data_len - offset);
+        report->data_len = MIN(max_data_len, data_len - offset);
         os_mbuf_copydata(rxpdu, offset, report->data_len, report->data);
         (*hci_ev)->length += report->data_len;
 

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -705,7 +705,7 @@ ble_ll_sync_send_per_adv_rpt(struct ble_ll_sync_sm *sm, struct os_mbuf *rxpdu,
         ev->rssi = rssi;
         ev->cte_type = 0xff;
 
-        ev->data_len = min(max_data_len, datalen - offset);
+        ev->data_len = MIN(max_data_len, datalen - offset);
         /* adjust event length */
         hci_ev->length += ev->data_len;
 

--- a/nimble/controller/src/ble_ll_utils.c
+++ b/nimble/controller/src/ble_ll_utils.c
@@ -458,8 +458,8 @@ ble_ll_utils_dci_iso_subevent(uint16_t chan_id, uint16_t *prn_sub_lu,
 
     /* Core 5.3, Vol 6, Part B, 4.5.8.3.6 (enjoy!) */
     /* TODO optimize this somehow */
-    d = max(1, max(min(3, num_used_chans - 5),
-                   min(11, (num_used_chans - 10) / 2)));
+    d = MAX(1, MAX(MIN(3, num_used_chans - 5),
+                   MIN(11, (num_used_chans - 10) / 2)));
     *remap_idx = (*remap_idx + d + prn_sub_se *
                   (num_used_chans - 2 * d + 1) / 65536) % num_used_chans;
 


### PR DESCRIPTION
Use macros provided by utils instead of relying on system providing min and max macros.