### PR TITLE
apps/bttester: do not fail pairing if it's already active

### DIFF
--- a/apps/bttester/src/gap.c
+++ b/apps/bttester/src/gap.c
@@ -1457,7 +1457,8 @@ pair(const uint8_t *data, uint16_t len)
         goto rsp;
     }
 
-    if (ble_gap_security_initiate(desc.conn_handle)) {
+    rc = ble_gap_security_initiate(desc.conn_handle);
+    if (rc != 0 && rc != BLE_HS_EALREADY) {
         status = BTP_STATUS_FAILED;
         goto rsp;
     }


### PR DESCRIPTION
Sometimes it's simpler to call pair() even when procedure is already active. Do not fail command in this case, as it doesn't influence already ongoing procedure.