### PR TITLE
nimble/host: Fix compilation error in ble_store_config.c

### DIFF
--- a/nimble/host/store/config/src/ble_store_config.c
+++ b/nimble/host/store/config/src/ble_store_config.c
@@ -225,6 +225,7 @@ ble_store_config_delete_our_sec(const struct ble_store_key_sec *key_sec)
 #if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int rc;
 
+    assert(ble_store_config_num_our_secs <= ARRAY_SIZE(ble_store_config_our_secs));
     rc = ble_store_config_delete_sec(key_sec, ble_store_config_our_secs,
                                      &ble_store_config_num_our_secs);
     if (rc != 0) {
@@ -248,6 +249,7 @@ ble_store_config_delete_peer_sec(const struct ble_store_key_sec *key_sec)
 #if MYNEWT_VAL(BLE_STORE_MAX_BONDS)
     int rc;
 
+    assert(ble_store_config_num_peer_secs <= ARRAY_SIZE(ble_store_config_peer_secs));
     rc = ble_store_config_delete_sec(key_sec, ble_store_config_peer_secs,
                                   &ble_store_config_num_peer_secs);
     if (rc != 0) {
@@ -369,10 +371,11 @@ ble_store_config_delete_cccd(const struct ble_store_key_cccd *key_cccd)
     int rc;
 
     idx = ble_store_config_find_cccd(key_cccd);
-    if (idx == -1) {
+    if (idx < 0) {
         return BLE_HS_ENOENT;
     }
 
+    assert(ble_store_config_num_cccds < ARRAY_SIZE(ble_store_config_cccds));
     rc = ble_store_config_delete_obj(ble_store_config_cccds,
                                      sizeof *ble_store_config_cccds,
                                      idx,


### PR DESCRIPTION
This should fix compilation error when -O2 optimization is enabled. GCC incorrectly detects problem.
This change adds asserts that convinces GCC that pre-condition will not result in accessing memory out-of-bounds.

This also changes one condition that also contributes to make GCC convinced that pre-condition are met.

Error: In function 'ble_store_config_delete_obj',
    inlined from 'ble_store_config_delete_cccd' at repos/apache-mynewt-nimble/nimble/host/store/config/src/ble_store_config.c:380:10,
    inlined from 'ble_store_config_delete' at repos/apache-mynewt-nimble/nimble/host/store/config/src/ble_store_config.c:542:14:
repos/apache-mynewt-nimble/nimble/host/store/config/src/ble_store_config.c:193:9: error: 'memmove' offset [16, 31] is out of the bounds [0, 16] of object 'ble_store_config_cccds' with type 'struct ble_store_value_cccd[1]' [-Werror=array-bounds]
  193 |         memmove(dst, src, move_count * value_size);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
repos/apache-mynewt-nimble/nimble/host/store/config/src/ble_store_config.c: In function 'ble_store_config_delete':
repos/apache-mynewt-nimble/nimble/host/store/config/src/ble_store_config.c:45:5: note: 'ble_store_config_cccds' declared here
   45 |     ble_store_config_cccds[MYNEWT_VAL(BLE_STORE_MAX_CCCDS)];

This should solve problem that #1693 tries to solve