### PR TITLE
porting/nuttx; Fix error: unrecognized command-line option '-m32'

### DIFF
--- a/porting/examples/nuttx/Make.defs
+++ b/porting/examples/nuttx/Make.defs
@@ -48,8 +48,7 @@ INC = \
 
 INCLUDES := $(addprefix -I, $(INC))
 
-CFLAGS +=                    \
-    $(NIMBLE_CFLAGS)        \
+CFLAGS +=                   \
     $(INCLUDES)             \
     $(TINYCRYPT_CFLAGS)     \
     -DNIMBLE_CFG_CONTROLLER=0 -DOS_CFG_ALIGN_4=4 -DOS_CFG_ALIGNMENT=4 \


### PR DESCRIPTION
-m32 is supported by x64 toolchain, not arm-none-eabi-gcc.
Report here: https://github.com/apache/nuttx-apps/actions/runs/4131763426/jobs/7139771820
