### PR TITLE
nimble/transport: Fix compilation with TCP socket transport

### DIFF
--- a/nimble/transport/socket/src/ble_hci_socket.c
+++ b/nimble/transport/socket/src/ble_hci_socket.c
@@ -178,7 +178,7 @@ static int s_ble_hci_device = MYNEWT_VAL(BLE_SOCK_LINUX_DEV);
 static int s_ble_hci_device = 0;
 #endif
 
-#if MYNEWT_VAL(BLE_SOCK_USE_LINUX_BLUE)
+#if MYNEWT_VAL(BLE_SOCK_USE_LINUX_BLUE) || MYNEWT_VAL(BLE_SOCK_USE_TCP)
 static int
 ble_hci_sock_acl_tx(struct os_mbuf *om)
 {
@@ -275,7 +275,7 @@ ble_hci_sock_acl_tx(struct os_mbuf *om)
 }
 #endif
 
-#if MYNEWT_VAL(BLE_SOCK_USE_LINUX_BLUE)
+#if MYNEWT_VAL(BLE_SOCK_USE_LINUX_BLUE) || MYNEWT_VAL(BLE_SOCK_USE_TCP)
 static int
 ble_hci_sock_cmdevt_tx(uint8_t *hci_ev, uint8_t h4_type)
 {


### PR DESCRIPTION
Hi,

This patch fixes host stack compilation with `BLE_SOCK_USE_TCP=1`. Error message below

```
/usr/bin/ld: libnimble.a(ble_hci_socket.c.o): in function `ble_hci_trans_ll_evt_tx':
/yoyo/mynewt-nimble/nimble/transport/socket/src/ble_hci_socket.c:730: undefined reference to `ble_hci_sock_cmdevt_tx'
/usr/bin/ld: libnimble.a(ble_hci_socket.c.o): in function `ble_hci_trans_ll_acl_tx':
/yoyo/mynewt-nimble/nimble/transport/socket/src/ble_hci_socket.c:744: undefined reference to `ble_hci_sock_acl_tx'
/usr/bin/ld: libnimble.a(ble_hci_socket.c.o): in function `ble_hci_trans_hs_cmd_tx':
/yoyo/mynewt-nimble/nimble/transport/socket/src/ble_hci_socket.c:759: undefined reference to `ble_hci_sock_cmdevt_tx'
/usr/bin/ld: libnimble.a(ble_hci_socket.c.o): in function `ble_hci_trans_hs_acl_tx':
/yoyo/mynewt-nimble/nimble/transport/socket/src/ble_hci_socket.c:773: undefined reference to `ble_hci_sock_acl_tx'
```

Let me know if you have any suggestions on implementation.