### PR TITLE
Fix a bug in ble_l2cap_sig_extract_expired

### DIFF
--- a/nimble/host/src/ble_l2cap_sig.c
+++ b/nimble/host/src/ble_l2cap_sig.c
@@ -1905,9 +1905,10 @@ ble_l2cap_sig_extract_expired(struct ble_l2cap_sig_proc_list *dst_list)
 
     ble_hs_lock();
 
-    prev = NULL;
+    next = NULL;
     proc = STAILQ_FIRST(&ble_l2cap_sig_procs);
     while (proc != NULL) {
+        prev = next;
         next = STAILQ_NEXT(proc, next);
 
         time_diff = proc->exp_os_ticks - now;


### PR DESCRIPTION
Next should be updated to point at the previous element in the list for removal to work correctly.

(Found and reported by clang-analyzer - [output](https://gist.githubusercontent.com/rojer/e8aaa84619625e1064904177ace11955/raw/28e6d4392acb9446bd588434d0578bb2d4952883/gistfile1.txt))