### PR TITLE
nimble/audio/bass: Add BIS sync information in add source.

### DIFF
--- a/nimble/host/audio/services/bass/include/services/bass/ble_audio_svc_bass.h
+++ b/nimble/host/audio/services/bass/include/services/bass/ble_audio_svc_bass.h
@@ -286,6 +286,9 @@ struct ble_svc_audio_bass_operation {
             /** Number of subgroups */
             uint8_t num_subgroups;
 
+            /* BIS Synchronisation of subgroups */
+            uint32_t bis_sync[BLE_SVC_AUDIO_BASS_SUB_NUM_MAX];
+
             /** Subgroup entries */
             struct ble_svc_audio_bass_subgroup
                 subgroups[BLE_SVC_AUDIO_BASS_SUB_NUM_MAX];


### PR DESCRIPTION
Add field to represent BIS sync subgroup status in add source operation.