### PR TITLE
Offset field in struct ble_gatt_access_ctxt as an indication of long attribute read

### DIFF
--- a/nimble/host/include/host/ble_gatt.h
+++ b/nimble/host/include/host/ble_gatt.h
@@ -960,6 +960,12 @@ struct ble_gatt_access_ctxt {
          */
         const struct ble_gatt_dsc_def *dsc;
     };
+
+    /**
+     * An offset in case of BLE_ATT_OP_READ_BLOB_REQ.
+     * If the value is greater than zero it's an indication of a long attribute read.
+     */
+    uint16_t offset;
 };
 
 /**

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -416,6 +416,7 @@ ble_gatts_chr_val_access(uint16_t conn_handle, uint16_t attr_handle,
 
     gatt_ctxt.op = ble_gatts_chr_op(att_op);
     gatt_ctxt.chr = chr_def;
+    gatt_ctxt.offset = offset;
 
     ble_gatts_chr_inc_val_stat(gatt_ctxt.op);
     rc = ble_gatts_val_access(conn_handle, attr_handle, offset, &gatt_ctxt, om,


### PR DESCRIPTION
To obtain an attribute value when the attribute size is greater than configured MTU long attribute read procedure could be used.
A client sends consecutive `ATT_READ_BLOB_REQ` requests (passing along an offset) to consume the attribute value. The offset is used internally in the nimble stack but is not passed to a user provided access callback in a GATT characteristic description. This callback is called the same number of times as the number of blob requests, but it's not possible to say whether it's a first request (or maybe just `ATT_READ_REQ`) or consecutive request.

The provided offset could indicate this situation to the app developer. However, Core Spec 5.4 Vol 3 Part F 3.4.4.5 notes:
> Note: The value of a Long Attribute may change between the server receiving one ATT_READ_BLOB_REQ PDU and the next ATT_READ_BLOB_REQ PDU. A higher layer specification should be aware of this and define appropriate behavior.

It's up to a developer to decide what to do, when consecutive (long attribute) reading takes place. This was discussed in #1090.