### PR TITLE
nimble/ll: fix ifdef

### DIFF
--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -856,7 +856,9 @@ ble_ll_ctrl_phy_update_ind_make(struct ble_ll_conn_sm *connsm, uint8_t *dptr,
     ctrdata[0] = m_to_s;
     ctrdata[1] = s_to_m;
 }
+#endif
 
+#if MYNEWT_VAL(BLE_LL_PHY)
 static bool
 ble_ll_ctrl_phy_update_ind_instant(struct ble_ll_conn_sm *connsm, uint8_t *ctrdata)
 {


### PR DESCRIPTION
ble_ll_ctrl_phy_update_ind_instant() is called from another function inside #if MYNEWT_VAL(BLE_LL_PHY), but it was defined only if ROLE_CENTRAL was enabled