### PR TITLE
apps/bttester: fix retrieving app included services

### DIFF
--- a/apps/bttester/src/gatt.c
+++ b/apps/bttester/src/gatt.c
@@ -138,7 +138,7 @@ gatt_svr_dsc_read_write_long_test(uint16_t conn_handle, uint16_t attr_handle,
 static const struct ble_gatt_svc_def gatt_svr_inc_svcs[] = {
     {
         .type = BLE_GATT_SVC_TYPE_PRIMARY,
-        .uuid = PTS_UUID_DECLARE(PTS_INC_SVC),
+        .uuid = BLE_UUID16_DECLARE(PTS_INC_SVC),
         .characteristics = (struct ble_gatt_chr_def[]) {{
                                                             .uuid = PTS_UUID_DECLARE(PTS_CHR_READ_WRITE_ALT),
                                                             .access_cb = gatt_svr_read_write_test,
@@ -1761,7 +1761,7 @@ get_attr_val(uint8_t *data, uint16_t len)
     struct ble_gap_conn_desc conn;
     struct os_mbuf *buf = os_msys_get(0, 0);
     uint16_t handle = sys_cpu_to_le16(cmd->handle);
-    uint8_t out_att_err;
+    uint8_t out_att_err = 0;
     int conn_status;
 
     conn_status = ble_gap_conn_find_by_addr((ble_addr_t *) data, &conn);


### PR DESCRIPTION
Local Included Service(s) values are retrieved using `ble_att_svr_read_handle`, which will lead to calling `entry->ha_cb` for Included Service. This will be `ble_gatts_inc_access`, which will not add UUID if it's not of 16 bit type. Use 16 bit UUID for included service.

`out_att_err` is now set to 0 by default - it may be not overwritten if no error occured. This will lead to undefined behavior and incorrect data in BTP response.