### PR TITLE
Fixed incorrect handling of bonded devices

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6210,7 +6210,7 @@ ble_gap_unpair_oldest_peer(void)
     }
 
     rc = ble_store_util_bonded_peers(
-            &oldest_peer_id_addr, &num_peers, 1);
+            &oldest_peer_id_addr, &num_peers, MYNEWT_VAL(BLE_STORE_MAX_BONDS));
     if (rc != 0) {
         return rc;
     }


### PR DESCRIPTION
- The `ble_store_util_bonded_peer` function has a hardcoded value of 1 for the `max_peer` parameter, which might cause issues when `BLE_STORE_MAX_BONDS` is greater than 1. In such cases, an error code (rc=6) is returned due to resource exhaustion. This prevents the execution of the `ble_gap_unpair` function, resulting in the oldest peer not being deleted.
- Modifications were made to accommodate a maximum of BLE_STORE_MAX_BONDS bonds.