### PR TITLE
apps/bttester: update Mesh commands

### DIFF
--- a/apps/bttester/src/btp/btp_mesh.h
+++ b/apps/bttester/src/btp/btp_mesh.h
@@ -47,7 +47,8 @@ struct btp_mesh_read_supported_commands_rp {
 #define BTP_MESH_CONFIG_PROVISIONING    0x02
 struct btp_mesh_config_provisioning_cmd {
     uint8_t uuid[16];
-    uint8_t static_auth[16];
+    uint8_t static_auth[32];
+    uint8_t static_auth_length;
     uint8_t out_size;
     uint16_t out_actions;
     uint8_t in_size;
@@ -66,6 +67,10 @@ struct btp_mesh_provision_node_cmd {
 } __packed;
 
 #define BTP_MESH_INIT            0x04
+struct btp_mesh_init_cmd {
+    uint8_t comp;
+} __packed;
+
 #define BTP_MESH_RESET            0x05
 #define BTP_MESH_INPUT_NUMBER        0x06
 struct btp_mesh_input_number_cmd {
@@ -132,6 +137,7 @@ struct btp_mesh_lpn_unsubscribe_cmd {
 
 #define BTP_MESH_RPL_CLEAR            0x12
 #define BTP_MESH_PROXY_IDENTITY        0x13
+#define BTP_MESH_START                  0x78
 
 /* events */
 #define BTP_MESH_EV_OUT_NUMBER_ACTION    0x80

--- a/apps/bttester/src/btp/btp_mesh.h
+++ b/apps/bttester/src/btp/btp_mesh.h
@@ -119,6 +119,7 @@ struct btp_mesh_lpn_set_cmd {
 
 #define BTP_MESH_MODEL_SEND            0x0f
 struct btp_mesh_model_send_cmd {
+    uint8_t ttl;
     uint16_t src;
     uint16_t dst;
     uint8_t payload_len;

--- a/apps/bttester/src/btp_mesh.c
+++ b/apps/bttester/src/btp_mesh.c
@@ -707,7 +707,7 @@ model_send(const void *cmd, uint16_t cmd_len,
         .net_idx = net.net_idx,
         .app_idx = BT_MESH_KEY_DEV,
         .addr = sys_le16_to_cpu(cp->dst),
-        .send_ttl = BT_MESH_TTL_DEFAULT,
+        .send_ttl = cp->ttl,
     };
 
     src = sys_le16_to_cpu(cp->src);


### PR DESCRIPTION
BTP_MESH_INIT now only initialises Mesh. It expects additional field defining which composition data to use. For now it's parsed but ignored (we use always same composition data)

Introduced BTP_MESH_START command that enables Mesh advertising, as before it was in BTP_MESH_INIT. Command may be longer now, because static_auth can be 32 octets long. Additional field `static_auth_length` is ignored for now, as we support only 16 octet long auth.