### PR TITLE
ci: Use latest RAT snapshots

### DIFF
--- a/.github/workflows/compliance_check.yml
+++ b/.github/workflows/compliance_check.yml
@@ -48,11 +48,15 @@ jobs:
           fetch-depth: 0
       - name: Install Dependencies
         run: |
+             sudo apt-get update
+             sudo apt-get install -y libxml2-utils
              mkdir repos
              git clone --depth=1 https://github.com/apache/mynewt-core repos/apache-mynewt-core
-             wget https://dlcdn.apache.org//creadur/apache-rat-0.15/apache-rat-0.15-bin.tar.gz
-             tar zxf apache-rat-0.15-bin.tar.gz apache-rat-0.15/apache-rat-0.15.jar
-             mv apache-rat-0.15/apache-rat-0.15.jar apache-rat.jar
+             wget https://repository.apache.org/content/repositories/snapshots/org/apache/rat/apache-rat/maven-metadata.xml -O snapshot.xml
+             SNAPSHOT=`xmllint --xpath "//latest/text()" snapshot.xml`
+             wget https://repository.apache.org/content/repositories/snapshots/org/apache/rat/apache-rat/$SNAPSHOT/maven-metadata.xml -O version.xml
+             VERSION=`xmllint --xpath "//snapshotVersion[1]/value/text()" version.xml`
+             wget https://repository.apache.org/content/repositories/snapshots/org/apache/rat/apache-rat/$SNAPSHOT/apache-rat-$VERSION.jar -O apache-rat.jar
       - name: check licensing
         run: |
              ./repos/apache-mynewt-core/.github/check_license.py


### PR DESCRIPTION
SPDX support is only available in unreleased RAT snapshot so for now use latest snapshots.