### PR TITLE
apps/bttester: copy whole buffer to response of get_attr_val

### DIFF
--- a/apps/bttester/src/btp_gatt.c
+++ b/apps/bttester/src/btp_gatt.c
@@ -1807,8 +1807,8 @@ get_attr_val(const void *cmd, uint16_t cmd_len,
         rp->att_response = out_att_err;
         rp->value_length = os_mbuf_len(buf) - sizeof(*rp);
 
-        (void)memcpy(rsp, buf->om_data,  buf->om_len);
-        *rsp_len = buf->om_len;
+        os_mbuf_copydata(buf, 0, os_mbuf_len(buf), rsp);
+        *rsp_len = os_mbuf_len(buf);
 
         goto free;
     } else {
@@ -1825,8 +1825,8 @@ get_attr_val(const void *cmd, uint16_t cmd_len,
         rp->att_response = out_att_err;
         rp->value_length = os_mbuf_len(buf) - sizeof(*rp);
 
-        (void)memcpy(rsp, buf->om_data,  buf->om_len);
-        *rsp_len = buf->om_len;
+        os_mbuf_copydata(buf, 0, os_mbuf_len(buf), rsp);
+        *rsp_len = os_mbuf_len(buf);
 
         goto free;
     }


### PR DESCRIPTION
Characteristic values can be long and not fit into single os_mbuf - copy whole chain instead.