### PR TITLE
nimble/host: Added debug flag around debug related code

### DIFF
--- a/nimble/host/src/ble_att_clt.c
+++ b/nimble/host/src/ble_att_clt.c
@@ -707,6 +707,8 @@ ble_att_clt_tx_write_cmd(uint16_t conn_handle, uint16_t handle,
 
     struct ble_att_write_cmd *cmd;
     struct os_mbuf *txom2;
+
+#if MYNEWT_VAL(BLE_HS_DEBUG)
     uint8_t b;
     int rc;
     int i;
@@ -720,7 +722,7 @@ ble_att_clt_tx_write_cmd(uint16_t conn_handle, uint16_t handle,
         assert(rc == 0);
         BLE_HS_LOG(DEBUG, "0x%02x", b);
     }
-
+#endif
 
     cmd = ble_att_cmd_get(BLE_ATT_OP_WRITE_CMD, sizeof(*cmd), &txom2);
     if (cmd == NULL) {


### PR DESCRIPTION
This PR attempts to put debug related code under DEBUG flag. If DEBUG flag is disabled, the existing code still executed the copying of txom contents in a loop, which wastes time. 