### PR TITLE
nimble/host: Expose the API to enable / disable privacy outside of stack.

### DIFF
--- a/nimble/host/include/ble_hs_pvcy.h
+++ b/nimble/host/include/ble_hs_pvcy.h
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_BLE_HS_PVCY_
+#define H_BLE_HS_PVCY_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int ble_hs_pvcy_set_resolve_enabled(int enable);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/nimble/host/src/ble_hs_pvcy.c
+++ b/nimble/host/src/ble_hs_pvcy.c
@@ -47,7 +47,7 @@ ble_hs_pvcy_set_addr_timeout(uint16_t timeout)
                              &cmd, sizeof(cmd), NULL, 0);
 }
 
-static int
+int
 ble_hs_pvcy_set_resolve_enabled(int enable)
 {
     struct ble_hci_le_set_addr_res_en_cp cmd;


### PR DESCRIPTION
This PR exposes the API to enable/ disable controller privacy outside stack. This way applications can enable / disable controller privacy as per use case. 