### PR TITLE
porting/npl/nuttx: add support for thread names

### DIFF
--- a/porting/examples/nuttx/main.c
+++ b/porting/examples/nuttx/main.c
@@ -111,8 +111,8 @@ int main(int argc, char *argv[])
 
     printf("hci_sock task init\n");
     ret = ble_npl_task_init(&s_task_hci, "hci_sock", ble_hci_sock_task,
-                      NULL, TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
-                      TASK_DEFAULT_STACK, TASK_DEFAULT_STACK_SIZE);
+                            NULL, TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
+                            TASK_DEFAULT_STACK, TASK_DEFAULT_STACK_SIZE);
 
     if (ret != 0)
       {
@@ -122,8 +122,8 @@ int main(int argc, char *argv[])
     /* Create task which handles default event queue for host stack. */
     printf("ble_host task init\n");
     ret = ble_npl_task_init(&s_task_host, "ble_host", ble_host_task,
-                      NULL, TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
-                      TASK_DEFAULT_STACK, TASK_DEFAULT_STACK_SIZE);
+                            NULL, TASK_DEFAULT_PRIORITY, BLE_NPL_TIME_FOREVER,
+                            TASK_DEFAULT_STACK, TASK_DEFAULT_STACK_SIZE);
 
 
     if (ret != 0)

--- a/porting/npl/nuttx/src/os_callout.c
+++ b/porting/npl/nuttx/src/os_callout.c
@@ -91,6 +91,7 @@ ble_npl_callout_init(struct ble_npl_callout *c,
         pthread_attr_init(&attr);
         pthread_attr_setstacksize(&attr, CONFIG_NIMBLE_CALLOUT_THREAD_STACKSIZE);
         pthread_create(&callout_thread, &attr, callout_handler, NULL);
+        pthread_setname_np(callout_thread, "ble_npl_callout");
         thread_started = true;
     }
 

--- a/porting/npl/nuttx/src/os_task.c
+++ b/porting/npl/nuttx/src/os_task.c
@@ -77,6 +77,10 @@ ble_npl_task_init(struct ble_npl_task *t, const char *name, ble_npl_task_func_t 
       {
         err = OS_ENOMEM;
       }
+    else
+      {
+        pthread_setname_np(t->handle, t->name);
+      }
 
     return err;
 }


### PR DESCRIPTION
This change adds name assignment for the threads created by nimBLE in NuttX based systems, so it is easier to track them in the process tree.