### PR TITLE
nimble/audio: Modify BASS control point write access.

### DIFF
--- a/nimble/host/audio/services/bass/src/ble_audio_svc_bass.c
+++ b/nimble/host/audio/services/bass/src/ble_audio_svc_bass.c
@@ -617,13 +617,16 @@ ble_svc_audio_bass_find_handler(uint8_t opcode)
 static int
 ble_svc_audio_bass_ctrl_point_write_access(struct ble_gatt_access_ctxt *ctxt, uint16_t conn_handle)
 {
+    uint8_t opcode;
+    struct os_mbuf *om;
+    uint16_t mbuf_len = OS_MBUF_PKTLEN(ctxt->om);
     struct ble_svc_audio_bass_ctrl_point_handler *handler;
 
-    uint8_t opcode = ctxt->om->om_data[0];
+    opcode = ctxt->om->om_data[0];
 
     handler = ble_svc_audio_bass_find_handler(opcode);
 
-    if (!handler) {
+    if (handler == NULL) {
         return BLE_SVC_AUDIO_BASS_ERR_OPCODE_NOT_SUPPORTED;
     }
 
@@ -633,7 +636,12 @@ ble_svc_audio_bass_ctrl_point_write_access(struct ble_gatt_access_ctxt *ctxt, ui
         return BLE_ATT_ERR_WRITE_REQ_REJECTED;
     }
 
-    return handler->handler_cb(&ctxt->om->om_data[1], ctxt->om->om_len - 1, conn_handle);
+    ctxt->om = os_mbuf_pullup(ctxt->om, mbuf_len);
+    if (!ctxt->om) {
+        return BLE_ATT_ERR_UNLIKELY;
+    }
+
+    return handler->handler_cb(&om->om_data[1], mbuf_len - 1, conn_handle);
 }
 
 static int


### PR DESCRIPTION
Modify BASS control point write access in a way that it would use proper mbuf for holding incoming data.

Fix handler check from simple bool comparison to ensuring that it's not NULL.