### PR TITLE
apps/bttester: fix start_direct_adv command

### DIFF
--- a/apps/bttester/src/btp/btp_gap.h
+++ b/apps/bttester/src/btp/btp_gap.h
@@ -212,7 +212,7 @@ struct btp_gap_passkey_confirm_cmd {
 #define BTP_GAP_START_DIRECT_ADV        0x15
 struct btp_gap_start_direct_adv_cmd {
     ble_addr_t address;
-    uint8_t high_duty;
+    uint16_t options;
 } __packed;
 
 #define BTP_GAP_CONN_PARAM_UPDATE        0x16

--- a/apps/bttester/src/btp_gap.c
+++ b/apps/bttester/src/btp_gap.c
@@ -1577,7 +1577,7 @@ start_direct_adv(const void *cmd, uint16_t cmd_len,
 
     SYS_LOG_DBG("");
 
-    adv_params.high_duty_cycle = cp->high_duty;
+    adv_params.high_duty_cycle = cp->options & BIT(1);
 
     err = ble_gap_adv_start(own_addr_type, &cp->address,
                             BLE_HS_FOREVER, &adv_params,


### PR DESCRIPTION
high_duty_cycle is defined in flags field that is 2 octet long, as first bit.