### PR TITLE
nimble/host: Update existing bond while re-pairing

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -2258,17 +2258,6 @@ cmd_keystore_parse_keydata(int argc, char **argv, union ble_store_key *out,
             return rc;
         }
 
-        out->sec.ediv = parse_arg_uint16("ediv", &rc);
-        if (rc != 0) {
-            console_printf("invalid 'ediv' parameter\n");
-            return rc;
-        }
-
-        out->sec.rand_num = parse_arg_uint64("rand", &rc);
-        if (rc != 0) {
-            console_printf("invalid 'rand' parameter\n");
-            return rc;
-        }
         return 0;
 
     default:
@@ -2317,8 +2306,6 @@ cmd_keystore_parse_valuedata(int argc, char **argv,
                 return rc;
             }
             out->sec.peer_addr = key->sec.peer_addr;
-            out->sec.ediv = key->sec.ediv;
-            out->sec.rand_num = key->sec.rand_num;
             break;
     }
 

--- a/nimble/host/include/host/ble_store.h
+++ b/nimble/host/include/host/ble_store.h
@@ -50,14 +50,6 @@ struct ble_store_key_sec {
      */
     ble_addr_t peer_addr;
 
-    /** Key by ediv; ediv_rand_present=0 means don't key off ediv. */
-    uint16_t ediv;
-
-    /** Key by rand_num; ediv_rand_present=0 means don't key off rand_num. */
-    uint64_t rand_num;
-
-    unsigned ediv_rand_present:1;
-
     /** Number of results to skip; 0 means retrieve the first match. */
     uint8_t idx;
 };

--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -1242,11 +1242,11 @@ ble_sm_retrieve_ltk(uint16_t ediv, uint64_t rand, uint8_t peer_addr_type,
     memset(&key_sec, 0, sizeof key_sec);
     key_sec.peer_addr.type = peer_addr_type;
     memcpy(key_sec.peer_addr.val, peer_addr, 6);
-    key_sec.ediv = ediv;
-    key_sec.rand_num = rand;
-    key_sec.ediv_rand_present = 1;
 
     rc = ble_store_read_our_sec(&key_sec, value_sec);
+    if (value_sec->ediv != ediv || value_sec->rand_num != rand) {
+        return BLE_HS_ENOENT;
+    }
     return rc;
 }
 

--- a/nimble/host/src/ble_store.c
+++ b/nimble/host/src/ble_store.c
@@ -299,10 +299,6 @@ ble_store_key_from_value_sec(struct ble_store_key_sec *out_key,
                              const struct ble_store_value_sec *value)
 {
     out_key->peer_addr = value->peer_addr;
-
-    out_key->ediv = value->ediv;
-    out_key->rand_num = value->rand_num;
-    out_key->ediv_rand_present = 1;
     out_key->idx = 0;
 }
 
@@ -341,18 +337,18 @@ ble_store_iterate(int obj_type,
     /* a magic value to retrieve anything */
     memset(&key, 0, sizeof(key));
     switch(obj_type) {
-        case BLE_STORE_OBJ_TYPE_PEER_SEC:
-        case BLE_STORE_OBJ_TYPE_OUR_SEC:
-            key.sec.peer_addr = *BLE_ADDR_ANY;
-            pidx = &key.sec.idx;
-            break;
-        case BLE_STORE_OBJ_TYPE_CCCD:
-            key.cccd.peer_addr = *BLE_ADDR_ANY;
-            pidx = &key.cccd.idx;
-            break;
-        default:
-            BLE_HS_DBG_ASSERT(0);
-            return BLE_HS_EINVAL;
+    case BLE_STORE_OBJ_TYPE_PEER_SEC:
+    case BLE_STORE_OBJ_TYPE_OUR_SEC:
+        key.sec.peer_addr = *BLE_ADDR_ANY;
+        pidx = &key.sec.idx;
+        break;
+    case BLE_STORE_OBJ_TYPE_CCCD:
+        key.cccd.peer_addr = *BLE_ADDR_ANY;
+        pidx = &key.cccd.idx;
+        break;
+    default:
+        BLE_HS_DBG_ASSERT(0);
+        return BLE_HS_EINVAL;
     }
 
     while (1) {

--- a/nimble/host/store/config/src/ble_store_config.c
+++ b/nimble/host/store/config/src/ble_store_config.c
@@ -75,10 +75,6 @@ ble_store_config_print_key_sec(const struct ble_store_key_sec *key_sec)
         ble_hs_log_flat_buf(key_sec->peer_addr.val, 6);
         BLE_HS_LOG(DEBUG, " ");
     }
-    if (key_sec->ediv_rand_present) {
-        BLE_HS_LOG(DEBUG, "ediv=0x%02x rand=0x%llx ",
-                       key_sec->ediv, key_sec->rand_num);
-    }
 }
 
 static int
@@ -87,36 +83,20 @@ ble_store_config_find_sec(const struct ble_store_key_sec *key_sec,
                           int num_value_secs)
 {
     const struct ble_store_value_sec *cur;
-    int skipped;
     int i;
 
-    skipped = 0;
+    if (!ble_addr_cmp(&key_sec->peer_addr, BLE_ADDR_ANY)) {
+        if (key_sec->idx < num_value_secs) {
+            return key_sec->idx;
+        }
+    } else if (key_sec->idx == 0) {
+        for (i = 0; i < num_value_secs; i++) {
+            cur = &value_secs[i];
 
-    for (i = 0; i < num_value_secs; i++) {
-        cur = value_secs + i;
-
-        if (ble_addr_cmp(&key_sec->peer_addr, BLE_ADDR_ANY)) {
-            if (ble_addr_cmp(&cur->peer_addr, &key_sec->peer_addr)) {
-                continue;
+            if (!ble_addr_cmp(&cur->peer_addr, &key_sec->peer_addr)) {
+                return i;
             }
         }
-
-        if (key_sec->ediv_rand_present) {
-            if (cur->ediv != key_sec->ediv) {
-                continue;
-            }
-
-            if (cur->rand_num != key_sec->rand_num) {
-                continue;
-            }
-        }
-
-        if (key_sec->idx > skipped) {
-            skipped++;
-            continue;
-        }
-
-        return i;
     }
 
     return -1;

--- a/nimble/host/test/src/ble_sm_test_util.c
+++ b/nimble/host/test/src/ble_sm_test_util.c
@@ -1671,9 +1671,6 @@ ble_sm_test_util_peer_bonding_good(int send_enc_req,
     TEST_ASSERT(ble_sm_test_store_obj_type == BLE_STORE_OBJ_TYPE_OUR_SEC);
     TEST_ASSERT(ble_sm_test_store_key.sec.peer_addr.type ==
                 ble_hs_misc_peer_addr_type_to_id(peer_addr_type));
-    TEST_ASSERT(ble_sm_test_store_key.sec.ediv_rand_present);
-    TEST_ASSERT(ble_sm_test_store_key.sec.ediv == ediv);
-    TEST_ASSERT(ble_sm_test_store_key.sec.rand_num == rand_num);
 
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
     TEST_ASSERT(ble_sm_num_procs() == 1);
@@ -1738,9 +1735,6 @@ ble_sm_test_util_peer_bonding_bad(uint16_t ediv, uint64_t rand_num)
     /* Ensure the LTK request event got sent to the application. */
     TEST_ASSERT(ble_sm_test_store_obj_type ==
                 BLE_STORE_OBJ_TYPE_OUR_SEC);
-    TEST_ASSERT(ble_sm_test_store_key.sec.ediv_rand_present);
-    TEST_ASSERT(ble_sm_test_store_key.sec.ediv == ediv);
-    TEST_ASSERT(ble_sm_test_store_key.sec.rand_num == rand_num);
 
     TEST_ASSERT(!conn->bhc_sec_state.encrypted);
 


### PR DESCRIPTION
While re-pairing ble_store_config_find_sec function was checking peer address, ediv and random number. Even if peer address was the same, the bond could be recognized as not the one we was looking for, because ediv and random number could be different. This was causing issues when the BLE_STORE_MAX_BONDS syscfg val was used. Re-pairing to the same device was treated as pairing to the new device and if current number of bonds was the same as BLE_STORE_MAX_BONDS, the re-pairing was failing.