### PR TITLE
nimble/host: Fix invalid memset in ble_gattc_read_mult_cb_var

### DIFF
--- a/apps/bttester/src/btp_gatt_cl.c
+++ b/apps/bttester/src/btp_gatt_cl.c
@@ -1392,6 +1392,7 @@ read_var_cb(uint16_t conn_handle,
         rp->data_length = 0;
         tester_event(BTP_SERVICE_ID_GATTC, BTP_GATTC_READ_MULTIPLE_VAR_RP,
                      rp, sizeof(*rp));
+        return 0;
     }
 
     for (int i = 0; i < num_attrs; i++) {

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -3345,7 +3345,7 @@ ble_gattc_read_mult_cb_var(struct ble_gattc_proc *proc, int status,
         return 0;
     }
 
-    memset(attr, 0, sizeof(*attr));
+    memset(attr, 0, sizeof(attr));
 
     for (i = 0; i < proc->read_mult.num_handles; i++) {
         attr[i].handle = proc->read_mult.handles[i];


### PR DESCRIPTION
- Add early exit in read_var_cb for readabilty 
- Apply correct value when using memset to fill attr array in ble_gattc_read_mult_cb_var. Fixes GATT/CL/GAR/BI-13-C, GATT/CL/GAR/BI-36-C, GATT/CL/GAR/BI-38-C, GATT/CL/GAR/BI-42-C, GATT/CL/GAR/BI-44-C, GATT/CL/GAR/BV-05-C
