### PR TITLE
nimble/host: Removed the extra status field in the enh read transmit power level

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6608,7 +6608,7 @@ ble_gap_enh_read_transmit_power_level(uint16_t conn_handle, uint8_t phy, uint8_t
         return rc;
     }
 
-    *out_status = rsp.status;
+    *out_status = rc;
     *out_phy = rsp.phy;
     *out_curr_tx_power_level = rsp.curr_tx_power_level;
     *out_max_tx_power_level = rsp.max_tx_power_level;

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1095,7 +1095,6 @@ struct ble_hci_le_enh_read_transmit_power_level_cp {
     uint8_t phy;
 } __attribute__((packed));
 struct ble_hci_le_enh_read_transmit_power_level_rp {
-    uint8_t status;
     uint16_t conn_handle;
     uint8_t phy;
     uint8_t curr_tx_power_level;


### PR DESCRIPTION
Removed the extra status field in the enhanced read transmit power level