### PR TITLE
nimble/transport: Remove initialization of hci socket from sysinit

### DIFF
--- a/nimble/transport/socket/pkg.yml
+++ b/nimble/transport/socket/pkg.yml
@@ -33,6 +33,3 @@ pkg.deps:
 
 pkg.apis:
     - ble_transport
-
-pkg.init:
-    ble_hci_sock_init: 'MYNEWT_VAL(BLE_SOCK_CLI_SYSINIT_STAGE)'


### PR DESCRIPTION
This caused double call to hci socket init function and triggered assertion while trying to run apps on native.

@andrzej-kaczmarek 