### PR TITLE
Fix remove from resolving list issue

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6202,7 +6202,12 @@ ble_gap_unpair(const ble_addr_t *peer_addr)
 
     rc = ble_hs_pvcy_remove_entry(peer_addr->type,
                              peer_addr->val);
-    if (rc != 0) {
+
+    /* We allow BLE_ERR_UNK_CONN_ID as the IRK of the peer might not be
+     * present on the resolving list, but we still should be able to
+     * remove that entry.
+     */
+    if (rc != 0 && rc != (BLE_HS_ERR_HCI_BASE + BLE_ERR_UNK_CONN_ID)) {
         return rc;
     }
 


### PR DESCRIPTION
IRK of the peer might not be present on the resolving list, but we still should be able to remove that entry.
Previously this operation would produce an error, and removal was unsuccessful.