### PR TITLE
porting/linux: Fix link in README

### DIFF
--- a/porting/examples/linux/README.md
+++ b/porting/examples/linux/README.md
@@ -23,7 +23,7 @@
 
 ## Overview
 
-See (https://mynewt.apache.org/network/ble/ble_intro/).
+See https://mynewt.apache.org/latest/network
 
 ## Building
 


### PR DESCRIPTION
Readme was using very old (dead) link to BLE guide.