### PR TITLE
nimble/audio: Change sizeof to ARRAY_SIZE in BASS

### DIFF
--- a/nimble/host/audio/services/bass/src/ble_audio_svc_bass.c
+++ b/nimble/host/audio/services/bass/src/ble_audio_svc_bass.c
@@ -201,7 +201,7 @@ ble_svc_audio_bass_receive_state_notify(struct ble_svc_audio_bass_rcv_state_entr
 {
     int i;
 
-    for (i = 0; i < sizeof(ble_svc_audio_bass_chrs); i++) {
+    for (i = 0; i < ARRAY_SIZE(ble_svc_audio_bass_chrs); i++) {
         if (ble_svc_audio_bass_chrs[i].arg == state) {
             ble_gatts_chr_updated(*ble_svc_audio_bass_chrs[i].val_handle);
             return 0;
@@ -217,7 +217,7 @@ ble_svc_audio_bass_receive_state_find_by_source_id(struct ble_svc_audio_bass_rcv
 {
     int i;
 
-    for (i = 0; i < sizeof(receiver_states); i++) {
+    for (i = 0; i < ARRAY_SIZE(receiver_states); i++) {
         if (receiver_states[i].source_id == source_id) {
             *out_state = &receiver_states[i];
             return 0;
@@ -232,7 +232,7 @@ ble_svc_audio_bass_receive_state_find_free(struct ble_svc_audio_bass_rcv_state_e
 {
     int i;
 
-    for (i = 0; i < sizeof(receiver_states); i++) {
+    for (i = 0; i < ARRAY_SIZE(receiver_states); i++) {
         if (receiver_states[i].source_id == BLE_SVC_AUDIO_BASS_RECEIVE_STATE_SRC_ID_NONE) {
             *out_state = &receiver_states[i];
             return 0;


### PR DESCRIPTION
Modify loop expressions to use ARRAY_SIZE macro instead of sizeof in BASS.