### PR TITLE
fix(nimble): Handled error return value while removing RPA list from …

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6041,6 +6041,7 @@ int
 ble_gap_unpair(const ble_addr_t *peer_addr)
 {
 #if NIMBLE_BLE_SM
+    int rc;
     struct ble_hs_conn *conn;
 
     if (!ble_hs_is_enabled()) {
@@ -6060,8 +6061,11 @@ ble_gap_unpair(const ble_addr_t *peer_addr)
 
     ble_hs_unlock();
 
-    ble_hs_pvcy_remove_entry(peer_addr->type,
+    rc = ble_hs_pvcy_remove_entry(peer_addr->type,
                              peer_addr->val);
+    if (rc != 0) {
+        return rc;
+    }
 
     return ble_store_util_delete_peer(peer_addr);
 #else


### PR DESCRIPTION
To remove the device from the RPA List ble_gap_unpair() API is used which sends a command to the controller. This command shall not be used when address resolution is enabled in the
Controller and:
- Advertising (other than periodic advertising) is enabled,
- Scanning is enabled, or
- an HCI_LE_Create_Connection, HCI_LE_Extended_Create_Connection, or
HCI_LE_Periodic_Advertising_Create_Sync command is pending.

An error check is added for the API `ble_hs_pvcy_remove_entry` which is invoked by `ble_gap_unpair()`.


