### PR TITLE
nimble/host: Add API to retrieve the size of the controller's white list

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -2240,6 +2240,15 @@ int ble_gap_terminate(uint16_t conn_handle, uint8_t hci_reason);
 int ble_gap_wl_set(const ble_addr_t *addrs, uint8_t white_list_count);
 
 /**
+ * Retrieves the size of whitelist supported by controller
+ *
+ * @param size                  On success, this holds the size of controller accept list
+ *
+ * @return                      0 on success; nonzero on failure
+ */
+int ble_gap_wl_read_size(uint8_t *size);
+
+/**
  * Initiates a connection parameter update procedure.
  *
  * @param conn_handle           The handle corresponding to the connection to

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -2398,6 +2398,23 @@ ble_gap_wl_tx_clear(void)
                                         BLE_HCI_OCF_LE_CLEAR_WHITE_LIST),
                              NULL, 0, NULL, 0 );
 }
+
+int
+ble_gap_wl_read_size(uint8_t *size)
+{
+    struct ble_hci_le_rd_white_list_rp rsp;
+    int rc;
+
+    rc = ble_hs_hci_cmd_tx(BLE_HCI_OP(BLE_HCI_OGF_LE,
+                                      BLE_HCI_OCF_LE_RD_WHITE_LIST_SIZE),
+                           NULL, 0, &rsp, sizeof(rsp));
+
+    if (rc == 0) {
+        *size = rsp.size;
+    }
+
+    return rc;
+}
 #endif
 
 int


### PR DESCRIPTION
Added an API to retrieve size of whitelist entries controller supports.  