### PR TITLE
nimble/host: NULL assign data pointer after free

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -3671,6 +3671,7 @@ ble_gap_ext_adv_set_data(uint8_t instance, struct os_mbuf *data)
 
 done:
     os_mbuf_free_chain(data);
+    data = NULL;
     return rc;
 }
 


### PR DESCRIPTION
After buffer is freed, explicitly NULL assign the pointer to data. 