### PR TITLE
controller: increase BLE_LL_STACK_SIZE for LE Audio Broadcast

### DIFF
--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -613,6 +613,9 @@ syscfg.vals.BLE_LL_CFG_FEAT_LL_EXT_ADV:
     BLE_HW_WHITELIST_ENABLE: 0
     BLE_LL_SCAN_AUX_SEGMENT_CNT: 8
 
+syscfg.vals.BLE_LL_ISO_BROADCASTER:
+    BLE_LL_STACK_SIZE: 180
+
 # Enable vendor event on assert in standalone build to make failed assertions in
 # controller code visible when connected to external host
 syscfg.vals.'!BLE_HOST && !BABBLESIM':


### PR DESCRIPTION
BIG encryption takes additional space on stack, due to crypto functions.