### PR TITLE
apps/bttester: enable EATT by default

### DIFF
--- a/apps/bttester/syscfg.yml
+++ b/apps/bttester/syscfg.yml
@@ -100,6 +100,7 @@ syscfg.vals:
     BLE_L2CAP_COC_MAX_NUM: 2
     BLE_L2CAP_SIG_MAX_PROCS: 2
     BLE_L2CAP_ENHANCED_COC: 1
+    BLE_EATT_CHAN_NUM: 5
     BLE_VERSION: 53
     # Some testcases require MPS < MTU
     BLE_L2CAP_COC_MPS: 100


### PR DESCRIPTION
Set max of 5 channels.