### PR TITLE
if MYNEWT -> ifdef MYNEWT

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -368,7 +368,7 @@ static void ble_ll_event_tx_pkt(struct ble_npl_event *ev);
 static void ble_ll_event_dbuf_overflow(struct ble_npl_event *ev);
 #endif
 
-#if MYNEWT
+#ifdef MYNEWT
 /* The BLE LL task data structure */
 struct os_task g_ble_ll_task;
 
@@ -1970,7 +1970,7 @@ ble_ll_init(void)
     ble_ll_ext_init();
 #endif
 
-#if MYNEWT
+#ifdef MYNEWT
     /* Initialize the LL task */
     os_task_init(&g_ble_ll_task, "ble_ll", ble_ll_task, NULL,
                  MYNEWT_VAL(BLE_LL_PRIO), OS_WAIT_FOREVER, g_ble_ll_stack,

--- a/nimble/host/mesh/src/adv_legacy.c
+++ b/nimble/host/mesh/src/adv_legacy.c
@@ -40,7 +40,7 @@ static int adv_initialized = false;
 /* TinyCrypt PRNG consumes a lot of stack space, so we need to have
  * an increased call stack whenever it's used.
  */
-#if MYNEWT
+#ifdef MYNEWT
 OS_TASK_STACK_DEFINE(g_blemesh_stack, MYNEWT_VAL(BLE_MESH_ADV_STACK_SIZE));
 struct os_task adv_task;
 #endif
@@ -214,7 +214,7 @@ void bt_mesh_adv_init(void)
 
 	ble_npl_eventq_init(&bt_mesh_adv_queue);
 
-#if MYNEWT
+#ifdef MYNEWT
 	os_task_init(&adv_task, "mesh_adv", mesh_adv_thread, NULL,
 	             MYNEWT_VAL(BLE_MESH_ADV_TASK_PRIO), OS_WAIT_FOREVER,
 	             g_blemesh_stack, MYNEWT_VAL(BLE_MESH_ADV_STACK_SIZE));

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -35,7 +35,7 @@
 #define max(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
-#if MYNEWT
+#ifdef MYNEWT
 #include "bsp/bsp.h"
 #else
 #define bssnz_t

--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -120,7 +120,7 @@ ble_hs_evq_set(struct ble_npl_eventq *evq)
 int
 ble_hs_locked_by_cur_task(void)
 {
-#if MYNEWT
+#ifdef MYNEWT
     struct os_task *owner;
 
     if (!ble_npl_os_started()) {

--- a/nimble/host/src/ble_hs_shutdown.c
+++ b/nimble/host/src/ble_hs_shutdown.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#if MYNEWT
+#ifdef MYNEWT
 
 #include "os/mynewt.h"
 #include "ble_hs_priv.h"

--- a/nimble/transport/socket/src/ble_hci_socket.c
+++ b/nimble/transport/socket/src/ble_hci_socket.c
@@ -146,7 +146,7 @@ STATS_NAME_END(hci_sock_stats)
 #define BLE_HCI_UART_H4_SKIP_CMD    0x81
 #define BLE_HCI_UART_H4_SKIP_ACL    0x82
 
-#if MYNEWT
+#ifdef MYNEWT
 
 #define BLE_SOCK_STACK_SIZE         \
     OS_STACK_ALIGN(MYNEWT_VAL(BLE_SOCK_STACK_SIZE))
@@ -778,7 +778,7 @@ ble_hci_sock_init_task(void)
     ble_npl_callout_init(&ble_hci_sock_state.timer, &ble_hci_sock_state.evq,
                     ble_hci_sock_rx_ev, NULL);
 
-#if MYNEWT
+#ifdef MYNEWT
     {
         os_stack_t *pstack;
 

--- a/porting/nimble/include/log/log.h
+++ b/porting/nimble/include/log/log.h
@@ -30,7 +30,7 @@ log_dummy(void *log, ...)
     (void)log;
 }
 
-#if MYNEWT
+#ifdef MYNEWT
 #define LOG_DEBUG(_log, _mod, ...)      log_dummy(_log, ## __VA_ARGS__)
 #define LOG_INFO(_log, _mod, ...)       log_dummy(_log, ## __VA_ARGS__)
 #define LOG_WARN(_log, _mod, ...)       log_dummy(_log, ## __VA_ARGS__)

--- a/porting/nimble/src/hal_timer.c
+++ b/porting/nimble/src/hal_timer.c
@@ -541,7 +541,7 @@ hal_timer_init(int timer_num, void *cfg)
 #ifndef RIOT_VERSION
     NVIC_SetPriority(irq_num, (1 << __NVIC_PRIO_BITS) - 1);
 #endif
-#if MYNEWT
+#ifdef MYNEWT
     NVIC_SetVector(irq_num, (uint32_t)irq_isr);
 #else
     ble_npl_hw_set_isr(irq_num, irq_isr);


### PR DESCRIPTION
Currently there's a mix of `#if MYNEWT` and `#ifdef MYNEWT` used in the codebase to check if the environment is Mynewt or not. This is incompatible with `-Wundef`, so switch common parts of the code to uniformly use `#ifdef`.