### PR TITLE
nimble/host: Fix compilation issues observed by enabling -O2 optimiza…

### DIFF
--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -1509,7 +1509,7 @@ static int
 ble_gattc_disc_all_svcs_rx_adata(struct ble_gattc_proc *proc,
                                  struct ble_att_read_group_type_adata *adata)
 {
-    struct ble_gatt_svc service;
+    struct ble_gatt_svc service = {0};
     int cbrc;
     int rc;
 


### PR DESCRIPTION
When O2 optimization is enabled, below error is thrown . This patch fixes the same. 


> nimble/host/src/ble_gattc.c: In function 'ble_gattc_find_inc_svcs_rx_adata':
> nimble/host/src/ble_gattc.c:1982:25: note: 'service' declared here
>  1982 |     struct ble_gatt_svc service;
>       |                         ^~~~~~~
> In function 'ble_gattc_find_inc_svcs_cb',
>     inlined from 'ble_gattc_find_inc_svcs_rx_adata' at nimble/host/src/ble_gattc.c:2031:16:
> nimble/host/src/ble_gattc.c:1832:14: error: 'service' may be used uninitialized [-Werror=maybe-uninitialized]
>  1832 |         rc = proc->find_inc_svcs.cb(proc->conn_handle,
>       |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>  1833 |                                     ble_gattc_error(status, att_handle),
>       |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>  1834 |                                     service, proc->find_inc_svcs.cb_arg);
>       |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> nimble/host/src/ble_gattc.c:1832:14: note: by argument 3 of type 'const struct ble_gatt_svc *' to 'ble_gatt_disc_svc_fn' {aka 'int(short unsigned int,  const struct ble_gatt_error *, const struct ble_gatt_svc *, void *)'}
> nimble/host/src/ble_gattc.c: In function 'ble_gattc_find_inc_svcs_rx_adata':
> nimble/host/src/ble_gattc.c:1982:25: note: 'service' declared here
>  1982 |     struct ble_gatt_svc service;
