### PR TITLE
host/sm: split error check for SC Only requirements in Pair Response

### DIFF
--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -1848,14 +1848,18 @@ ble_sm_pair_req_rx(uint16_t conn_handle, struct os_mbuf **om,
         } else if (req->max_enc_key_size > BLE_SM_PAIR_KEY_SZ_MAX) {
             res->sm_err = BLE_SM_ERR_INVAL;
             res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_INVAL);
-        } else if (MYNEWT_VAL(BLE_SM_SC_ONLY) && ((req->max_enc_key_size != BLE_SM_PAIR_KEY_SZ_MAX) ||
-                                                  !(req->authreq & BLE_SM_PAIR_AUTHREQ_SC))) {
-            /* Fail if Secure Connections Only mode is on and remote does not meet
-             * key size requirements - MITM was checked in last step. Fail if SC is not supported
-             * by peer.
+        } else if (MYNEWT_VAL(BLE_SM_SC_ONLY)) {
+            /* Fail if Secure Connections Only mode is on and remote does not
+             * meet key size requirements - MITM was checked in last step.
+             * Fail if SC is not supported by peer or key size is too small
              */
-            res->sm_err = BLE_SM_ERR_ENC_KEY_SZ;
-            res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_ENC_KEY_SZ);
+            if (!(req->authreq & BLE_SM_PAIR_AUTHREQ_SC)) {
+                res->sm_err = BLE_SM_ERR_AUTHREQ;
+                res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_AUTHREQ);
+            } else if (req->max_enc_key_size != BLE_SM_PAIR_KEY_SZ_MAX) {
+                res->sm_err = BLE_SM_ERR_ENC_KEY_SZ;
+                res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_ENC_KEY_SZ);
+            }
         } else if (!ble_sm_verify_auth_requirements(req->authreq)) {
             res->sm_err = BLE_SM_ERR_AUTHREQ;
             res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_AUTHREQ);


### PR DESCRIPTION
Different status shall be returned when key size is to small and when SC is not supported.

This is affecting GAP/SEC/SEM/BV-23-C