### PR TITLE
nimble/host: Add connection handle related GAP APIs

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -1090,6 +1090,7 @@ struct ble_gap_event {
 };
 
 typedef int ble_gap_event_fn(struct ble_gap_event *event, void *arg);
+typedef int ble_gap_conn_foreach_handle_fn(uint16_t conn_handle, void *arg);
 
 #define BLE_GAP_CONN_MODE_NON               0
 #define BLE_GAP_CONN_MODE_DIR               1

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -509,6 +509,57 @@ ble_gap_conn_find_by_addr(const ble_addr_t *addr,
 #endif
 }
 
+int
+ble_gap_conn_find_handle_by_addr(const ble_addr_t *addr, uint16_t *out_conn_handle)
+{
+#if NIMBLE_BLE_CONNECT
+    struct ble_hs_conn *conn;
+
+    ble_hs_lock();
+
+    conn = ble_hs_conn_find_by_addr(addr);
+    if (conn != NULL) {
+        *out_conn_handle = conn->bhc_handle;
+    } else {
+        *out_conn_handle = BLE_HS_CONN_HANDLE_NONE;
+    }
+
+    ble_hs_unlock();
+
+    if (conn == NULL) {
+        return BLE_HS_ENOTCONN;
+    }
+
+    return 0;
+#else
+    return BLE_HS_ENOTSUP;
+#endif
+}
+
+struct foreach_handle_cb_arg {
+    ble_gap_conn_foreach_handle_fn *cb;
+    void *arg;
+};
+
+static int
+ble_gap_conn_foreach_handle_callback(struct ble_hs_conn *conn, void *arg)
+{
+    struct foreach_handle_cb_arg *cb_arg = (struct foreach_handle_cb_arg *)arg;
+
+    return cb_arg->cb(conn->bhc_handle, cb_arg->arg);
+}
+
+void
+ble_gap_conn_foreach_handle(ble_gap_conn_foreach_handle_fn *cb, void *arg)
+{
+    struct foreach_handle_cb_arg cb_arg = {
+        .cb = cb,
+        .arg = arg,
+    };
+
+    ble_hs_conn_foreach(ble_gap_conn_foreach_handle_callback, &cb_arg);
+}
+
 #if NIMBLE_BLE_CONNECT
 static int
 ble_gap_extract_conn_cb(uint16_t conn_handle,


### PR DESCRIPTION
This adds two new GAP APIs:

void ble_gap_conn_foreach_handle(ble_gap_conn_foreach_handle_fn &ast;cb, void &ast;arg)
API can be used to call function declared by the user for every connection that is currently established. As arguments, it takes a pointer to the function, that will be called and a void pointer, which is used to pass the optional argument of any type to the called function. Function from passed pointer should return an int value and take two arguments - uint16_t for conn_handle and void&ast; for the optional argument (see ble_gap_conn_foreach_handle_fn typedef).

int ble_gap_conn_func_handle_by_addr(const ble_addr_t &ast;addr, uint16_t &ast;out_conn_handle)
API will look for the connection with address specified in the first argument and if it succeds, it will write the connection handle to the variable pointed by out_conn_handle. Returns 0 on success or BLE_HS_ENOTCONN if connection with specified address was not found.