### PR TITLE
nimble/host: Modify Advertising Tx power levels

### DIFF
--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1428,8 +1428,17 @@ struct ble_hci_vs_set_local_irk_cp {
 #define BLE_HCI_ADV_PEER_ADDR_MAX           (1)
 
 /* --- LE advertising channel tx power (OCF 0x0007) */
-#define BLE_HCI_ADV_CHAN_TXPWR_MIN             (-20)
-#define BLE_HCI_ADV_CHAN_TXPWR_MAX             (10)
+#if MYNEWT_VAL(BLE_VERSION) == 50
+#define BLE_HCI_ADV_CHAN_TXPWR_MIN          (-20)
+#define BLE_HCI_ADV_CHAN_TXPWR_MAX          (10)
+#elif MYNEWT_VAL(BLE_VERSION) == 51
+#define BLE_HCI_ADV_CHAN_TXPWR_MIN          (-20)
+#define BLE_HCI_ADV_CHAN_TXPWR_MAX          (20)
+#elif MYNEWT_VAL(BLE_VERSION) >= 52
+#define BLE_HCI_ADV_CHAN_TXPWR_MIN          (-127)
+#define BLE_HCI_ADV_CHAN_TXPWR_MAX          (20)
+#endif
+
 
 /* --- LE set scan enable (OCF 0x000c) */
 


### PR DESCRIPTION
For LE Read Advertising Physical Channel Tx Power command , different version of BLE specification have updated the return values for Tx Power level. 

Currently (spec 5.2 onwards) the supported values are from (-127) to (20). 

Latest values as per Spec ver 5.4 , Vol 4, Part E, section 7.8.6 has range specified. 

Update the min / max macros to reflect the same