### PR TITLE
nimble/ll: Fix hci supported cmds

### DIFF
--- a/nimble/controller/src/ble_ll_hci_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_hci_supp_cmd.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <syscfg/syscfg.h>
+#include <controller/ble_ll.h>
 #include <controller/ble_ll_hci.h>
 
 /* Magic macros */


### PR DESCRIPTION
BLE_LL_BT5_PHY_SUPPORTED is defined in ble_ll.h so if that file is not included, we calculate incorrect hci supported cmds bitmask.