### PR TITLE
nimble/ll: Improve scheduling of 1st BIG event

### DIFF
--- a/nimble/controller/include/controller/ble_ll_adv.h
+++ b/nimble/controller/include/controller/ble_ll_adv.h
@@ -201,6 +201,9 @@ int ble_ll_adv_periodic_set_info_transfer(const uint8_t *cmdbuf, uint8_t len,
 
 /* Get advertising instance with periodic advertising configured */
 struct ble_ll_adv_sm *ble_ll_adv_sync_get(uint8_t handle);
+/* Get periodic advertising event scheduled time */
+int ble_ll_adv_sync_sched_get(struct ble_ll_adv_sm *advsm,
+                              uint32_t *start_time, uint32_t *end_time);
 
 #if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
 struct ble_ll_iso_big;

--- a/nimble/controller/include/controller/ble_ll_sched.h
+++ b/nimble/controller/include/controller/ble_ll_sched.h
@@ -219,7 +219,7 @@ uint32_t ble_ll_sched_css_get_conn_interval_us(void);
 #endif
 
 #if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
-int ble_ll_sched_iso_big(struct ble_ll_sched_item *sch, int first);
+int ble_ll_sched_iso_big(struct ble_ll_sched_item *sch, int first, int fixed);
 #endif /* BLE_LL_ISO_BROADCASTER */
 
 #ifdef __cplusplus

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -5310,6 +5310,24 @@ ble_ll_adv_sync_get(uint8_t handle)
 }
 
 int
+ble_ll_adv_sync_sched_get(struct ble_ll_adv_sm *advsm, uint32_t *start_time,
+                          uint32_t *end_time)
+{
+    struct ble_ll_adv_sync *sync;
+
+    if (!advsm || !advsm->periodic_adv_active) {
+        return -EIO;
+    }
+
+    sync = SYNC_CURRENT(advsm);
+
+    *start_time = sync->sch.start_time + g_ble_ll_sched_offset_ticks;
+    *end_time = sync->sch.end_time;
+
+    return 0;
+}
+
+int
 ble_ll_adv_sync_big_add(struct ble_ll_adv_sm *advsm,
                         struct ble_ll_iso_big *big)
 {

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -844,14 +844,14 @@ ble_ll_sched_adv_resched_pdu(struct ble_ll_sched_item *sch)
 
 #if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
 int
-ble_ll_sched_iso_big(struct ble_ll_sched_item *sch, int first)
+ble_ll_sched_iso_big(struct ble_ll_sched_item *sch, int first, int fixed)
 {
     os_sr_t sr;
     int rc;
 
     OS_ENTER_CRITICAL(sr);
 
-    if (first) {
+    if (first && !fixed) {
         rc = ble_ll_sched_insert(sch, BLE_LL_SCHED_MAX_DELAY_ANY, preempt_none);
     } else {
         /* XXX provide better strategy for preemption */


### PR DESCRIPTION
This improves BIG scheduling in case periodic advertising interval is an integer multiple of ISO interval. In such case placing BIG event directly before periodic advertising event makes sure both won't overlap even if periodic advertising data changes in future.

Note that there may still be conflicts with other instances and this patch doesn't resolve that.