### PR TITLE
  nimble/host:Handled error return value BLE_ERR_UNK_CONN_ID when encryption is enabled without distributing IRK.

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6042,6 +6042,7 @@ ble_gap_unpair(const ble_addr_t *peer_addr)
 {
 #if NIMBLE_BLE_SM
     struct ble_hs_conn *conn;
+    int rc;
 
     if (!ble_hs_is_enabled()) {
         return BLE_HS_EDISABLED;
@@ -6062,6 +6063,9 @@ ble_gap_unpair(const ble_addr_t *peer_addr)
 
     ble_hs_pvcy_remove_entry(peer_addr->type,
                              peer_addr->val);
+    if (rc != 0 && rc != BLE_HS_HCI_ERR(BLE_ERR_UNK_CONN_ID)) {
+        return rc;
+    }
 
     return ble_store_util_delete_peer(peer_addr);
 #else


### PR DESCRIPTION
If address resolution is enabled in the controller it will reject any RL modification during scanning, adv, etc. Hence controller sends a Command disallowed error which needs to be sent back to the application. Also when encryption is enabled without distributing IRK and hence the controller has no IRK but the host has LTK then the controller will return error 0x202 which needs not to be returned to delete LTK. (Hence it is skipped to return when the error code is 0 or 0x202.)