### PR TITLE
nimble/audio/bass: Modify add source operation in BASS

### DIFF
--- a/nimble/host/audio/services/bass/include/services/bass/ble_audio_svc_bass.h
+++ b/nimble/host/audio/services/bass/include/services/bass/ble_audio_svc_bass.h
@@ -71,6 +71,9 @@
 /** BLE AUDIO BASS Error: Invalid Source ID */
 #define BLE_SVC_AUDIO_BASS_ERR_INVALID_SOURCE_ID                         0x81
 
+/** BLE AUDIO BASS ADVERTISING SID MAX VALUE */
+#define BLE_SVC_AUDIO_BASS_ADV_SID_MAX_VAL                               0x0F
+
 /** BLE AUDIO BASS Encryption States */
 enum ble_svc_audio_bass_big_enc {
     /** BLE AUDIO BASS BIG Encryption: Not Encrypted */


### PR DESCRIPTION
Modify add source with new mbuf data style format. Add BIS sync information to receive state.
Fix memcpy wrong field format from address.
Move check_bis_sync up, so add source can use it.
Add checks for address type.
Add checks for advertising sid.
Add pa_sync_state and num of subgroups to receive state.