### PR TITLE
apps/bttester: disable EATT in default config

### DIFF
--- a/apps/bttester/syscfg.yml
+++ b/apps/bttester/syscfg.yml
@@ -144,5 +144,3 @@ syscfg.vals:
 
     BLE_MESH_ADV_BUF_COUNT: 20
     BLE_MESH_TX_SEG_MAX: 6
-
-    BLE_EATT_CHAN_NUM: 1


### PR DESCRIPTION
EATT causes issues with tests GAP/SEC/SEM/BV-{65-67}-C. It is experimental feature and should not influence config for current test plan.