### PR TITLE
apps/btshell: fix cmd_l2cap_reconfig command

### DIFF
--- a/apps/btshell/src/cmd_l2cap.c
+++ b/apps/btshell/src/cmd_l2cap.c
@@ -291,7 +291,7 @@ cmd_l2cap_reconfig(int argc, char **argv)
     uint16_t conn;
     uint16_t mtu;
     uint8_t idxs[5];
-    int num;
+    unsigned int num;
     int rc;
 
     rc = parse_arg_init(argc - 1, argv + 1);


### PR DESCRIPTION
parse_arg_byte_stream_custom takes unsigned int as argument for result lenght.