### PR TITLE
nimble/host: Truncate data in ble_eatt_tx

### DIFF
--- a/nimble/host/src/ble_eatt.c
+++ b/nimble/host/src/ble_eatt.c
@@ -476,6 +476,8 @@ ble_eatt_tx(uint16_t conn_handle, uint16_t cid, struct os_mbuf *txom)
         goto error;
     }
 
+    ble_att_truncate_to_mtu(eatt->chan, txom);
+
     rc = ble_l2cap_send(eatt->chan, txom);
     if (rc == 0) {
         goto done;


### PR DESCRIPTION
Data packets sent over eatt chan weren't correctly truncated. Data packet is now adjusted to peer device's MTU for the channel.
Fixes various GATT/SR test cases that verify support for Read Long Characteristic Value Requests, Multiple Read Characteristic Value Requests etc.
https://github.com/apache/mynewt-nimble/issues/1800 related