### PR TITLE
nimble/host/src/ble_gap.c:  undefined SET_BIT before defining it.

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -41,6 +41,7 @@
 #define bssnz_t
 #endif
 
+#undef SET_BIT
 #define SET_BIT(t, n)  (t |= 1UL << (n))
 
 /**


### PR DESCRIPTION
Was getting duplicate definitions of SET_BIT when compiling for an STM32F4 device.