### PR TITLE
nimble/ll: Allow to locally update connection min/max CE length

### DIFF
--- a/nimble/controller/include/controller/ble_ll_hci.h
+++ b/nimble/controller/include/controller/ble_ll_hci.h
@@ -38,7 +38,7 @@ extern "C" {
  */
 #define BLE_LL_CFG_NUM_HCI_CMD_PKTS     (1)
 
-typedef void (*ble_ll_hci_post_cmd_complete_cb)(void);
+typedef void (*ble_ll_hci_post_cmd_complete_cb)(void *user_data);
 
 #if MYNEWT_VAL(BLE_LL_HCI_VS)
 typedef int (* ble_ll_hci_vs_cb_t)(uint16_t ocf,
@@ -80,6 +80,9 @@ bool ble_ll_hci_adv_mode_ext(void);
 int ble_ll_hci_check_dle(uint16_t max_octets, uint16_t max_time);
 
 void ble_ll_hci_supp_cmd_get(uint8_t *buf);
+
+/* Used to set post HCI command hook */
+void ble_ll_hci_post_cmd_cb_set(ble_ll_hci_post_cmd_complete_cb cb, void *user_data);
 
 #if MYNEWT_VAL(BLE_LL_HCI_VS)
 void ble_ll_hci_vs_register(struct ble_ll_hci_vs_cmd *cmds, uint32_t num_cmds);

--- a/nimble/controller/include/controller/ble_ll_sync.h
+++ b/nimble/controller/include/controller/ble_ll_sync.h
@@ -34,7 +34,7 @@ struct ble_ll_scan_addr_data;
 struct ble_ll_sync_sm;
 
 int ble_ll_sync_create(const uint8_t *cmdbuf, uint8_t len);
-int ble_ll_sync_cancel(ble_ll_hci_post_cmd_complete_cb *post_cmd_cb);
+int ble_ll_sync_cancel(void);
 int ble_ll_sync_terminate(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_sync_list_add(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_sync_list_remove(const uint8_t *cmdbuf, uint8_t len);

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -204,7 +204,7 @@ int ble_ll_conn_hci_param_rr(const uint8_t *cmdbuf, uint8_t len,
                              uint8_t *rspbuf, uint8_t *rsplen);
 int ble_ll_conn_hci_param_nrr(const uint8_t *cmdbuf, uint8_t len,
                              uint8_t *rspbuf, uint8_t *rsplen);
-int ble_ll_conn_create_cancel(ble_ll_hci_post_cmd_complete_cb *post_cmd_cb);
+int ble_ll_conn_create_cancel(void);
 void ble_ll_conn_num_comp_pkts_event_send(struct ble_ll_conn_sm *connsm);
 void ble_ll_conn_comp_event_send(struct ble_ll_conn_sm *connsm, uint8_t status,
                                  uint8_t *evbuf, struct ble_ll_adv_sm *advsm);

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -1559,13 +1559,13 @@ ble_ll_sync_create(const uint8_t *cmdbuf, uint8_t len)
 }
 
 static void
-ble_ll_sync_cancel_complete_event(void)
+ble_ll_sync_cancel_complete_event(void *user_data)
 {
     ble_ll_sync_est_event_failed(BLE_ERR_OPERATION_CANCELLED);
 }
 
 int
-ble_ll_sync_cancel(ble_ll_hci_post_cmd_complete_cb *post_cmd_cb)
+ble_ll_sync_cancel(void)
 {
     struct ble_ll_sync_sm *sm;
     os_sr_t sr;
@@ -1596,7 +1596,7 @@ ble_ll_sync_cancel(ble_ll_hci_post_cmd_complete_cb *post_cmd_cb)
     OS_EXIT_CRITICAL(sr);
 
     /* g_ble_ll_sync_create_comp_ev will be cleared by this callback */
-    *post_cmd_cb = ble_ll_sync_cancel_complete_event;
+    ble_ll_hci_post_cmd_cb_set(ble_ll_sync_cancel_complete_event, NULL);
 
     return BLE_ERR_SUCCESS;
 }


### PR DESCRIPTION
Updating Min/Max CE Length can be done without triggering LL procedure. We can do that if current connection parameters fits parameters parameters provided in HCI command. Note that this is also valid for Connections Strict Scheduling.