### PR TITLE
apps/blecent: Fix incorrect return value handling in blecent_should_connect.

### DIFF
--- a/apps/blecent/src/main.c
+++ b/apps/blecent/src/main.c
@@ -272,7 +272,7 @@ blecent_should_connect(const struct ble_gap_disc_desc *disc)
 
     rc = ble_hs_adv_parse_fields(&fields, disc->data, disc->length_data);
     if (rc != 0) {
-        return rc;
+        return 0;
     }
 
     /* The device has to advertise support for the Alert Notification


### PR DESCRIPTION
apps/blecent: Fix incorrect return value handling in blecent_should_connect. 

ble_hs_adv_parse_fields can return a non zero code as error. However, a non-zero value is being treated as success in the application. So even if parsing of fields fails, the code would still assume it to be successful and proceed. 