### PR TITLE
nimble/phy/nrfx: Add support for extending T_IFS

### DIFF
--- a/nimble/drivers/nrf5x/src/ble_phy.c
+++ b/nimble/drivers/nrf5x/src/ble_phy.c
@@ -852,6 +852,8 @@ ble_phy_wfr_enable(int txrx, uint8_t tx_phy_mode, uint32_t wfr_usecs)
          * by waiting 1 usec more.
          */
         end_time += 1;
+
+        end_time += MYNEWT_VAL(BLE_PHY_EXTENDED_TIFS);
     } else {
         /*
          * RX shall start no later than wfr_usecs after RX enabled.

--- a/nimble/drivers/nrf5x/syscfg.yml
+++ b/nimble/drivers/nrf5x/syscfg.yml
@@ -26,6 +26,16 @@ syscfg.defs:
         experimental: 1
         value: 0
 
+    BLE_PHY_EXTENDED_TIFS:
+        description: >
+            This allows to extend T_ifs (inter-frame spacing) by additional
+            microseconds to improve interoperability with peripherals that
+            send packets too late (eg 153us). This prolongs reception time by
+            additional microseconds. Defaults to 2us to improve operations with
+            devices already on the market.
+        range: 0..4
+        value: 2
+
     BLE_PHY_SYSVIEW:
         description: >
             Enable SystemView tracing module for radio driver.


### PR DESCRIPTION
This allows to extend T_ifs (inter-frame spacing) by additional microseconds to improve interoperability with peripherals that send packets too late (eg 153us). This prolongs reception time by additional microseconds. Defaults to 2us to improve operations with devices already on the market.