### PR TITLE
nimble/ll: Fix connection update instant calculation

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -109,6 +109,7 @@ union ble_ll_conn_sm_flags {
         uint32_t awaiting_host_reply:1;
         uint32_t terminate_started:1;
         uint32_t conn_update_sched:1;
+        uint32_t conn_update_use_cp:1;
         uint32_t host_expects_upd_event:1;
         uint32_t version_ind_sent:1;
         uint32_t rxd_version_ind:1;

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1976,7 +1976,7 @@ ble_ll_conn_sm_new(struct ble_ll_conn_sm *connsm)
     struct ble_ll_conn_global_params *conn_params;
 
     /* Reset following elements */
-    connsm->csmflags.conn_flags = 0;
+    memset(&connsm->csmflags, 0, sizeof(connsm->csmflags));
     connsm->event_cntr = 0;
     connsm->conn_state = BLE_LL_CONN_STATE_IDLE;
     connsm->disconnect_reason = 0;


### PR DESCRIPTION
The instant for connection update was calculated at the time PDU was
enqueued in connsm. This caused new conn params to be always applied at
instant regardless if PDU was event dequeued for tx, e.g. in case there
were lots of data PDUs to be send before control PDU.

Currently we calculate instant when PDU is dequeued to make sure this is
the next PDU to be sent and thus instant is valid.