### PR TITLE
porting/npl/linux: Fix stuck callouts

### DIFF
--- a/porting/npl/linux/src/os_callout.c
+++ b/porting/npl/linux/src/os_callout.c
@@ -32,7 +32,7 @@ ble_npl_callout_timer_cb(union sigval sv)
 {
     struct ble_npl_callout *c = (struct ble_npl_callout *)sv.sival_ptr;
     assert(c);
-
+    c->c_active = false;
     if (c->c_evq) {
         ble_npl_eventq_put(c->c_evq, &c->c_ev);
     } else {


### PR DESCRIPTION
`ble_npl_callout.c_active` is not reset after callout is executed, so only the first callout fires and subsequent are not scheduled at all.

Fixes https://github.com/apache/mynewt-nimble/issues/1771