### PR TITLE
nimble/ll: Fix BIG anchor offset overflow

### DIFF
--- a/nimble/controller/src/ble_ll_iso_big.c
+++ b/nimble/controller/src/ble_ll_iso_big.c
@@ -183,8 +183,10 @@ big_sched_set(struct ble_ll_iso_big *big)
 
     ble_ll_tmr_add(&big->sch.start_time, &big->sch.remainder, offset_us);
 
-    /* Reset anchor base every 30mins to avoid overflows in calculations later. */
-    if (offset_us >= 30 * 60 * 1000000) {
+    /* Reset anchor base before anchor offset wraps-around.
+     * This happens much earlier than possible overflow in calculations.
+     */
+    if (big->anchor_offset == UINT16_MAX) {
         big->anchor_base_ticks = big->sch.start_time;
         big->anchor_base_rem_us = big->sch.remainder;
         big->anchor_offset = 0;


### PR DESCRIPTION
The anchor base for BIG events was reset every 30mins to avoid overflow in offset calculations which could happen after more than 60mins of streaming.

However, as it turns out anchor offset wraps-around much earlier than that after just ~10m55s (at 10ms iso interval) so we should better take care of anchor offset instead of offset_us.