### PR TITLE
nimble/host: fix gcc 13 warnings

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6461,6 +6461,9 @@ ble_gap_preempt_done(void)
         void *arg;
     } slaves[BLE_ADV_INSTANCES];
 
+    master_cb = NULL;
+    master_arg = NULL;
+
     disc_preempted = 0;
 
     /* Protects slaves from accessing by multiple threads */


### PR DESCRIPTION
Fix for warnings appeared while building with gcc 13.1.0

```
In function 'ble_gap_call_event_cb',
     inlined from 'ble_gap_preempt_done' at ../../../../../../components/bt/host/nimble/nimble/nimble/host/src/ble_gap.c:6755:9:
 ../../../../../../components/bt/host/nimble/nimble/nimble/host/src/ble_gap.c:769:14: error: 'master_cb' may be used uninitialized [-Werror=maybe-uninitialized]
   769 |         rc = cb(event, cb_arg);
       |              ^~~~~~~~~~~~~~~~~
 ../../../../../../components/bt/host/nimble/nimble/nimble/host/src/ble_gap.c: In function 'ble_gap_preempt_done':
 ../../../../../../components/bt/host/nimble/nimble/nimble/host/src/ble_gap.c:6704:23: note: 'master_cb' was declared here
  6704 |     ble_gap_event_fn *master_cb;
       |                       ^~~~~~~~~
 In function 'ble_gap_call_event_cb',
     inlined from 'ble_gap_preempt_done' at ../../../../../../components/bt/host/nimble/nimble/nimble/host/src/ble_gap.c:6755:9:
 ../../../../../../components/bt/host/nimble/nimble/nimble/host/src/ble_gap.c:769:14: error: 'master_arg' may be used uninitialized [-Werror=maybe-uninitialized]
   769 |         rc = cb(event, cb_arg);
       |              ^~~~~~~~~~~~~~~~~
 ../../../../../../components/bt/host/nimble/nimble/nimble/host/src/ble_gap.c: In function 'ble_gap_preempt_done':
 ../../../../../../components/bt/host/nimble/nimble/nimble/host/src/ble_gap.c:6705:11: note: 'master_arg' was declared here
  6705 |     void *master_arg;
       |           ^~~~~~~~~~
```