### PR TITLE
nimble/transport: Fix build with RX task

### DIFF
--- a/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
+++ b/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
@@ -111,7 +111,7 @@ nrf5340_ble_hci_trans_rx(int channel, void *user_data)
 {
     assert(channel == IPC_RX_CHANNEL);
 
-#if MYNEWT_VAL(BLE_TRANSPORT_NRF5340_RX_TASK)
+#if MYNEWT_VAL(BLE_TRANSPORT_RX_TASK)
     ble_transport_rx();
 #else
     rx_func(NULL);
@@ -123,7 +123,7 @@ nrf5340_ble_hci_init(void)
 {
     SYSINIT_ASSERT_ACTIVE();
 
-#if MYNEWT_VAL(BLE_TRANSPORT_NRF5340_RX_TASK)
+#if MYNEWT_VAL(BLE_TRANSPORT_RX_TASK)
     ble_transport_rx_register(rx_func, NULL);
 #endif
     ipc_nrf5340_recv(IPC_RX_CHANNEL, nrf5340_ble_hci_trans_rx, NULL);

--- a/nimble/transport/nrf5340/syscfg.yml
+++ b/nimble/transport/nrf5340/syscfg.yml
@@ -15,14 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-syscfg.defs:
-    BLE_TRANSPORT_NRF5340_RX_TASK:
-        description: >
-            Use separate task for RX. This is required and enabled by default
-            if monitor is used, optional otherwise.
-        value: 0
-
 syscfg.vals.BLE_MONITOR:
-    BLE_TRANSPORT_NRF5340_RX_TASK: 1
-    BLE_TRANSPORT_RX_PRIO: 1
-    BLE_TRANSPORT_RX_STACK_SIZE: 120
+    BLE_TRANSPORT_RX_TASK_STACK_SIZE: 120
+    BLE_TRANSPORT_RX_TASK_PRIO: 1

--- a/nimble/transport/src/rx_task.c
+++ b/nimble/transport/src/rx_task.c
@@ -26,13 +26,13 @@
 #include <nimble/transport.h>
 #include <nimble/nimble_npl.h>
 
-#if !defined(MYNEWT) || MYNEWT_VAL(BLE_TRANSPORT_RX_STACK_SIZE) > 0
+#if !defined(MYNEWT) || MYNEWT_VAL(BLE_TRANSPORT_RX_TASK_STACK_SIZE)
 
 static ble_transport_rx_func_t *rx_func;
 static void *rx_func_arg;
 
 #if MYNEWT
-OS_TASK_STACK_DEFINE(rx_stack, MYNEWT_VAL(BLE_TRANSPORT_RX_STACK_SIZE));
+OS_TASK_STACK_DEFINE(rx_stack, MYNEWT_VAL(BLE_TRANSPORT_RX_TASK_STACK_SIZE));
 static struct os_task rx_task;
 #endif
 
@@ -70,8 +70,8 @@ ble_transport_rx_register(ble_transport_rx_func_t *func, void *arg)
 
 #ifdef MYNEWT
     os_task_init(&rx_task, "hci_rx_task", rx_task_func, NULL,
-                 MYNEWT_VAL(BLE_TRANSPORT_RX_PRIO), OS_WAIT_FOREVER, rx_stack,
-                 MYNEWT_VAL(BLE_TRANSPORT_RX_STACK_SIZE));
+                 MYNEWT_VAL(BLE_TRANSPORT_RX_TASK_PRIO), OS_WAIT_FOREVER,
+                 rx_stack, MYNEWT_VAL(BLE_TRANSPORT_RX_TASK_STACK_SIZE));
 #endif
 }
 

--- a/nimble/transport/syscfg.yml
+++ b/nimble/transport/syscfg.yml
@@ -110,12 +110,18 @@ syscfg.defs:
             of ISO buffers available for controller.
         value: MYNEWT_VAL(BLE_TRANSPORT_ISO_COUNT)
 
-    BLE_TRANSPORT_RX_PRIO:
+    BLE_TRANSPORT_RX_TASK_STACK_SIZE:
+        description: >
+            Stack size of RX task.
+            RX task is started if stack size is set to a valid value.
+        value:
+
+syscfg.defs.BLE_TRANSPORT_RX_TASK_STACK_SIZE:
+    BLE_TRANSPORT_RX_TASK: 1
+    BLE_TRANSPORT_RX_TASK_PRIO:
         description: Priority of RX task
         type: task_priority
-        value: 126
-    BLE_TRANSPORT_RX_STACK_SIZE:
-        description: Stack size of RX task
+        restrictions: $notnull
         value:
 
 # import monitor and defunct settings from separate file to reduce clutter in main file


### PR DESCRIPTION
Remove separate syscfg to enable RX task from nrf5340 transport package. RX task is now enabled if RX task stack size is set to a valid value.
    
RX task priority should not be set to default value to avoid conflicts with other task priorities if RX task is not used (this is always verified by newt). Since empty value is not a valid priority we should better only define that setting if RX task is enabled.

