### PR TITLE
porting/npl/nuttx/include/nimble/nimble_npl_os_log.h: fix gcc14 error

### DIFF
--- a/porting/npl/nuttx/include/nimble/nimble_npl_os_log.h
+++ b/porting/npl/nuttx/include/nimble/nimble_npl_os_log.h
@@ -21,6 +21,7 @@
 #define _NIMBLE_NPL_OS_LOG_H_
 
 #include <stdarg.h>
+#include <stdio.h>
 
 /* Example on how to use macro to generate module logging functions */
 #define BLE_NPL_LOG_IMPL(lvl) \


### PR DESCRIPTION
porting/npl/nuttx/include/nimble/nimble_npl_os_log.h: fix gcc14 error

> error: implicit declaration of function 'vprintf' [-Wimplicit-function-declaration]
>   32 |             vprintf(fmt, args);

GCC14 has a more restrictive warning policy and treats some warnings as errors, which breaks compilation for NuttX

EDIT: it looks like the problem also occurs for older GCC versions, as reported by NuttX CI: https://github.com/apache/nuttx-apps/actions/runs/9483234519/job/26130011374#step:7:368