### PR TITLE
ext/libsamplerate: always build with DNDEBUG flag

### DIFF
--- a/ext/libsamplerate/pkg.yml
+++ b/ext/libsamplerate/pkg.yml
@@ -26,11 +26,7 @@ pkg.keywords:
 
 pkg.type: sdk
 
-pkg.cflags: -DHAVE_STDBOOL_H -fsingle-precision-constant -DHAVE_CONFIG_H
-pkg.cflags.ENABLE_SINC_BEST_CONVERTER: -DENABLE_SINC_BEST_CONVERTER
-pkg.cflags.ENABLE_SINC_MEDIUM_CONVERTER: -DENABLE_SINC_MEDIUM_CONVERTER
-pkg.cflags.ENABLE_SINC_FAST_CONVERTER: -DENABLE_SINC_FAST_CONVERTER
-pkg.cflags.LIBSAMPLER_NDEBUG: -DNDEBUG
+pkg.cflags: -DHAVE_STDBOOL_H -fsingle-precision-constant -DHAVE_CONFIG_H -DNDEBUG
 pkg.lflags: -lm
 
 pkg.ign_dirs:

--- a/ext/libsamplerate/pkg.yml
+++ b/ext/libsamplerate/pkg.yml
@@ -29,16 +29,6 @@ pkg.type: sdk
 pkg.cflags: -DHAVE_STDBOOL_H -fsingle-precision-constant -DHAVE_CONFIG_H -DNDEBUG
 pkg.lflags: -lm
 
-pkg.ign_dirs:
-    - "@libsamplerate/Octave"
-    - "@libsamplerate/Win32"
-    - "@libsamplerate/cmake"
-    - "@libsamplerate/docs"
-    - "@libsamplerate/examples"
-    - "@libsamplerate/include"
-    - "@libsamplerate/m4"
-    - "@libsamplerate/tests"
-
 pkg.src_dirs:
     - "@libsamplerate/src"
 


### PR DESCRIPTION
Debug build pulls assert.h and nrfx, in which PACKAGE define isi pulled from libsamplerate/serc/config.h. This is not correct behavior and these defines are not correlated. Library should be always build without asserts, circumventing the issue.

Cleaned up duplicated cflags in pkg.yml.