### PR TITLE
nimble: iso: Move Rx callback param to Setup ISO Data Path command

### DIFF
--- a/nimble/host/include/host/ble_iso.h
+++ b/nimble/host/include/host/ble_iso.h
@@ -333,14 +333,6 @@ int ble_iso_terminate_big(uint8_t big_handle);
 struct ble_iso_bis_params {
     /** BIS index */
     uint8_t bis_index;
-
-    /** The callback to associate with the BIS.
-     *  Received ISO data is reported through this callback.
-     */
-    ble_iso_event_fn *cb;
-
-    /** The optional argument to pass to the callback function */
-    void *cb_arg;
 };
 
 /** @brief BIG Sync parameters for @ref ble_iso_big_sync_create */
@@ -443,6 +435,15 @@ struct ble_iso_data_path_setup_params {
 
     /** Codec Configuration */
     const uint8_t *codec_config;
+
+    /**
+     * The ISO Data callback. Must be set if @p data_path_id is HCI.
+     * Received ISO data is reported through this callback.
+     */
+    ble_iso_event_fn *cb;
+
+    /** The optional argument to pass to the callback function */
+    void *cb_arg;
 };
 
 /**

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -2423,6 +2423,8 @@ struct hci_data_hdr
 #define BLE_HCI_ISO_DATA_PATH_DIR_INPUT         0x00
 #define BLE_HCI_ISO_DATA_PATH_DIR_OUTPUT        0x01
 
+#define BLE_HCI_ISO_DATA_PATH_ID_HCI            0x00
+
 struct ble_hci_iso {
     uint16_t handle;
     uint16_t length;


### PR DESCRIPTION
This moves the ISO Rx callback to be provided by application as Setup ISO Data Path function parameter, as the callback will be used only for HCI data path, thus there is no point to require the callback when the broadcast sync is created.