### PR TITLE
nimble/host: Fix compilation issues observed by enabling -O2 optimization

### DIFF
--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -1956,7 +1956,7 @@ static int
 ble_gattc_find_inc_svcs_rx_adata(struct ble_gattc_proc *proc,
                                  struct ble_att_read_type_adata *adata)
 {
-    struct ble_gatt_svc service;
+    struct ble_gatt_svc service = {0};
     int call_cb;
     int cbrc;
     int rc;


### PR DESCRIPTION
When attempting to compile code with -O2 optimization enabled, observe compilation errors: 

In function 'ble_gattc_find_inc_svcs_cb',
    inlined from 'ble_gattc_find_inc_svcs_rx_adata' at /home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c:2008:16:
/home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c:1809:14: error: 'service' may be used uninitialized [-Werror=maybe-uninitialized]
 1809 |         rc = proc->find_inc_svcs.cb(proc->conn_handle,
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1810 |                                     ble_gattc_error(status, att_handle),
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1811 |                                     service, proc->find_inc_svcs.cb_arg);
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c:1809:14: note: by argument 3 of type 'const struct ble_gatt_svc *' to 'ble_gatt_disc_svc_fn' {aka 'int(short unsigned int,  const struct ble_gatt_error *, const struct ble_gatt_svc *, void *)'}
/home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c: In function 'ble_gattc_find_inc_svcs_rx_adata':
/home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c:1959:25: note: 'service' declared here
 1959 |     struct ble_gatt_svc service;
      |                         ^~~~~~~
In function 'ble_gattc_find_inc_svcs_cb',
    inlined from 'ble_gattc_find_inc_svcs_rx_adata' at /home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c:2008:16:
/home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c:1809:14: error: 'service' may be used uninitialized [-Werror=maybe-uninitialized]
 1809 |         rc = proc->find_inc_svcs.cb(proc->conn_handle,
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1810 |                                     ble_gattc_error(status, att_handle),
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1811 |                                     service, proc->find_inc_svcs.cb_arg);
      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c:1809:14: note: by argument 3 of type 'const struct ble_gatt_svc *' to 'ble_gatt_disc_svc_fn' {aka 'int(short unsigned int,  const struct ble_gatt_error *, const struct ble_gatt_svc *, void *)'}
/home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c: In function 'ble_gattc_find_inc_svcs_rx_adata':
/home/rahul/development/gitlab/esp-idf/components/bt/host/nimble/nimble/nimble/host/src/ble_gattc.c:1959:25: note: 'service' declared here
 1959 |     struct ble_gatt_svc service;
      |                         ^~~~~~~
cc1: some warnings being treated as errors
