### PR TITLE
nimble/host: move ble_gatts_peer_cl_sup_feat_update to private API

### DIFF
--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -1883,12 +1883,15 @@ ble_ll_ctrl_chanmap_req_make(struct ble_ll_conn_sm *connsm, uint8_t *pyld)
     memcpy(pyld, g_ble_ll_data.chan_map, BLE_LL_CHAN_MAP_LEN);
     memcpy(connsm->req_chanmap, pyld, BLE_LL_CHAN_MAP_LEN);
 
+    /* Instant is placed in ble_ll_ctrl_chanmap_req_instant()*/
+}
+
+static void
+ble_ll_ctrl_chanmap_req_instant(struct ble_ll_conn_sm *connsm, uint8_t *pyld)
+{
     /* Place instant into request */
     connsm->chanmap_instant = connsm->event_cntr + connsm->periph_latency + 6 + 1;
     put_le16(pyld + BLE_LL_CHAN_MAP_LEN, connsm->chanmap_instant);
-
-    /* Set scheduled flag */
-    connsm->flags.chanmap_update_sched = 1;
 }
 
 /**
@@ -3105,6 +3108,10 @@ ble_ll_ctrl_tx_start(struct ble_ll_conn_sm *connsm, struct os_mbuf *txpdu)
     case BLE_LL_CTRL_CONN_UPDATE_IND:
         ble_ll_ctrl_conn_update_make_ind_pdu(connsm, ctrdata);
         connsm->flags.conn_update_sched = 1;
+        break;
+    case BLE_LL_CTRL_CHANNEL_MAP_REQ:
+        ble_ll_ctrl_chanmap_req_instant(connsm, ctrdata);
+        connsm->flags.chanmap_update_sched = 1;
         break;
 #if MYNEWT_VAL(BLE_LL_PHY)
     case BLE_LL_CTRL_PHY_UPDATE_IND:

--- a/nimble/host/include/host/ble_gatt.h
+++ b/nimble/host/include/host/ble_gatt.h
@@ -1077,26 +1077,6 @@ int ble_gatts_reset(void);
 int ble_gatts_start(void);
 
 /**
- * Saves Client Supported Features for specified connection.
- *
- * @param conn_handle           Connection handle identifying connection for
- *                              which Client Supported Features should be saved
- * @param om                    The mbuf chain to set value from.
- *
- * @return                      0 on success;
- *                              BLE_HS_ENOTCONN if no matching connection
- *                              was found
- *                              BLE_HS_EINVAL if supplied buffer is empty or
- *                              if any Client Supported Feature was
- *                              attempted to be disabled.
- *                              A BLE host core return code on unexpected
- *                              error.
- *
- */
-int ble_gatts_peer_cl_sup_feat_update(uint16_t conn_handle,
-                                      struct os_mbuf *om);
-
-/**
  * Gets Client Supported Features for specified connection.
  *
  * @param conn_handle           Connection handle identifying connection for

--- a/nimble/host/services/gatt/src/ble_svc_gatt.c
+++ b/nimble/host/services/gatt/src/ble_svc_gatt.c
@@ -22,6 +22,7 @@
 #include "sysinit/sysinit.h"
 #include "host/ble_hs.h"
 #include "services/gatt/ble_svc_gatt.h"
+#include "../src/ble_gatt_priv.h"
 
 static uint16_t ble_svc_gatt_changed_val_handle;
 static uint16_t ble_svc_gatt_start_handle;
@@ -112,7 +113,9 @@ ble_svc_gatt_cl_sup_feat_access(uint16_t conn_handle, uint16_t attr_handle,
         return 0;
     }
     if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
-        return ble_gatts_peer_cl_sup_feat_update(conn_handle, ctxt->om);
+        if (ble_gatts_peer_cl_sup_feat_update(conn_handle, ctxt->om)) {
+            return BLE_ATT_ERR_UNLIKELY;
+        }
     }
 
     return 0;

--- a/nimble/host/src/ble_gatt_priv.h
+++ b/nimble/host/src/ble_gatt_priv.h
@@ -201,6 +201,8 @@ int ble_gatts_clt_cfg_access(uint16_t conn_handle, uint16_t attr_handle,
                              uint8_t op, uint16_t offset, struct os_mbuf **om,
                              void *arg);
 
+int ble_gatts_peer_cl_sup_feat_update(uint16_t conn_handle,
+                                      struct os_mbuf *om);
 /*** @misc. */
 int ble_gatts_conn_can_alloc(void);
 int ble_gatts_conn_init(struct ble_gatts_conn *gatts_conn);


### PR DESCRIPTION
This should be only for internal use. Return ATT error in ble_svc_gatt_cl_sup_feat_access, as ble_gatts_peer_cl_sup_feat_update returns host one.