### PR TITLE
nimble/gatts: Modify client supported features READ

### DIFF
--- a/nimble/host/include/host/ble_gatt.h
+++ b/nimble/host/include/host/ble_gatt.h
@@ -1096,6 +1096,25 @@ int ble_gatts_start(void);
 int ble_gatts_peer_cl_sup_feat_update(uint16_t conn_handle,
                                       struct os_mbuf *om);
 
+/**
+ * Gets Client Supported Features for specified connection.
+ *
+ * @param conn_handle           Connection handle identifying connection for
+ *                              which Client Supported Features should be saved
+ * @param out_supported_feat    Client supported features to be returned.
+ *
+ * @return                      0 on success;
+ *                              BLE_HS_ENOTCONN if no matching connection
+ *                              was found
+ *                              BLE_HS_EINVAL if supplied buffer is empty or
+ *                              if any Client Supported Feature was
+ *                              attempted to be disabled.
+ *                              A BLE host core return code on unexpected
+ *                              error.
+ *
+ */
+int ble_gatts_peer_cl_sup_feat_get(uint16_t conn_handle, uint8_t *out_supported_feat, uint8_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/nimble/host/services/gatt/src/ble_svc_gatt.c
+++ b/nimble/host/services/gatt/src/ble_svc_gatt.c
@@ -100,10 +100,14 @@ static int
 ble_svc_gatt_cl_sup_feat_access(uint16_t conn_handle, uint16_t attr_handle,
                                 struct ble_gatt_access_ctxt *ctxt, void *arg)
 {
+    uint8_t supported_feat;
+    int rc;
+
     if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
-        uint8_t supported_feat =
-            (MYNEWT_VAL(BLE_EATT_CHAN_NUM) > 0) << 1 |
-            (MYNEWT_VAL(BLE_ATT_SVR_NOTIFY_MULTI) == 1) << 2;
+        rc = ble_gatts_peer_cl_sup_feat_get(conn_handle, &supported_feat, 1);
+        if (rc != 0) {
+            return BLE_ATT_ERR_UNLIKELY;
+        }
         os_mbuf_append(ctxt->om, &supported_feat, sizeof(supported_feat));
         return 0;
     }

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1581,6 +1581,35 @@ ble_gatts_chr_updated(uint16_t chr_val_handle)
 }
 
 int
+ble_gatts_peer_cl_sup_feat_get(uint16_t conn_handle, uint8_t *out_supported_feat, uint8_t len)
+{
+    struct ble_hs_conn *conn;
+    int rc = 0;
+
+    if (out_supported_feat == NULL) {
+        return BLE_HS_EINVAL;
+    }
+
+    ble_hs_lock();
+    conn = ble_hs_conn_find(conn_handle);
+    if (conn == NULL) {
+        rc = BLE_HS_ENOTCONN;
+        goto done;
+    }
+
+    if (BLE_GATT_CHR_CLI_SUP_FEAT_SZ < len) {
+        len = BLE_GATT_CHR_CLI_SUP_FEAT_SZ;
+    }
+
+    memcpy(out_supported_feat, conn->bhc_gatt_svr.peer_cl_sup_feat,
+           sizeof(uint8_t) * len);
+
+done:
+    ble_hs_unlock();
+    return rc;
+}
+
+int
 ble_gatts_peer_cl_sup_feat_update(uint16_t conn_handle, struct os_mbuf *om)
 {
     struct ble_hs_conn *conn;


### PR DESCRIPTION
1. Fix read on client-supported features. 
2. Read cannot return the local client-supported features, it should return the client-supported features for the reading connection. (This change is needed for PTS). 