### PR TITLE
nimble/transport: Fix race in nrf5340 IPC transport

### DIFF
--- a/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
+++ b/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
@@ -121,12 +121,18 @@ nrf5340_ble_hci_trans_rx(int channel, void *user_data)
 static void
 nrf5340_ble_hci_init(void)
 {
+    os_sr_t sr;
+
     SYSINIT_ASSERT_ACTIVE();
 
 #if MYNEWT_VAL(BLE_TRANSPORT_RX_TASK)
     ble_transport_rx_register(rx_func, NULL);
 #endif
     ipc_nrf5340_recv(IPC_RX_CHANNEL, nrf5340_ble_hci_trans_rx, NULL);
+
+    OS_ENTER_CRITICAL(sr);
+    nrf5340_ble_hci_trans_rx(IPC_RX_CHANNEL, NULL);
+    OS_EXIT_CRITICAL(sr);
 }
 
 #if MYNEWT_VAL(BLE_CONTROLLER)


### PR DESCRIPTION
The HCI transport is initialized after LL task is initialized, but the IPC itself is initialized before LL task. If host on appcore starts before HCI transport is initialized on netcore, it can put HCI Reset in IPC shm before we can receive it and handle. This causes host to send 2nd HCI Reset which triggers handling of data in IPC shm and will fail because we cannot handle 2 HCI commands at the same time (i.e. 2x HCI Reset).

This fixes the problem by triggering read from IPC shm just after HCI transport is initialized so we can handle command that was sent there before we were ready to receive it.