### PR TITLE
nimble/ll: Fix encryption start procedure

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1372,6 +1372,9 @@ conn_tx_pdu:
         ble_phy_encrypt_iv_set(connsm->enc_data.iv);
         ble_phy_encrypt_counter_set(connsm->enc_data.tx_pkt_cntr,
                                     CONN_IS_CENTRAL(connsm));
+        if (txend_func == NULL) {
+            txend_func = ble_ll_conn_continue_rx_encrypt;
+        }
     } else if (is_ctrl && (opcode == BLE_LL_CTRL_START_ENC_REQ)) {
         /*
          * Only the peripheral sends this and it gets sent unencrypted but


### PR DESCRIPTION
We need to update rx packet counter and direction bit after sending LL_START_ENC_RSP in central role as otherwise we will fail to decrypt LL_START_ENC_RSP from peripheral and will drop connection due to MIC failure.

This only happens if peripheral replies with LL_START_ENC_RSP in the next slot after we send LL_START_ENC_RSP. If peripheral replies with an empty PDU instead, we will update direction bit on continuation and decryption on rx will be successful.