### PR TITLE
porting/npl/freertos: Add way of including HW specific header

### DIFF
--- a/porting/npl/freertos/src/npl_os_freertos.c
+++ b/porting/npl/freertos/src/npl_os_freertos.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include "nimble/nimble_npl.h"
 
+/* Include the file that defines the SCB for your HW. */
 #ifdef NIMBLE_NPL_OS_EXTRA_INCLUDE
 #include NIMBLE_NPL_OS_EXTRA_INCLUDE
 #endif

--- a/porting/npl/freertos/src/npl_os_freertos.c
+++ b/porting/npl/freertos/src/npl_os_freertos.c
@@ -22,6 +22,10 @@
 #include <string.h>
 #include "nimble/nimble_npl.h"
 
+#ifdef NIMBLE_NPL_OS_EXTRA_INCLUDE
+#include NIMBLE_NPL_OS_EXTRA_INCLUDE
+#endif
+
 static inline bool
 in_isr(void)
 {


### PR DESCRIPTION
As mentioned in the in_isr function, there is HW specific code in this file but there is no way to include a header file that defines the SCB etc. This PR adds a way to include a header file so it is possible to make this file compile without local changes.