### PR TITLE
nimble/audio/bass: Modify remove source operation

### DIFF
--- a/nimble/host/audio/services/bass/src/ble_audio_svc_bass.c
+++ b/nimble/host/audio/services/bass/src/ble_audio_svc_bass.c
@@ -549,7 +549,7 @@ static int
 ble_svc_audio_bass_remove_source(uint8_t *data, uint16_t data_len, uint16_t conn_handle)
 {
     struct ble_audio_event ev = {
-        .type = BLE_AUDIO_EVENT_BASS_BROADCAST_CODE_SET,
+        .type = BLE_AUDIO_EVENT_BASS_OPERATION_STATUS,
         .bass_operation_status = {
             .op = BLE_AUDIO_EVENT_BASS_SOURCE_REMOVED,
             .status = 0
@@ -557,10 +557,12 @@ ble_svc_audio_bass_remove_source(uint8_t *data, uint16_t data_len, uint16_t conn
     };
     struct ble_svc_audio_bass_rcv_state_entry *rcv_state = NULL;
     struct ble_svc_audio_bass_operation operation;
+    uint16_t chr_val;
     int rc = 0;
     int i;
 
     ev.bass_set_broadcast_code.source_id = data[0];
+    operation.op = BLE_SVC_AUDIO_BASS_OPERATION_REMOVE_SOURCE;
 
     ble_svc_audio_bass_receive_state_find_by_source_id(&rcv_state,
                                                        ev.bass_operation_status.source_id);
@@ -587,12 +589,12 @@ ble_svc_audio_bass_remove_source(uint8_t *data, uint16_t data_len, uint16_t conn
 
     memset(rcv_state, 0, sizeof(*rcv_state));
     rcv_state->source_id = BLE_SVC_AUDIO_BASS_RECEIVE_STATE_SRC_ID_NONE;
+    rcv_state->chr_val = chr_val;
 
 done:
     if (!rc) {
         rc = ble_svc_audio_bass_receive_state_notify(rcv_state);
         ev.bass_operation_status.status = rc;
-        goto done;
     }
 
     ble_audio_event_listener_call(&ev);


### PR DESCRIPTION
Fix event type in ble_audio_event structure.
Modify data for use with new mbuf.
Add characteristic value in receive state.
Remove goto pointing to goto itself.