### PR TITLE
porting/linux: fix ble_hci_sock_init assertion

### DIFF
--- a/porting/examples/linux/main.c
+++ b/porting/examples/linux/main.c
@@ -37,7 +37,6 @@ static struct ble_npl_task s_task_hci;
 
 void nimble_host_task(void *param);
 void ble_hci_sock_ack_handler(void *param);
-void ble_hci_sock_init(void);
 void ble_hci_sock_set_device(int dev);
 void ble_store_ram_init(void);
 
@@ -67,7 +66,6 @@ int main(int argc, char *argv[])
     }
 
     nimble_port_init();
-    ble_hci_sock_init();
 
     /* This example provides GATT Alert service */
     ble_svc_gap_init();

--- a/porting/examples/linux_blemesh/main.c
+++ b/porting/examples/linux_blemesh/main.c
@@ -80,7 +80,6 @@ int main(int argc, char *argv[])
     }
 
     nimble_port_init();
-    ble_hci_sock_init();
 
     ble_svc_gap_init();
     ble_svc_gatt_init();

--- a/porting/examples/nuttx/main.c
+++ b/porting/examples/nuttx/main.c
@@ -43,7 +43,6 @@ static struct ble_npl_task s_task_hci;
 
 void nimble_host_task(void *param);
 void ble_hci_sock_ack_handler(void *param);
-void ble_hci_sock_init(void);
 void ble_hci_sock_set_device(int dev);
 void ble_store_ram_init(void);
 
@@ -88,9 +87,6 @@ int main(int argc, char *argv[])
 
     printf("port init\n");
     nimble_port_init();
-
-    printf("hci init\n");
-    ble_hci_sock_init();
 
     /* This example provides GATT Alert service */
     printf("gap init\n");


### PR DESCRIPTION
Since HCI socket was initialized by `ble_transport_ll_init` in LL side,
we should remove `ble_hci_sock_init` from example apps.

Fixes：https://github.com/apache/mynewt-nimble/issues/1669