### PR TITLE
ci: Use latest go for building newt

### DIFF
--- a/.github/workflows/build_targets.yml
+++ b/.github/workflows/build_targets.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: 'stable'
       - uses: carlosperate/arm-none-eabi-gcc-action@48db4484a55750df7a0ccca63347fcdea6534d78
         with:
           release: '12.2.Rel1'
@@ -45,7 +45,7 @@ jobs:
       - name: Install newt
         run: |
              go version
-             go get mynewt.apache.org/newt/newt@latest
+             go install mynewt.apache.org/newt/newt@latest
       - name: Setup project
         run: |
              cp .github/project.yml project.yml

--- a/.github/workflows/newt_test_all.yml
+++ b/.github/workflows/newt_test_all.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: 'stable'
       - name: Install Dependencies
         run: |
              sudo apt-get update
@@ -37,7 +37,7 @@ jobs:
       - name: Install newt
         run: |
              go version
-             go get mynewt.apache.org/newt/newt@latest
+             go install mynewt.apache.org/newt/newt@latest
       - name: Setup project
         run: |
              cp .github/project.yml project.yml

--- a/.github/workflows/ports_syscfg_check.yml
+++ b/.github/workflows/ports_syscfg_check.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: 'stable'
       - uses: carlosperate/arm-none-eabi-gcc-action@48db4484a55750df7a0ccca63347fcdea6534d78
         with:
           release: '12.2.Rel1'
@@ -40,7 +40,7 @@ jobs:
       - name: Install newt
         run: |
              go version
-             go get mynewt.apache.org/newt/newt@latest
+             go install mynewt.apache.org/newt/newt@latest
       - name: Setup project
         run: |
              mkdir /tmp/proj


### PR DESCRIPTION
This should make it easier for upgrading dependencies in newt.