### PR TITLE
nimble/audio: Add subgroups information for modify operation

### DIFF
--- a/nimble/host/audio/services/bass/include/services/bass/ble_audio_svc_bass.h
+++ b/nimble/host/audio/services/bass/include/services/bass/ble_audio_svc_bass.h
@@ -327,8 +327,6 @@ struct ble_svc_audio_bass_operation {
             /** Number of subgroups */
             uint16_t num_subgroups;
 
-            /** BIS Synchronisation of subgroups */
-            uint32_t bis_sync[BLE_SVC_AUDIO_BASS_SUB_NUM_MAX];
             /** Subgroup entries */
             struct ble_svc_audio_bass_subgroup
                 subgroups[BLE_SVC_AUDIO_BASS_SUB_NUM_MAX];

--- a/nimble/host/audio/src/ble_audio_scan_delegator.c
+++ b/nimble/host/audio/src/ble_audio_scan_delegator.c
@@ -197,8 +197,9 @@ bass_modify_source_op_handler(struct ble_svc_audio_bass_operation *op, void *arg
     BLE_AUDIO_DBG_ASSERT(sync_opt->num_subgroups < ARRAY_SIZE(sync_opt->subgroups));
 
     for (uint8_t i = 0; i < sync_opt->num_subgroups; i++) {
-        sync_opt->subgroups[i].bis_sync = op->modify_source.bis_sync[i];
-        /* FIXME: Missing metadata in Modify Source */
+        sync_opt->subgroups[i].bis_sync = op->modify_source.subgroups[i].bis_sync_state;
+        sync_opt->subgroups[i].metadata_length = op->modify_source.subgroups[i].metadata_length;
+        sync_opt->subgroups[i].metadata = op->modify_source.subgroups[i].metadata;
     }
 
     action.type = BLE_AUDIO_SCAN_DELEGATOR_ACTION_SOURCE_MODIFY;


### PR DESCRIPTION
Add subgroups info for modify source operation. Now metadata field can be handled in scan delegator during modify procedure.