### PR TITLE
nimble/host : Added leading_space as parameter to os_msys_get_pkthdr

### DIFF
--- a/nimble/host/src/ble_hs_mbuf.c
+++ b/nimble/host/src/ble_hs_mbuf.c
@@ -31,9 +31,9 @@ ble_hs_mbuf_gen_pkt(uint16_t leading_space)
     int rc;
 
 #if MYNEWT_VAL(BLE_CONTROLLER)
-    om = os_msys_get_pkthdr(0, sizeof(struct ble_mbuf_hdr));
+    om = os_msys_get_pkthdr(leading_space, sizeof(struct ble_mbuf_hdr));
 #else
-    om = os_msys_get_pkthdr(0, 0);
+    om = os_msys_get_pkthdr(leading_space, 0);
 #endif
     if (om == NULL) {
         return NULL;


### PR DESCRIPTION
1. os_msys_get_pkthdr is called without considering the leading space required in the packet.
2. This can lead to BLE_HS_ENOMEM if the packet size is not large enough to accommodate leading space.
3. Fixed this by passing leading_space to os_msys_get_pkthdr as parameter.

