### PR TITLE
nimble/phy/nrf5x: Fix tx-tx timing

### DIFF
--- a/nimble/drivers/nrf5x/src/ble_phy.c
+++ b/nimble/drivers/nrf5x/src/ble_phy.c
@@ -1113,6 +1113,10 @@ ble_phy_tx_end_isr(void)
              */
             tx_time = NRF_TIMER0->CC[1] - ble_ll_pdu_syncword_us(tx_phy_mode) +
                       g_ble_phy_data.txtx_time_us;
+            /* Adjust for delay between EVENT_ADDRESS and actual address TX time */
+            /* FIXME assume this is the same as EVENT_END to end, but we should
+             *       measure this to be sure */
+            tx_time += g_ble_phy_t_txenddelay[tx_phy_mode];
         }
 
         /* Adjust for delay between EVENT_END and actual TX end time */


### PR DESCRIPTION
When scheduling relative to TX start time we should also adjust for delay between radio event and actual TX time.