### PR TITLE
controller/ble_ll_sync.c: acad_len potentially uninitialised

### DIFF
--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -1136,7 +1136,7 @@ ble_ll_sync_rx_pkt_in(struct os_mbuf *rxpdu, struct ble_mbuf_hdr *hdr)
     int8_t tx_power = 127; /* defaults to not available */
     uint8_t *aux = NULL;
     uint8_t *acad = NULL;
-    uint8_t acad_len;
+    uint8_t acad_len = 0;
     const uint8_t *biginfo = NULL;
     uint8_t biginfo_len = 0;
     int datalen;


### PR DESCRIPTION
acad_len in ble_ll_sync_rx_pkt_in is filled in ble_ll_sync_parse_ext_hdr and later accessed in ble_ll_sync_check_acad. There is a possibility that extended advertising header is missing data containing acad, and it will not get filled, leaving it uninitialised.

This fixes compilation warning:
```
Error: In function 'ble_ll_sync_check_acad',
    inlined from 'ble_ll_sync_rx_pkt_in' at repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_sync.c:1207:18:
repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_sync.c:1064:21: error: 'acad_len' may be used uninitialized [-Werror=maybe-uninitialized]
 1064 |     while (acad_len > 2) {
      |            ~~~~~~~~~^~~
repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_sync.c: In function 'ble_ll_sync_rx_pkt_in':
repos/apache-mynewt-nimble/nimble/controller/src/ble_ll_sync.c:1139:13: note: 'acad_len' was declared here
 1139 |     uint8_t acad_len;
      |             ^~~~~~~~
cc1: all warnings being treated as errors
```