### PR TITLE
host/ble_iso.h: remove unused functions

### DIFF
--- a/nimble/host/include/host/ble_iso.h
+++ b/nimble/host/include/host/ble_iso.h
@@ -109,14 +109,6 @@ int ble_iso_create_big(const struct ble_iso_create_big_params *create_params,
 
 int ble_iso_terminate_big(uint8_t big_id);
 
-void
-ble_gap_rx_create_big_complete(const struct
-                               ble_hci_ev_le_subev_create_big_complete *ev);
-void
-ble_gap_rx_terminate_big_complete(const struct
-                                  ble_hci_ev_le_subev_terminate_big_complete
-                                  *ev);
-
 int ble_iso_tx(uint16_t conn_handle, void *data, uint16_t data_len);
 
 int ble_iso_init(void);


### PR DESCRIPTION
ble_gap_rx_create_big_complete and ble_gap_rx_terminate_big_complete are a leftover from initial implementation and shall be removed. Correct, implemented funcions are ble_iso_rx_create_big_complete and ble_iso_rx_terminate_big_completem, in private API