### PR TITLE
porting/npl/linux: Replace pthread_yield() with sched_yield()

### DIFF
--- a/porting/npl/linux/src/os_task.c
+++ b/porting/npl/linux/src/os_task.c
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include <sched.h>
+
 #include "os/os.h"
 #include "nimble/nimble_npl.h"
 
@@ -106,7 +108,7 @@ bool ble_npl_os_started(void)
 
 void ble_npl_task_yield(void)
 {
-    pthread_yield();
+    sched_yield();
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Per `pthread_yield(3)`:
```
  This call is nonstandard, but present on several other systems.
  Use the standardized sched_yield(2) instead.
```