### PR TITLE
host/sm: Add CSIS SIRK encryption

### DIFF
--- a/nimble/host/include/host/ble_sm.h
+++ b/nimble/host/include/host/ble_sm.h
@@ -22,6 +22,8 @@
 
 #include <inttypes.h>
 #include "syscfg/syscfg.h"
+#include <stdbool.h>
+#include "nimble/ble.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -111,6 +113,23 @@ struct ble_sm_io {
 };
 
 int ble_sm_sc_oob_generate_data(struct ble_sm_sc_oob_data *oob_data);
+
+#if MYNEWT_VAL(BLE_SM_CSIS_SIRK)
+/**
+ * Resolves CSIS RSI to check if advertising device is part of the same Coordinated Set,
+ * as the device with specified SIRK
+ *
+ * @param rsi                   RSI value from Advertising Data
+ * @param sirk                  SIRK
+ * @param ltk_peer_addr         If SIRK is in plaintext form this should be set to NULL,
+ *                              otherwise peer address should be passed here to get
+ *                              LTK and decrypt SIRK
+ *
+ * @return                      0 if RSI was resolved succesfully; nonzero on failure.
+ */
+int ble_sm_csis_resolve_rsi(const uint8_t *rsi, const uint8_t *sirk,
+                            const ble_addr_t *ltk_peer_addr);
+#endif
 
 #if NIMBLE_BLE_SM
 int ble_sm_inject_io(uint16_t conn_handle, struct ble_sm_io *pkey);

--- a/nimble/host/src/ble_sm_priv.h
+++ b/nimble/host/src/ble_sm_priv.h
@@ -314,11 +314,24 @@ int ble_sm_alg_f6(const uint8_t *w, const uint8_t *n1, const uint8_t *n2,
                   const uint8_t *r, const uint8_t *iocap, uint8_t a1t,
                   const uint8_t *a1, uint8_t a2t, const uint8_t *a2,
                   uint8_t *check);
+int ble_sm_alg_csis_k1(const uint8_t *n, size_t n_len, const uint8_t *salt,
+                       const uint8_t *p, size_t p_len, uint8_t *out);
+int ble_sm_alg_csis_s1(const uint8_t *m, size_t m_len, uint8_t *out);
+int ble_sm_alg_csis_sef(const uint8_t *k, const uint8_t *plaintext_sirk,
+                        uint8_t *out);
+int ble_sm_alg_csis_sdf(const uint8_t *k, const uint8_t *enc_sirk,
+                        uint8_t *out);
+int ble_sm_alg_csis_sih(const uint8_t *k, const uint8_t *r, uint8_t *out);
 int ble_sm_alg_gen_dhkey(const uint8_t *peer_pub_key_x,
                          const uint8_t *peer_pub_key_y,
                          const uint8_t *our_priv_key, uint8_t *out_dhkey);
 int ble_sm_alg_gen_key_pair(uint8_t *pub, uint8_t *priv);
 void ble_sm_alg_ecc_init(void);
+
+int ble_sm_csis_generate_rsi(const uint8_t *sirk, uint8_t *out);
+int ble_sm_csis_encrypt_sirk(const uint8_t *ltk, const uint8_t *plaintext_sirk,
+                             uint8_t *out);
+int ble_sm_csis_decrypt_sirk(const uint8_t *ltk, const uint8_t *enc_sirk, uint8_t *out);
 
 void ble_sm_enc_change_rx(const struct ble_hci_ev_enrypt_chg *ev);
 void ble_sm_enc_key_refresh_rx(const struct ble_hci_ev_enc_key_refresh *ev);

--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -188,6 +188,11 @@ syscfg.defs:
             allows to decrypt air traffic easily and thus should be only used
             for debugging.
         value: 0
+    BLE_SM_CSIS_SIRK:
+        description: >
+            Enable LE Audio CSIS SIRK Encryption and Decryption API.
+        value: 0
+        experimental: 1
 
     # GAP options.
     BLE_GAP_MAX_PENDING_CONN_PARAM_UPDATE:

--- a/nimble/host/test/syscfg.yml
+++ b/nimble/host/test/syscfg.yml
@@ -24,6 +24,7 @@ syscfg.vals:
     BLE_GATT_MAX_PROCS: 16
     BLE_SM: 1
     BLE_SM_SC: 1
+    BLE_SM_CSIS_SIRK: 1
     MSYS_1_BLOCK_COUNT: 100
     BLE_L2CAP_COC_MAX_NUM: 2
     CONFIG_FCB: 1


### PR DESCRIPTION
This adds functions and algorithms to encrypt and decrypt SIRK from Coordinated Set Identification Service.

This also adds API to resolve RSI. Application can use it to find devices that are part of Coordinated Set.