### PR TITLE
Fix compilation issue when Max Bonds or CCCD is set as 0

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6106,6 +6106,7 @@ int
 ble_gap_unpair_oldest_except(const ble_addr_t *peer_addr)
 {
 #if NIMBLE_BLE_SM
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     ble_addr_t peer_id_addrs[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
     int num_peers;
     int rc, i;
@@ -6135,6 +6136,9 @@ ble_gap_unpair_oldest_except(const ble_addr_t *peer_addr)
     }
 
     return ble_gap_unpair(&peer_id_addrs[i]);
+#else
+    return BLE_HS_ENOTSUP;
+#endif
 #else
     return BLE_HS_ENOTSUP;
 #endif

--- a/nimble/host/src/ble_store_util.c
+++ b/nimble/host/src/ble_store_util.c
@@ -192,6 +192,7 @@ ble_store_util_count(int type, int *out_count)
 int
 ble_store_util_delete_oldest_peer(void)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     ble_addr_t peer_id_addrs[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
     int num_peers;
     int rc;
@@ -211,7 +212,7 @@ ble_store_util_delete_oldest_peer(void)
     if (rc != 0) {
         return rc;
     }
-
+#endif
     return 0;
 }
 

--- a/nimble/host/store/config/src/ble_store_config.c
+++ b/nimble/host/store/config/src/ble_store_config.c
@@ -27,22 +27,31 @@
 #include "store/config/ble_store_config.h"
 #include "ble_store_config_priv.h"
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 struct ble_store_value_sec
     ble_store_config_our_secs[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
+#endif
 int ble_store_config_num_our_secs;
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 struct ble_store_value_sec
     ble_store_config_peer_secs[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
+#endif
+
 int ble_store_config_num_peer_secs;
 
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
 struct ble_store_value_cccd
     ble_store_config_cccds[MYNEWT_VAL(BLE_STORE_MAX_CCCDS)];
+#endif
+
 int ble_store_config_num_cccds;
 
 /*****************************************************************************
  * $sec                                                                      *
  *****************************************************************************/
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 static void
 ble_store_config_print_value_sec(const struct ble_store_value_sec *sec)
 {
@@ -65,6 +74,7 @@ ble_store_config_print_value_sec(const struct ble_store_value_sec *sec)
 
     BLE_HS_LOG(DEBUG, "\n");
 }
+#endif
 
 static void
 ble_store_config_print_key_sec(const struct ble_store_key_sec *key_sec)
@@ -77,6 +87,7 @@ ble_store_config_print_key_sec(const struct ble_store_key_sec *key_sec)
     }
 }
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 static int
 ble_store_config_find_sec(const struct ble_store_key_sec *key_sec,
                           const struct ble_store_value_sec *value_secs,
@@ -101,11 +112,13 @@ ble_store_config_find_sec(const struct ble_store_key_sec *key_sec,
 
     return -1;
 }
+#endif
 
 static int
 ble_store_config_read_our_sec(const struct ble_store_key_sec *key_sec,
                               struct ble_store_value_sec *value_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int idx;
 
     idx = ble_store_config_find_sec(key_sec, ble_store_config_our_secs,
@@ -116,12 +129,16 @@ ble_store_config_read_our_sec(const struct ble_store_key_sec *key_sec,
 
     *value_sec = ble_store_config_our_secs[idx];
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 
 static int
 ble_store_config_write_our_sec(const struct ble_store_value_sec *value_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     struct ble_store_key_sec key_sec;
     int idx;
     int rc;
@@ -151,8 +168,13 @@ ble_store_config_write_our_sec(const struct ble_store_value_sec *value_sec)
     }
 
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 static int
 ble_store_config_delete_obj(void *values, int value_size, int idx,
                             int *num_values)
@@ -195,10 +217,12 @@ ble_store_config_delete_sec(const struct ble_store_key_sec *key_sec,
 
     return 0;
 }
+#endif
 
 static int
 ble_store_config_delete_our_sec(const struct ble_store_key_sec *key_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int rc;
 
     rc = ble_store_config_delete_sec(key_sec, ble_store_config_our_secs,
@@ -213,11 +237,15 @@ ble_store_config_delete_our_sec(const struct ble_store_key_sec *key_sec)
     }
 
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 static int
 ble_store_config_delete_peer_sec(const struct ble_store_key_sec *key_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int rc;
 
     rc = ble_store_config_delete_sec(key_sec, ble_store_config_peer_secs,
@@ -230,14 +258,17 @@ ble_store_config_delete_peer_sec(const struct ble_store_key_sec *key_sec)
     if (rc != 0) {
         return rc;
     }
-
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 static int
 ble_store_config_read_peer_sec(const struct ble_store_key_sec *key_sec,
                                struct ble_store_value_sec *value_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int idx;
 
     idx = ble_store_config_find_sec(key_sec, ble_store_config_peer_secs,
@@ -248,11 +279,16 @@ ble_store_config_read_peer_sec(const struct ble_store_key_sec *key_sec,
 
     *value_sec = ble_store_config_peer_secs[idx];
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
 static int
 ble_store_config_write_peer_sec(const struct ble_store_value_sec *value_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     struct ble_store_key_sec key_sec;
     int idx;
     int rc;
@@ -280,14 +316,17 @@ ble_store_config_write_peer_sec(const struct ble_store_value_sec *value_sec)
     if (rc != 0) {
         return rc;
     }
-
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 /*****************************************************************************
  * $cccd                                                                     *
  *****************************************************************************/
 
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
 static int
 ble_store_config_find_cccd(const struct ble_store_key_cccd *key)
 {
@@ -318,13 +357,14 @@ ble_store_config_find_cccd(const struct ble_store_key_cccd *key)
 
         return i;
     }
-
     return -1;
 }
+#endif
 
 static int
 ble_store_config_delete_cccd(const struct ble_store_key_cccd *key_cccd)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
     int idx;
     int rc;
 
@@ -345,14 +385,17 @@ ble_store_config_delete_cccd(const struct ble_store_key_cccd *key_cccd)
     if (rc != 0) {
         return rc;
     }
-
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 static int
 ble_store_config_read_cccd(const struct ble_store_key_cccd *key_cccd,
                            struct ble_store_value_cccd *value_cccd)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
     int idx;
 
     idx = ble_store_config_find_cccd(key_cccd);
@@ -362,11 +405,15 @@ ble_store_config_read_cccd(const struct ble_store_key_cccd *key_cccd,
 
     *value_cccd = ble_store_config_cccds[idx];
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 static int
 ble_store_config_write_cccd(const struct ble_store_value_cccd *value_cccd)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
     struct ble_store_key_cccd key_cccd;
     int idx;
     int rc;
@@ -392,6 +439,9 @@ ble_store_config_write_cccd(const struct ble_store_value_cccd *value_cccd)
     }
 
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 /*****************************************************************************

--- a/nimble/host/store/ram/src/ble_store_ram.c
+++ b/nimble/host/store/ram/src/ble_store_ram.c
@@ -36,22 +36,32 @@
 #include "host/ble_hs.h"
 #include "store/ram/ble_store_ram.h"
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 static struct ble_store_value_sec
     ble_store_ram_our_secs[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
+#endif
+
 static int ble_store_ram_num_our_secs;
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 static struct ble_store_value_sec
     ble_store_ram_peer_secs[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
+#endif
+
 static int ble_store_ram_num_peer_secs;
 
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
 static struct ble_store_value_cccd
     ble_store_ram_cccds[MYNEWT_VAL(BLE_STORE_MAX_CCCDS)];
+#endif
+
 static int ble_store_ram_num_cccds;
 
 /*****************************************************************************
  * $sec                                                                      *
  *****************************************************************************/
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 static void
 ble_store_ram_print_value_sec(const struct ble_store_value_sec *sec)
 {
@@ -74,6 +84,7 @@ ble_store_ram_print_value_sec(const struct ble_store_value_sec *sec)
 
     BLE_HS_LOG(DEBUG, "\n");
 }
+#endif
 
 static void
 ble_store_ram_print_key_sec(const struct ble_store_key_sec *key_sec)
@@ -86,6 +97,7 @@ ble_store_ram_print_key_sec(const struct ble_store_key_sec *key_sec)
     }
 }
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 static int
 ble_store_ram_find_sec(const struct ble_store_key_sec *key_sec,
                        const struct ble_store_value_sec *value_secs,
@@ -110,11 +122,13 @@ ble_store_ram_find_sec(const struct ble_store_key_sec *key_sec,
 
     return -1;
 }
+#endif
 
 static int
 ble_store_ram_read_our_sec(const struct ble_store_key_sec *key_sec,
                            struct ble_store_value_sec *value_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int idx;
 
     idx = ble_store_ram_find_sec(key_sec, ble_store_ram_our_secs,
@@ -125,11 +139,16 @@ ble_store_ram_read_our_sec(const struct ble_store_key_sec *key_sec,
 
     *value_sec = ble_store_ram_our_secs[idx];
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
 static int
 ble_store_ram_write_our_sec(const struct ble_store_value_sec *value_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     struct ble_store_key_sec key_sec;
     int idx;
 
@@ -151,9 +170,15 @@ ble_store_ram_write_our_sec(const struct ble_store_value_sec *value_sec)
     }
 
     ble_store_ram_our_secs[idx] = *value_sec;
+
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
 static int
 ble_store_ram_delete_obj(void *values, int value_size, int idx,
                          int *num_values)
@@ -196,10 +221,12 @@ ble_store_ram_delete_sec(const struct ble_store_key_sec *key_sec,
 
     return 0;
 }
+#endif
 
 static int
 ble_store_ram_delete_our_sec(const struct ble_store_key_sec *key_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int rc;
 
     rc = ble_store_ram_delete_sec(key_sec, ble_store_ram_our_secs,
@@ -207,13 +234,17 @@ ble_store_ram_delete_our_sec(const struct ble_store_key_sec *key_sec)
     if (rc != 0) {
         return rc;
     }
-
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
 static int
 ble_store_ram_delete_peer_sec(const struct ble_store_key_sec *key_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int rc;
 
     rc = ble_store_ram_delete_sec(key_sec, ble_store_ram_peer_secs,
@@ -221,14 +252,18 @@ ble_store_ram_delete_peer_sec(const struct ble_store_key_sec *key_sec)
     if (rc != 0) {
         return rc;
     }
-
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
 static int
 ble_store_ram_read_peer_sec(const struct ble_store_key_sec *key_sec,
                             struct ble_store_value_sec *value_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int idx;
 
     idx = ble_store_ram_find_sec(key_sec, ble_store_ram_peer_secs,
@@ -239,11 +274,16 @@ ble_store_ram_read_peer_sec(const struct ble_store_key_sec *key_sec,
 
     *value_sec = ble_store_ram_peer_secs[idx];
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
 static int
 ble_store_ram_write_peer_sec(const struct ble_store_value_sec *value_sec)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     struct ble_store_key_sec key_sec;
     int idx;
 
@@ -266,12 +306,17 @@ ble_store_ram_write_peer_sec(const struct ble_store_value_sec *value_sec)
 
     ble_store_ram_peer_secs[idx] = *value_sec;
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
 /*****************************************************************************
  * $cccd                                                                     *
  *****************************************************************************/
 
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
 static int
 ble_store_ram_find_cccd(const struct ble_store_key_cccd *key)
 {
@@ -305,10 +350,12 @@ ble_store_ram_find_cccd(const struct ble_store_key_cccd *key)
 
     return -1;
 }
+#endif
 
 static int
 ble_store_ram_delete_cccd(const struct ble_store_key_cccd *key_cccd)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
     int idx;
     int rc;
 
@@ -324,14 +371,18 @@ ble_store_ram_delete_cccd(const struct ble_store_key_cccd *key_cccd)
     if (rc != 0) {
         return rc;
     }
-
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
 static int
 ble_store_ram_read_cccd(const struct ble_store_key_cccd *key_cccd,
                         struct ble_store_value_cccd *value_cccd)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
     int idx;
 
     idx = ble_store_ram_find_cccd(key_cccd);
@@ -340,12 +391,17 @@ ble_store_ram_read_cccd(const struct ble_store_key_cccd *key_cccd,
     }
 
     *value_cccd = ble_store_ram_cccds[idx];
+
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
 }
 
 static int
 ble_store_ram_write_cccd(const struct ble_store_value_cccd *value_cccd)
 {
+#if MYNEWT_VAL(BLE_STORE_MAX_CCCDS)
     struct ble_store_key_cccd key_cccd;
     int idx;
 
@@ -364,6 +420,10 @@ ble_store_ram_write_cccd(const struct ble_store_value_cccd *value_cccd)
 
     ble_store_ram_cccds[idx] = *value_cccd;
     return 0;
+#else
+    return BLE_HS_ENOENT;
+#endif
+
 }
 
 /*****************************************************************************


### PR DESCRIPTION
This MR address the issue of code compilation warnings if Max bonds or Mac CCCDs is set to 0. Current code assumes that these values will never be 0. 