### PR TITLE
host/ble_att_svr.c: do not read own characteristics without read perm…

### DIFF
--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -404,11 +404,10 @@ ble_att_svr_read(uint16_t conn_handle,
 
     att_err = 0;    /* Silence gcc warning. */
 
-    if (conn_handle != BLE_HS_CONN_HANDLE_NONE) {
-        rc = ble_att_svr_check_perms(conn_handle, 1, entry, &att_err);
-        if (rc != 0) {
-            goto err;
-        }
+    rc = ble_att_svr_check_perms(conn_handle, 1, entry, &att_err);
+    BLE_HS_LOG(DEBUG, "ble_att_svr_check_perms %f", rc);
+    if (rc != 0) {
+        goto err;
     }
 
     BLE_HS_DBG_ASSERT(entry->ha_cb != NULL);


### PR DESCRIPTION
…ission

Characteristics without read permission most likely do not expect being read by their access callback. This especially relates to control point characteristics, that do not hold any particular value, but are used to access procedures, like GATT_PROXY_DATA_IN characteristic in Mesh. Reading them will lead to triggering procedures resulting with undefined behavior.