### PR TITLE
nimble/ll: Account for host provided Max_CE_length

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -291,8 +291,7 @@ struct ble_ll_conn_sm
     /* Connection timing */
     uint16_t conn_itvl;
     uint16_t supervision_tmo;
-    uint16_t min_ce_len;
-    uint16_t max_ce_len;
+    uint32_t max_ce_len_ticks;
     uint16_t tx_win_off;
     uint32_t anchor_point;
     uint8_t anchor_point_usecs;     /* XXX: can this be uint8_t ?*/

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -480,12 +480,14 @@ ble_ll_conn_hci_create_check_params(struct ble_ll_conn_create_params *cc_params)
         return BLE_ERR_INV_HCI_CMD_PARMS;
     }
 
-    /* Adjust min/max ce length to be less than interval */
-    if (cc_params->min_ce_len > cc_params->conn_itvl) {
-        cc_params->min_ce_len = cc_params->conn_itvl;
+    /* Adjust min/max ce length to be less than interval
+     * Note that interval is in 1.25ms and CE is in 625us
+     */
+    if (cc_params->min_ce_len > cc_params->conn_itvl * 2) {
+        cc_params->min_ce_len = cc_params->conn_itvl * 2;
     }
-    if (cc_params->max_ce_len > cc_params->conn_itvl) {
-        cc_params->max_ce_len = cc_params->conn_itvl;
+    if (cc_params->max_ce_len > cc_params->conn_itvl * 2) {
+        cc_params->max_ce_len = cc_params->conn_itvl * 2;
     }
 
     /* Precalculate conn interval */


### PR DESCRIPTION
If host provides maximum CE length (when initiating connection or updating its parameters) LL will take it into account when checking if more packages can be send in current event.