### PR TITLE
nimble/host: Add API to allow given address from whitelist

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -2237,6 +2237,15 @@ int ble_gap_terminate(uint16_t conn_handle, uint8_t hci_reason);
 int ble_gap_wl_set(const ble_addr_t *addrs, uint8_t white_list_count);
 
 /**
+ * Removes the given address from controller's white list.
+ *
+ * @param addrs                 The entry to be removed from the white list.
+ *
+ * @return                      0 on success; nonzero on failure.
+ */
+int ble_gap_wl_tx_rmv(const ble_addr_t *addrs);
+
+/**
  * Initiates a connection parameter update procedure.
  *
  * @param conn_handle           The handle corresponding to the connection to

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -2364,6 +2364,22 @@ ble_gap_wl_tx_clear(void)
 #endif
 
 int
+ble_gap_wl_tx_rmv(const ble_addr_t *addr)
+{
+    struct ble_hci_le_rmv_white_list_cp cmd;
+
+    if (addr->type > BLE_ADDR_RANDOM) {
+        return BLE_HS_EINVAL;
+    }
+
+    memcpy(cmd.addr, addr->val, BLE_DEV_ADDR_LEN);
+    cmd.addr_type = addr->type;
+    return ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                        BLE_HCI_OCF_LE_RMV_WHITE_LIST),
+                             &cmd, sizeof(cmd), NULL, 0);
+}
+
+int
 ble_gap_wl_set(const ble_addr_t *addrs, uint8_t white_list_count)
 {
 #if MYNEWT_VAL(BLE_WHITELIST)


### PR DESCRIPTION
This patch adds a  API which allows host to remove a given address from whitelist.

Current existing APIs clear complete whitelist. This API provides flexibility to application to manage whitelist address by deleting a particular address from whitelist.