### PR TITLE
apps/bttester: remove unstalled_cb from btp_l2cap.c

### DIFF
--- a/apps/bttester/src/btp_l2cap.c
+++ b/apps/bttester/src/btp_l2cap.c
@@ -141,19 +141,6 @@ recv_cb(uint16_t conn_handle, struct ble_l2cap_chan *chan,
 }
 
 static void
-unstalled_cb(uint16_t conn_handle, struct ble_l2cap_chan *chan,
-             int status, void *arg)
-{
-    if (status) {
-        tester_rsp(BTP_SERVICE_ID_L2CAP, BTP_L2CAP_SEND_DATA,
-                   BTP_STATUS_FAILED);
-    } else {
-        tester_rsp(BTP_SERVICE_ID_L2CAP, BTP_L2CAP_SEND_DATA,
-                   BTP_STATUS_SUCCESS);
-    }
-}
-
-static void
 reconfigured_ev(uint16_t conn_handle, struct ble_l2cap_chan *chan,
                 struct ble_l2cap_chan_info *chan_info,
                 int status)
@@ -349,10 +336,6 @@ tester_l2cap_event(struct ble_l2cap_event *event, void *arg)
             (uint32_t) event->tx_unstalled.chan,
             event->tx_unstalled.conn_handle,
             event->tx_unstalled.status);
-
-        unstalled_cb(event->tx_unstalled.conn_handle,
-                     event->tx_unstalled.chan,
-                     event->tx_unstalled.status, arg);
         return 0;
     case BLE_L2CAP_EVENT_COC_RECONFIG_COMPLETED:
         if (ble_l2cap_get_chan_info(event->reconfigured.chan,


### PR DESCRIPTION
Response to BTP_L2CAP_SEND_DATA command is already sent in command handler (`send_data()`). Sending further responses to already answered command is confusing - we cannot fail successful procedure retroactively. Data sending is already confirmed to be started successfully and no further responses are expected - more so, it appears to break `available_queue` management and further commands cannot be processed correctly.

Similar callback may be proposed in the future if confirmation of sending data is needed, but not in form of BTP response, but BTP event.