### PR TITLE
nimble/ll: Fix assert on scan start

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -1134,6 +1134,11 @@ ble_ll_scan_event_proc(struct ble_npl_event *ev)
             ble_ll_state_set(BLE_LL_STATE_STANDBY);
         }
         break;
+#if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
+    case BLE_LL_STATE_BIG:
+        start_scan = false;
+        break;
+#endif
     case BLE_LL_STATE_STANDBY:
         break;
     default:


### PR DESCRIPTION
LL_STATE_BIG was not handled properly when trying to start scan window.