### PR TITLE
nimble/drivers: Add driver for SKY66405 FEM

### DIFF
--- a/nimble/drivers/fem/sky66405/include/sky66405/sky66405.h
+++ b/nimble/drivers/fem/sky66405/include/sky66405/sky66405.h
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#ifndef _SKY66405_H
+#define _SKY66405_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void sky66405_rx_bypass(uint8_t enabled);
+void sky66405_tx_bypass(uint8_t enabled);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SKY66405_H */

--- a/nimble/drivers/fem/sky66405/pkg.yml
+++ b/nimble/drivers/fem/sky66405/pkg.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: nimble/drivers/fem/sky66405
+pkg.description: Driver for SKY66405 front-end module
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "https://mynewt.apache.org/"
+pkg.apis:
+    - ble_fem_pa
+    - ble_fem_lna
+pkg.deps:
+    - nimble/controller
+
+pkg.init:
+    sky66405_init: 999

--- a/nimble/drivers/fem/sky66405/src/sky66405.c
+++ b/nimble/drivers/fem/sky66405/src/sky66405.c
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <syscfg/syscfg.h>
+#include <hal/hal_gpio.h>
+#include <controller/ble_fem.h>
+#include <sky66405/sky66405.h>
+
+static struct {
+    uint8_t rx_bypass : 1;
+    uint8_t tx_bypass : 1;
+} sky66405_config = {
+    .rx_bypass = MYNEWT_VAL(SKY66405_RX_BYPASS),
+    .tx_bypass = MYNEWT_VAL(SKY66405_TX_BYPASS),
+};
+
+static void
+sky66405_bypass(uint8_t enabled)
+{
+    /* this is called only if bypass is enabled which means CPS PIN is
+     * correctly set and there is no need to check it here.
+     */
+    hal_gpio_write(MYNEWT_VAL(SKY66405_PIN_CPS), enabled);
+}
+
+void
+ble_fem_pa_init(void)
+{
+    sky66405_tx_bypass(0);
+}
+
+void
+ble_fem_pa_enable(void)
+{
+    if (sky66405_config.tx_bypass) {
+        sky66405_bypass(1);
+    }
+}
+
+void
+ble_fem_pa_disable(void)
+{
+    if (sky66405_config.tx_bypass) {
+        sky66405_bypass(0);
+    }
+}
+
+void
+ble_fem_lna_init(void)
+{
+    sky66405_rx_bypass(0);
+}
+
+void
+ble_fem_lna_enable(void)
+{
+    if (sky66405_config.rx_bypass) {
+        sky66405_bypass(1);
+    }
+}
+
+void
+ble_fem_lna_disable(void)
+{
+    if (sky66405_config.rx_bypass) {
+        sky66405_bypass(0);
+    }
+}
+
+void
+sky66405_rx_bypass(uint8_t enabled)
+{
+    int pin = MYNEWT_VAL(SKY66405_PIN_CPS);
+
+    if (pin >= 0) {
+        sky66405_config.rx_bypass = enabled;
+        sky66405_bypass(enabled);
+    }
+}
+
+void
+sky66405_tx_bypass(uint8_t enabled)
+{
+    int pin = MYNEWT_VAL(SKY66405_PIN_CPS);
+
+    if (pin >= 0) {
+        sky66405_config.tx_bypass = enabled;
+        sky66405_bypass(enabled);
+    }
+}
+
+void
+sky66405_init(void)
+{
+    int pin;
+
+    /* Disable bypass, we'll enable it when needed */
+    pin = MYNEWT_VAL(SKY66405_PIN_CPS);
+    if (pin >= 0) {
+        hal_gpio_init_out(pin, 0);
+    }
+}

--- a/nimble/drivers/fem/sky66405/syscfg.yml
+++ b/nimble/drivers/fem/sky66405/syscfg.yml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    SKY66405_PIN_CPS:
+        description: >
+            GPIO pin number to control CPS signal.
+            When set to '-1', pin state will not be changed and it should be
+            driven externally.
+        value: -1
+    SKY66405_TX_BYPASS:
+        description: >
+            Enables bypass for TX which effectively disables operation as PA.
+            Only valid if CPS signal is controller by driver.
+        value: 0
+    SKY66405_RX_BYPASS:
+        description: >
+            Enables bypass for RX which effectively disables operation as PA.
+            Only valid if CPS signal is controller by driver.
+        value: 0
+
+syscfg.vals.!BLE_FEM_PA:
+    # Enable TX bypass by default if PA is disabled
+    SKY66405_TX_BYPASS: 1
+
+syscfg.vals.!BLE_FEM_LNA:
+    # Enable RX bypass by default if LNA is disabled
+    SKY66405_RX_BYPASS: 1


### PR DESCRIPTION
This adds driver for SKY66405 FEM.

The bypass function is only supported using dedicated pin (CPS). Enabling bypass by setting both CTX and CRX to high state is not supported due to limitation in FEM API.