### PR TITLE
apps/bttester: Fix compilation with GCC 13

### DIFF
--- a/apps/bttester/src/btp/btp_gap.h
+++ b/apps/bttester/src/btp/btp_gap.h
@@ -135,8 +135,7 @@ struct btp_gap_set_bondable_rp {
 struct btp_gap_start_advertising_cmd {
     uint8_t adv_data_len;
     uint8_t scan_rsp_len;
-    uint8_t adv_data[0];
-    uint8_t scan_rsp[0];
+    uint8_t adv_sr_data[];
 /*
  * This command is very unfortunate because it has two fields after variable
  * data. Those needs to be handled explicitly by handler.

--- a/apps/bttester/src/btp_gap.c
+++ b/apps/bttester/src/btp_gap.c
@@ -462,9 +462,9 @@ start_advertising(const void *cmd, uint16_t cmd_len,
     }
 
     /* currently ignored */
-    duration = get_le32(cp->adv_data + cp->adv_data_len + cp->scan_rsp_len);
+    duration = get_le32(cp->adv_sr_data + cp->adv_data_len + cp->scan_rsp_len);
     (void)duration;
-    addr_type = cp->adv_data[cp->adv_data_len +
+    addr_type = cp->adv_sr_data[cp->adv_data_len +
                              cp->scan_rsp_len +
                              sizeof(duration)];
 
@@ -474,9 +474,9 @@ start_advertising(const void *cmd, uint16_t cmd_len,
             return BTP_STATUS_FAILED;
         }
 
-        ad[adv_len].type = cp->scan_rsp[i++];
-        ad[adv_len].data_len = cp->scan_rsp[i++];
-        ad[adv_len].data = &cp->scan_rsp[i];
+        ad[adv_len].type = cp->adv_sr_data[i++];
+        ad[adv_len].data_len = cp->adv_sr_data[i++];
+        ad[adv_len].data = &cp->adv_sr_data[i];
         i += ad[adv_len].data_len;
     }
 
@@ -486,9 +486,9 @@ start_advertising(const void *cmd, uint16_t cmd_len,
             return BTP_STATUS_FAILED;
         }
 
-        sd[sd_len].type = cp->scan_rsp[i++];
-        sd[sd_len].data_len = cp->scan_rsp[i++];
-        sd[sd_len].data = &cp->scan_rsp[i];
+        sd[sd_len].type = cp->adv_sr_data[i++];
+        sd[sd_len].data_len = cp->adv_sr_data[i++];
+        sd[sd_len].data = &cp->adv_sr_data[i];
         i += sd[sd_len].data_len;
     }
 


### PR DESCRIPTION
GCC 13 is complaining about zero elemen array that is not at the end of structure.

Error: repos/apache-mynewt-nimble/apps/bttester/src/btp_gap.c:
     In function 'start_advertising':
repos/apache-mynewt-nimble/apps/bttester/src/btp_gap.c:467:29:
     error: array subscript 514 is outside the bounds of an interior
     zero-length array 'const uint8_t[0]' {aka 'const unsigned char[]'}
     [-Werror=zero-length-bounds]
  467 |     addr_type = cp->adv_data[cp->adv_data_len +
      |                 ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
  468 |                              cp->scan_rsp_len +
      |                              ~~~~~~~~~~~~~~~~~~
  469 |                              sizeof(duration)];
      |                              ~~~~~~~~~~~~~~~~~
In file included from repos/apache-mynewt-nimble/apps/bttester/src/btp/btp.h:31,
                 from repos/apache-mynewt-nimble/apps/bttester/src/btp_gap.c:36:
repos/apache-mynewt-nimble/apps/bttester/src/btp/btp_gap.h:138:13: note:
     while referencing 'adv_data'
  138 |     uint8_t adv_data[0];
      |             ^~~~~~~~
cc1: all warnings being treated as errors