### PR TITLE
ci: Fix Check ports syscfg update workflow

### DIFF
--- a/.github/workflows/ports_syscfg_check.yml
+++ b/.github/workflows/ports_syscfg_check.yml
@@ -52,21 +52,21 @@ jobs:
              newt upgrade --shallow=1
              rm -rf repos/apache-mynewt-nimble
              git clone .. repos/apache-mynewt-nimble
-             cd ..
       - name: Build ports tests targets
         shell: bash
         run: |
              cd build
              ./repos/apache-mynewt-nimble/porting/update_generated_files.sh
-             cd repos/apache-mynewt-nimble
       - name: Check ports syscfg (debug)
         shell: bash
         if:  runner.debug == '1'
         run: |
+              cd build/repos/apache-mynewt-nimble
               git diff
       - name: Check ports syscfg
         shell: bash
         run: |
+             cd build/repos/apache-mynewt-nimble
              git diff --quiet || (\
                echo -e "\033[0;31mChanges in system configration files detected.";
                echo -e "\033[0;31mRun ./repos/apache-mynewt-nimble/porting/update_generated_files.sh" \


### PR DESCRIPTION
Changes the way 'cd' command is used, so it takes into account that each step is run in a separate shell instance.