### PR TITLE
nimble/host: Fix data type of power level and delta to handle negative values

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -1068,14 +1068,14 @@ struct ble_gap_event {
 	    /** Advertising PHY */
 	    uint8_t phy;
 
-	    /** Transmit power Level */
-	    uint8_t transmit_power_level;
+            /** Transmit power Level */
+            int8_t transmit_power_level;
 
 	    /** Transmit Power Level Flag */
 	    uint8_t transmit_power_level_flag;
 
-	    /** Delta indicating change in transmit Power Level */
-	    uint8_t delta;
+            /** Delta indicating change in transmit Power Level */
+            int8_t delta;
 	} transmit_power;
 #endif
         /**

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1937,14 +1937,14 @@ struct ble_hci_ev_le_subev_path_loss_threshold {
 
 #define BLE_HCI_LE_SUBEV_TRANSMIT_POWER_REPORT   (0x21)
 struct ble_hci_ev_le_subev_transmit_power_report {
-    uint8_t  subev_code;
-    uint8_t  status;
+    uint8_t subev_code;
+    uint8_t status;
     uint16_t conn_handle;
-    uint8_t  reason;
-    uint8_t  phy;
-    uint8_t  transmit_power_level;
-    uint8_t  transmit_power_level_flag;
-    uint8_t delta;
+    uint8_t reason;
+    uint8_t phy;
+    int8_t transmit_power_level;
+    uint8_t transmit_power_level_flag;
+    int8_t delta;
 } __attribute__((packed));
 
 #define BLE_HCI_LE_SUBEV_BIGINFO_ADV_REPORT         (0x22)


### PR DESCRIPTION
Current code had unsigned data type for power level and delta values. Since negative numbers are possible, so modified code to have signed data types.