### PR TITLE
nimble: Fixed incrementing tx credits in l2cap coc layer after a packet has been sent.

### DIFF
--- a/nimble/host/src/ble_l2cap_coc.c
+++ b/nimble/host/src/ble_l2cap_coc.c
@@ -443,6 +443,7 @@ ble_l2cap_coc_continue_tx(struct ble_l2cap_chan *chan)
     struct ble_hs_conn *conn;
     uint16_t sdu_size_offset;
     int rc;
+    uint16_t num_tx_credits = 0;
 
     /* If there is no data to send, just return success */
     tx = &chan->coc_tx;
@@ -511,6 +512,7 @@ ble_l2cap_coc_continue_tx(struct ble_l2cap_chan *chan)
         } else {
             tx->credits--;
             tx->data_offset += len - sdu_size_offset;
+            num_tx_credits++;
         }
 
         BLE_HS_LOG(DEBUG, "Sent %d bytes, credits=%d, to send %d bytes \n",
@@ -522,6 +524,7 @@ ble_l2cap_coc_continue_tx(struct ble_l2cap_chan *chan)
             os_mbuf_free_chain(tx->sdus[0]);
             tx->sdus[0] = NULL;
             tx->data_offset = 0;
+            tx->credits += num_tx_credits;
             break;
         }
     }


### PR DESCRIPTION
In function `ble_l2cap_coc_continue_tx` after sending a packet `tx->credits` was not getting incremented. Due to this, l2cap was not able to send more packets than initial credits. 
For example, after sending one packet of 512 bytes, l2cap tx credits became 0 which didn't allow sending any more packet.
Fixed it by keeping a count `num_tx_credits` which will keep track of credits used for a packet and after that packet has been sent `tx->credit` will be incremented by `num_tx_credits`.