### PR TITLE
host/ble_store_util.c: Pass the actual return value

### DIFF
--- a/nimble/host/src/ble_store_util.c
+++ b/nimble/host/src/ble_store_util.c
@@ -153,11 +153,7 @@ ble_store_util_delete_all(int type, const union ble_store_key *key)
         rc = ble_store_delete(type, key);
     } while (rc == 0);
 
-    if (rc != BLE_HS_ENOENT) {
-        return rc;
-    }
-
-    return 0;
+    return rc;
 }
 
 static int


### PR DESCRIPTION
During deletion of records, existing code returned 0 (success) even if device was not found in the list. Instead, we should return the actual value (sucess / failure) for the operation done.