### PR TITLE
 nimble/host: Added return type handling for npl_mutex_init

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6593,7 +6593,12 @@ ble_gap_init(void)
     memset(&ble_gap_sync, 0, sizeof(ble_gap_sync));
 #endif
 
-    ble_npl_mutex_init(&preempt_done_mutex);
+    rc = ble_npl_mutex_init(&preempt_done_mutex);
+
+    if (rc) {
+       BLE_HS_LOG(ERROR, "mutex init failed with reason %d \n", rc);
+       return rc;
+    }
 
     SLIST_INIT(&ble_gap_update_entries);
     SLIST_INIT(&ble_gap_event_listener_list);

--- a/nimble/transport/src/monitor.c
+++ b/nimble/transport/src/monitor.c
@@ -299,6 +299,7 @@ void
 ble_monitor_init(void)
 {
     SYSINIT_ASSERT_ACTIVE();
+    ble_npl_error_t rc;
 
 #if MYNEWT_VAL(BLE_MONITOR_UART)
     struct uart_conf uc = {
@@ -340,7 +341,8 @@ ble_monitor_init(void)
     SYSINIT_PANIC_ASSERT(rtt_index >= 0);
 #endif
 
-    ble_npl_mutex_init(&lock);
+    rc = ble_npl_mutex_init(&lock);
+    SYSINIT_PANIC_ASSERT(rc == 0);
 
 #if BLE_MONITOR
     ble_monitor_new_index(0, (uint8_t[6]){ }, "nimble0");


### PR DESCRIPTION
npl_mutex_init may return a non-zero value in case of failure. At certain places, the check is missing to capture the return value. Added the same. 