### PR TITLE
syscfg: fix typo

### DIFF
--- a/nimble/host/syscfg.yml
+++ b/nimble/host/syscfg.yml
@@ -526,7 +526,7 @@ syscfg.defs:
         value: 1
 
     BLE_ISO_MAX_BIGS:
-        desciptrion: >
+        description: >
             Number of available BIGs
         value: 'MYNEWT_VAL_BLE_MULTI_ADV_INSTANCES'
         restrictions:


### PR DESCRIPTION
simple typo