### PR TITLE
host/ble_hs: call ble_iso_rx_data if BLE_ISO_BROADCAST_SINK

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -818,7 +818,7 @@ ble_transport_to_hs_acl_impl(struct os_mbuf *om)
 int
 ble_transport_to_hs_iso_impl(struct os_mbuf *om)
 {
-#if MYNEWT_VAL(BLE_ISO)
+#if MYNEWT_VAL(BLE_ISO_BROADCAST_SINK)
     return ble_iso_rx_data(om, NULL);
 #else
     os_mbuf_free_chain(om);


### PR DESCRIPTION
BLE_ISO defines ISO as whole, but we RX iso data only when device is broadcast sink.