### PR TITLE
ll/ble_ll_sched: fix preprocessor directives in ble_ll_sched_preempt

### DIFF
--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -159,17 +159,17 @@ ble_ll_sched_preempt(struct ble_ll_sched_item *sch,
             case BLE_LL_SCHED_TYPE_SCAN_AUX:
                 ble_ll_scan_aux_break(entry->cb_arg);
                 break;
+#endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV)
 #if MYNEWT_VAL(BLE_LL_ROLE_BROADCASTER)
             case BLE_LL_SCHED_TYPE_PERIODIC:
                 ble_ll_adv_periodic_rmvd_from_sched(entry->cb_arg);
                 break;
 #endif
-#if MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV) && MYNEWT_VAL(BLE_LL_ROLE_OBSERVER)
             case BLE_LL_SCHED_TYPE_SYNC:
                 ble_ll_sync_rmvd_from_sched(entry->cb_arg);
                 break;
-#endif
 #endif
 #endif
 #if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)


### PR DESCRIPTION
BLE_LL_SCHED_TYPE_PERIODIC does not require BLE_LL_CFG_FEAT_LL_EXT_ADV.