### PR TITLE
porting/nuttx: Fix error: implicit declaration of function 'usleep'

### DIFF
--- a/porting/examples/nuttx/main.c
+++ b/porting/examples/nuttx/main.c
@@ -22,9 +22,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
-
-
 #include <pthread.h>
+#include <unistd.h>
+
 #include "nimble/nimble_npl.h"
 #include "nimble/nimble_port.h"
 


### PR DESCRIPTION
Report here:
https://github.com/apache/nuttx/actions/runs/4098214664/jobs/7067171681
