### PR TITLE
nimble/phy/nrf5x: Update NRF5340 errata 158

### DIFF
--- a/nimble/drivers/nrf5x/src/ble_phy.c
+++ b/nimble/drivers/nrf5x/src/ble_phy.c
@@ -1571,7 +1571,9 @@ ble_phy_init(void)
     /* Errata 158: load trim values after toggling power */
     for (uint32_t index = 0; index < 32ul &&
          NRF_FICR_NS->TRIMCNF[index].ADDR != (uint32_t *)0xFFFFFFFFul; index++) {
-        *((volatile uint32_t *)NRF_FICR_NS->TRIMCNF[index].ADDR) = NRF_FICR_NS->TRIMCNF[index].DATA;
+        if (((uint32_t)NRF_FICR_NS->TRIMCNF[index].ADDR & 0xFFFFF000ul) == (volatile uint32_t)NRF_RADIO_NS) {
+            *((volatile uint32_t *)NRF_FICR_NS->TRIMCNF[index].ADDR) = NRF_FICR_NS->TRIMCNF[index].DATA;
+        }
     }
 
     *(volatile uint32_t *)(NRF_RADIO_NS_BASE + 0x774) =


### PR DESCRIPTION
Errata specifies only NRF_RADIO registers that should be copied from FICR, code copied all registers from TRIMCNF.

Now only NRF_RADIO registers are copied as part of Errata 158 implementation.