### PR TITLE
host/ble_audio.c: fix ble_audio_adv_parse_broadcast_announcement

### DIFF
--- a/nimble/host/audio/src/ble_audio.c
+++ b/nimble/host/audio/src/ble_audio.c
@@ -47,8 +47,6 @@ ble_audio_adv_parse_broadcast_announcement(const struct ble_hs_adv_field *field,
 
     event = &data->event.broadcast_announcement;
 
-    data->success = false;
-
     switch (field->type) {
     case BLE_HS_ADV_TYPE_SVC_DATA_UUID16:
         if (value_len < 2) {


### PR DESCRIPTION
data->success was set to false at every entry to the funcion. That made the valid advertising payload fail after parsing
BLE_BROADCAST_PUB_ANNOUNCEMENT_SVC_UUID - final break in block was reached but the success set in parsing
BLE_BROADCAST_AUDIO_ANNOUNCEMENT_SVC_UUID was cleared.