### PR TITLE
nimble/host: Fix matching responses to ATT procedures

### DIFF
--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -961,10 +961,12 @@ ble_gattc_proc_matches_conn_rx_entry(struct ble_gattc_proc *proc, void *arg)
 
     criteria = arg;
 
-    if (criteria->conn_handle != BLE_HS_CONN_HANDLE_NONE &&
-        criteria->conn_handle != proc->conn_handle &&
-        criteria->cid != proc->cid) {
+    if ((criteria->conn_handle != BLE_HS_CONN_HANDLE_NONE) &&
+        (criteria->conn_handle != proc->conn_handle)) {
+        return 0;
+    }
 
+    if (criteria->cid != proc->cid) {
         return 0;
     }
 


### PR DESCRIPTION
If we sent the same request to two different peers at exactly the same time, it was possible that responses could be matched with invalid procedures.