### PR TITLE
nimble/host: add eatt opcode check in ble_eatt_l2cap_event_fn

### DIFF
--- a/nimble/host/src/ble_att.c
+++ b/nimble/host/src/ble_att.c
@@ -636,6 +636,51 @@ ble_att_create_chan(uint16_t conn_handle)
 }
 
 bool
+ble_eatt_supported_req(uint8_t opcode)
+{
+    switch (opcode) {
+    case BLE_ATT_OP_WRITE_CMD:
+    case BLE_ATT_OP_FIND_INFO_REQ:
+    case BLE_ATT_OP_FIND_TYPE_VALUE_REQ:
+    case BLE_ATT_OP_READ_TYPE_REQ:
+    case BLE_ATT_OP_READ_REQ:
+    case BLE_ATT_OP_READ_BLOB_REQ:
+    case BLE_ATT_OP_READ_MULT_REQ:
+    case BLE_ATT_OP_READ_GROUP_TYPE_REQ:
+    case BLE_ATT_OP_WRITE_REQ:
+    case BLE_ATT_OP_PREP_WRITE_REQ:
+    case BLE_ATT_OP_EXEC_WRITE_REQ:
+    case BLE_ATT_OP_INDICATE_REQ:
+    case BLE_ATT_OP_READ_MULT_VAR_REQ:
+    case BLE_ATT_OP_NOTIFY_MULTI_REQ:
+        return true;
+    }
+    return false;
+}
+
+bool
+ble_eatt_supported_rsp(uint8_t opcode)
+{
+    switch (opcode) {
+    case BLE_ATT_OP_ERROR_RSP:
+    case BLE_ATT_OP_FIND_INFO_RSP:
+    case BLE_ATT_OP_FIND_TYPE_VALUE_RSP:
+    case BLE_ATT_OP_READ_TYPE_RSP:
+    case BLE_ATT_OP_INDICATE_RSP:
+    case BLE_ATT_OP_READ_RSP:
+    case BLE_ATT_OP_READ_BLOB_RSP:
+    case BLE_ATT_OP_READ_MULT_RSP:
+    case BLE_ATT_OP_READ_GROUP_TYPE_RSP:
+    case BLE_ATT_OP_WRITE_RSP:
+    case BLE_ATT_OP_PREP_WRITE_RSP:
+    case BLE_ATT_OP_EXEC_WRITE_RSP:
+    case BLE_ATT_OP_READ_MULT_VAR_RSP:
+        return true;
+    }
+    return false;
+}
+
+bool
 ble_att_is_request_op(uint8_t opcode)
 {
     switch (opcode) {

--- a/nimble/host/src/ble_att_cmd_priv.h
+++ b/nimble/host/src/ble_att_cmd_priv.h
@@ -462,6 +462,8 @@ int ble_att_tx_with_conn(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan,
                          struct os_mbuf *txom);
 bool ble_att_is_response_op(uint8_t opcode);
 bool ble_att_is_request_op(uint8_t opcode);
+bool ble_eatt_supported_req(uint8_t opcode);
+bool ble_eatt_supported_rsp(uint8_t opcode);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Att opcode check caused l2cap disconnection when opcode included in received data was write command which is supported and can be used on eatt. Also, the comment seemed irrelevant. Fixes GATT/SR/GAW/BV-01-C
