### PR TITLE
apps/blestress: Fix nrfx include path

### DIFF
--- a/apps/blestress/src/rx_stress.h
+++ b/apps/blestress/src/rx_stress.h
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <console/console.h>
 #include <errno.h>
-#include <nrfx/hal/nrf_aar.h>
+#include <hal/nrf_aar.h>
 
 /* BLE */
 #include "nimble/ble.h"


### PR DESCRIPTION
This fixes include path after nrfx was switched
to used github repository

This is needed when https://github.com/apache/mynewt-core/pull/2989 is merged