### PR TITLE
nimble/host: ble_gap_adv_get_free_instance shall return non-negative value

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -1694,12 +1694,14 @@ int ble_gap_ext_adv_clear(void);
 int ble_gap_ext_adv_active(uint8_t instance);
 
 /**
- * Returns first not configured advertising instance.
+ * Finds first not configured advertising instance.
  *
- * @return advertising instance if one was found, negative error code otherwise
+ * @param[out] out_adv_instance            Pointer to be filled with found advertising instance
+ *
+ * @return 0 if free advertising instance was found, error code otherwise
  *
  */
-int ble_gap_adv_get_free_instance(void);
+int ble_gap_adv_get_free_instance(uint8_t *out_adv_instance);
 #endif
 
 /* Periodic Advertising */

--- a/nimble/host/services/auracast/src/ble_svc_auracast.c
+++ b/nimble/host/services/auracast/src/ble_svc_auracast.c
@@ -42,6 +42,7 @@ ble_svc_auracast_create(const struct ble_svc_auracast_create_params *params,
     uint8_t data_offset = 1;
 
     uint8_t features = 0;
+    int rc;
 
     features |= params->big_params->encryption;
 
@@ -79,8 +80,8 @@ ble_svc_auracast_create(const struct ble_svc_auracast_create_params *params,
 
     auracast_svc_data[0] = data_offset - 1;
 
-    adv_instance = ble_gap_adv_get_free_instance();
-    if (adv_instance < 0) {
+    rc = ble_gap_adv_get_free_instance(&adv_instance);
+    if (rc) {
         return BLE_HS_ENOENT;
     }
 

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -1392,17 +1392,18 @@ int ble_gap_ext_adv_active(uint8_t instance)
 }
 
 int
-ble_gap_adv_get_free_instance(void)
+ble_gap_adv_get_free_instance(uint8_t *out_adv_instance)
 {
-    int i;
+    uint8_t i;
 
     for (i = 0; i < BLE_ADV_INSTANCES; i++) {
         if (!ble_gap_slave[i].configured) {
-            return i;
+            *out_adv_instance = i;
+            return 0;
         }
     }
 
-    return -BLE_HS_ENOENT;
+    return BLE_HS_ENOENT;
 }
 #endif
 


### PR DESCRIPTION
All public GAP API functions shall return non-negative error codes. Now, function fills out pointer with found advertising instance and returns correct error code.