### PR TITLE
ble_hci_socket.c: fix NuttX CI error

### DIFF
--- a/nimble/transport/socket/src/ble_hci_socket.c
+++ b/nimble/transport/socket/src/ble_hci_socket.c
@@ -334,6 +334,7 @@ ble_hci_sock_cmdevt_tx(uint8_t *hci_ev, uint8_t h4_type)
 
     memcpy(&addr, &addr, sizeof(struct sockaddr_hci));
 
+    len = 0;
     if (h4_type == BLE_HCI_UART_H4_CMD) {
         len = sizeof(struct ble_hci_cmd) + hci_ev[2];
         STATS_INC(hci_sock_stats, ocmd);


### PR DESCRIPTION
ble_hci_socket.c: fix warning 'len' may be used uninitialized in this function [-Wmaybe-uninitialized]