### PR TITLE
nimble/host: Add support for ext adv param v2 HCI command

### DIFF
--- a/nimble/host/include/host/ble_gap.h
+++ b/nimble/host/include/host/ble_gap.h
@@ -1582,6 +1582,12 @@ struct ble_gap_ext_adv_params {
 
     /** Advertising Set ID */
     uint8_t sid;
+
+    /** Primary phy options */
+    uint8_t pri_phy_opt;
+
+    /** Secondary phy options */
+    uint8_t sec_phy_opt;
 };
 
 /**

--- a/nimble/host/src/ble_hs_hci_priv.h
+++ b/nimble/host/src/ble_hs_hci_priv.h
@@ -80,7 +80,7 @@ struct hci_periodic_adv_params
 #endif
 
 struct ble_hs_hci_sup_cmd {
-    unsigned event_mask2 : 1; /** Indicates whether the controller supports the set event mask page 2 command */
+    uint8_t commands[64];
 };
 
 extern uint16_t ble_hs_hci_avail_pkts;

--- a/nimble/host/src/ble_hs_startup.c
+++ b/nimble/host/src/ble_hs_startup.c
@@ -82,8 +82,7 @@ ble_hs_startup_read_sup_cmd_tx(void)
         return rc;
     }
 
-    /* Only check support for Set Event ­Mask ­Page ­2 command */
-    sup_cmd.event_mask2 = (rsp.commands[22] & 0x04) != 0;
+    memcpy(&sup_cmd.commands, &rsp.commands, sizeof(sup_cmd));
     ble_hs_hci_set_hci_supported_cmd(sup_cmd);
 
     return 0;
@@ -373,7 +372,7 @@ ble_hs_startup_set_evmask_tx(void)
         return rc;
     }
 
-    if ((version >= BLE_HCI_VER_BCS_4_1) && sup_cmd.event_mask2) {
+    if ((version >= BLE_HCI_VER_BCS_4_1) && ((sup_cmd.commands[22] & 0x04) != 0)) {
         /**
          * Enable the following events:
          *     0x0000000000800000 Authenticated Payload Timeout Event

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -593,6 +593,7 @@ struct ble_hci_le_set_ext_adv_params_cp {
     uint8_t sid;
     uint8_t scan_req_notif;
 } __attribute__((packed));
+
 struct ble_hci_le_set_ext_adv_params_rp {
     int8_t  tx_power;
 } __attribute__((packed));
@@ -1147,6 +1148,13 @@ struct ble_hci_le_subrate_req_cp {
     uint16_t max_latency;
     uint16_t cont_num;
     uint16_t supervision_tmo;
+} __attribute__((packed));
+
+#define BLE_HCI_OCF_LE_SET_EXT_ADV_PARAM_V2             (0x007F)
+struct ble_hci_le_set_ext_adv_params_v2_cp {
+    struct ble_hci_le_set_ext_adv_params_cp cmd;
+    uint8_t pri_phy_opt;
+    uint8_t sec_phy_opt;
 } __attribute__((packed));
 
 #define BLE_HCI_OCF_LE_CS_RD_LOC_SUPP_CAP                (0x0089)


### PR DESCRIPTION
BLE spec version 5.4 introduced support for host to pass primary and secondary phy options in set extended advertising parameters. For this a new HCI command "HCI_LE_Set_Extended_Advertising_Parameters v[2] " with OCF 0x007F got introduced. 

This patch adds support in host for this HCI command. 