### PR TITLE
Fix the compiler warning on NuttX

### DIFF
--- a/nimble/transport/socket/src/ble_hci_socket.c
+++ b/nimble/transport/socket/src/ble_hci_socket.c
@@ -356,7 +356,7 @@ ble_hci_sock_cmdevt_tx(uint8_t *hci_ev, uint8_t h4_type)
                (struct sockaddr *)&addr, sizeof(struct sockaddr_hci));
 
     free(buf);
-    ble_hci_trans_buf_free(hci_ev);
+    ble_transport_free(hci_ev);
     if (i != len + 1) {
         if (i < 0) {
             dprintf(1, "sendto() failed : %d\n", errno);

--- a/porting/npl/linux/include/nimble/nimble_npl_os.h
+++ b/porting/npl/linux/include/nimble/nimble_npl_os.h
@@ -37,13 +37,6 @@ extern "C" {
 
 #define SYSINIT_PANIC_MSG(msg) __assert_fail(msg, __FILE__, __LINE__, __func__)
 
-#define SYSINIT_PANIC_ASSERT_MSG(rc, msg) do \
-{                                            \
-    if (!(rc)) {                             \
-        SYSINIT_PANIC_MSG(msg);              \
-    }                                        \
-} while (0)
-
 #ifdef __cplusplus
 }
 #endif

--- a/porting/npl/nuttx/include/nimble/nimble_npl_os.h
+++ b/porting/npl/nuttx/include/nimble/nimble_npl_os.h
@@ -37,13 +37,6 @@ extern "C" {
 
 #define SYSINIT_PANIC_MSG(msg) { fprintf(stderr, "%s\n", msg); abort(); }
 
-#define SYSINIT_PANIC_ASSERT_MSG(rc, msg) do \
-{                                            \
-    if (!(rc)) {                             \
-        SYSINIT_PANIC_MSG(msg);              \
-    }                                        \
-} while (0)
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Report here: https://github.com/apache/nuttx-apps/actions/runs/4102723052/jobs/7076100328
- Fix ble_hci_socket.c:359:5: warning: implicit declaration of function ‘ble_hci_trans_buf_free’
- Fix SYSINIT_PANIC_ASSERT_MSG refinition warning
