### PR TITLE
nimble/host: Fix not catching conversion error in hex2bin

### DIFF
--- a/nimble/host/src/ble_uuid.c
+++ b/nimble/host/src/ble_uuid.c
@@ -69,7 +69,7 @@ hex2bin(const char *hex, uint8_t *bin, size_t bin_len)
 
     while (*hex && len < bin_len) {
         rc = hex2val(*hex++, &tmp_val);
-        if (rc < 0) {
+        if (rc != 0) {
             return 0;
         }
 
@@ -81,7 +81,7 @@ hex2bin(const char *hex, uint8_t *bin, size_t bin_len)
         }
 
         rc = hex2val(*hex++, &tmp_val);
-        if (rc < 0) {
+        if (rc != 0) {
             return 0;
         }
         bin[len++] |= tmp_val;


### PR DESCRIPTION
hex2val returns BLE_HS_EINVAL on error which is positive value. This could result in UUID conversion errors as hex2bin is used by ble_uuid_from_str.

This was also causing build error with GCC 9:

repos/apache-mynewt-nimble/nimble/host/src/ble_uuid.c:76:28: error:
     'tmp_val' may be used uninitialized in this function
     [-Werror=maybe-uninitialized]
   76 |         bin[len] = tmp_val << 4;
      |                    ~~~~~~~~^~~~
cc1: all warnings being treated as errors