### PR TITLE
nimble/ll: Add option to control initial DLE update

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -129,7 +129,9 @@ union ble_ll_conn_sm_flags {
         uint32_t aux_conn_req: 1;
         uint32_t rxd_features:1;
         uint32_t pending_hci_rd_features:1;
+#if MYNEWT_VAL(BLE_LL_CONN_INIT_AUTO_DLE)
         uint32_t pending_initiate_dle:1;
+#endif
         uint32_t subrate_trans:1;
         uint32_t subrate_ind_txd:1;
         uint32_t subrate_host_req:1;

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -2137,7 +2137,10 @@ ble_ll_ctrl_update_features(struct ble_ll_conn_sm *connsm, uint8_t *feat)
         }
 #endif
 
+#if MYNEWT_VAL(BLE_LL_CONN_INIT_AUTO_DLE)
         connsm->csmflags.cfbit.pending_initiate_dle = 1;
+#endif
+
         connsm->csmflags.cfbit.rxd_features = 1;
     }
 }
@@ -3050,10 +3053,12 @@ ll_ctrl_send_rsp:
 #endif
     }
 
+#if MYNEWT_VAL(BLE_LL_CONN_INIT_AUTO_DLE)
     if (connsm->csmflags.cfbit.pending_initiate_dle) {
         connsm->csmflags.cfbit.pending_initiate_dle = 0;
         ble_ll_ctrl_initiate_dle(connsm, true);
     }
+#endif
 
     return rc;
 }

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -140,11 +140,15 @@ syscfg.defs:
     BLE_LL_CONN_INIT_MAX_TX_BYTES:
         description: >
             Used to set the initial maximum transmit PDU size in a
-            connection. If this is set to a value greater than 27,
-            the controller will automatically attempt to do the
-            data length update procedure. The host can always tell
-            the controller to update this value.
+            connection. The host can always tell the controller to update this
+            value.
         value: '27'
+    BLE_LL_CONN_INIT_AUTO_DLE:
+        description: >
+            If BLE_LL_CONN_INIT_MAX_TX_BYTES is set to value greater than 27
+            controller will automatically attempt to do the data length update
+            procedure.
+        value: 1
 
     # The number of slots that will be allocated to each connection
     BLE_LL_CONN_INIT_SLOTS:

--- a/porting/npl/riot/include/syscfg/syscfg.h
+++ b/porting/npl/riot/include/syscfg/syscfg.h
@@ -1046,6 +1046,10 @@
 #define MYNEWT_VAL_BLE_LL_CONN_EVENT_END_MARGIN (0)
 #endif
 
+#ifndef MYNEWT_VAL_BLE_LL_CONN_INIT_AUTO_DLE
+#define MYNEWT_VAL_BLE_LL_CONN_INIT_AUTO_DLE (1)
+#endif
+
 /* Overridden by @apache-mynewt-nimble/porting/targets/riot (defined by @apache-mynewt-nimble/nimble/controller) */
 #ifndef MYNEWT_VAL_BLE_LL_CONN_INIT_MAX_TX_BYTES
 #define MYNEWT_VAL_BLE_LL_CONN_INIT_MAX_TX_BYTES (MYNEWT_VAL_BLE_LL_MAX_PKT_SIZE)


### PR DESCRIPTION
New option allows to select if controller should initiate DLE update automatically for connection. By default it is enabled to not change existing controller behavior.