### PR TITLE
transport/hci_h4: fix compilation error

### DIFF
--- a/nimble/transport/common/hci_h4/src/hci_h4.c
+++ b/nimble/transport/common/hci_h4/src/hci_h4.c
@@ -27,6 +27,14 @@
 #include <nimble/transport.h>
 #include <nimble/transport/hci_h4.h>
 
+#ifndef min
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef max
+#define max(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
 #define HCI_H4_SM_W4_PKT_TYPE   0
 #define HCI_H4_SM_W4_HEADER     1
 #define HCI_H4_SM_W4_PAYLOAD    2


### PR DESCRIPTION
`min(a, b)` was not defined but was used at
https://github.com/apache/mynewt-nimble/blob/690945db8b4bae8733f786cec861dc2bb90e518b/nimble/transport/common/hci_h4/src/hci_h4.c#L100

https://github.com/apache/mynewt-nimble/blob/690945db8b4bae8733f786cec861dc2bb90e518b/nimble/transport/common/hci_h4/src/hci_h4.c#L198