### PR TITLE
nimble/host: Add peer id addr to identity resolved event

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -808,6 +808,8 @@ struct ble_gap_event {
         struct {
             /** The handle of the relevant connection. */
             uint16_t conn_handle;
+            /** Peer identity address */
+            ble_addr_t peer_id_addr;
         } identity_resolved;
 
         /**

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -5934,7 +5934,7 @@ ble_gap_enc_event(uint16_t conn_handle, int status,
 }
 
 void
-ble_gap_identity_event(uint16_t conn_handle)
+ble_gap_identity_event(uint16_t conn_handle, const ble_addr_t *peer_id_addr)
 {
 #if NIMBLE_BLE_SM && NIMBLE_BLE_CONNECT
     struct ble_gap_event event;
@@ -5944,6 +5944,7 @@ ble_gap_identity_event(uint16_t conn_handle)
     memset(&event, 0, sizeof event);
     event.type = BLE_GAP_EVENT_IDENTITY_RESOLVED;
     event.identity_resolved.conn_handle = conn_handle;
+    event.identity_resolved.peer_id_addr = *peer_id_addr;
     ble_gap_call_conn_event_cb(&event, conn_handle);
 #endif
 }

--- a/nimble/host/src/ble_gap_priv.h
+++ b/nimble/host/src/ble_gap_priv.h
@@ -135,7 +135,7 @@ void ble_gap_subscribe_event(uint16_t conn_handle, uint16_t attr_handle,
                              uint8_t prev_notify, uint8_t cur_notify,
                              uint8_t prev_indicate, uint8_t cur_indicate);
 void ble_gap_mtu_event(uint16_t conn_handle, uint16_t cid, uint16_t mtu);
-void ble_gap_identity_event(uint16_t conn_handle);
+void ble_gap_identity_event(uint16_t conn_handle, const ble_addr_t *peer_id_addr);
 int ble_gap_repeat_pairing_event(const struct ble_gap_repeat_pairing *rp);
 void ble_gap_pairing_complete_event(uint16_t conn_handle, int status);
 void ble_gap_vs_hci_event(const void *buf, uint8_t len);

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -573,7 +573,8 @@ ble_sm_persist_keys(struct ble_sm_proc *proc)
     ble_hs_unlock();
 
     if (identity_ev) {
-        ble_gap_identity_event(proc->conn_handle);
+        /* Use peer_addr since it does have proper addr type (i.e. 0/1, not 2/3) */
+        ble_gap_identity_event(proc->conn_handle, &peer_addr);
     }
 
     authenticated = proc->flags & BLE_SM_PROC_F_AUTHENTICATED;


### PR DESCRIPTION
This way app does not need to query for new ID address.