### PR TITLE
nimble/porting: Fix OS_MEMPOOL_SIZE() macro

### DIFF
--- a/porting/nimble/include/os/os_mempool.h
+++ b/porting/nimble/include/os/os_mempool.h
@@ -164,7 +164,7 @@ typedef __uint128_t os_membuf_t;
 #else
 #error "Unhandled `OS_ALIGNMENT` for `os_membuf_t`"
 #endif /* OS_ALIGNMENT == * */
-#define OS_MEMPOOL_SIZE(n,blksize)      ((((blksize) + ((OS_ALIGNMENT)-1)) / (OS_ALIGNMENT)) * (n))
+#define OS_MEMPOOL_SIZE(n,blksize)      (((OS_MEMPOOL_BLOCK_SZ(blksize) + ((OS_ALIGNMENT)-1)) / (OS_ALIGNMENT)) * (n))
 
 /** Calculates the number of bytes required to initialize a memory pool. */
 #define OS_MEMPOOL_BYTES(n,blksize)     \


### PR DESCRIPTION
The OS_MEMPOOL_SIZE() macro returns an invalid size when guards are used (an additional 4 bytes must be reserved for each block, which is not done at the moment). Correct this in line with the macro defined in mynewt core.