### PR TITLE
nimble/ll: Fix periodic advertising event timing

### DIFF
--- a/nimble/controller/include/controller/ble_ll_adv.h
+++ b/nimble/controller/include/controller/ble_ll_adv.h
@@ -201,9 +201,9 @@ int ble_ll_adv_periodic_set_info_transfer(const uint8_t *cmdbuf, uint8_t len,
 
 /* Get advertising instance with periodic advertising configured */
 struct ble_ll_adv_sm *ble_ll_adv_sync_get(uint8_t handle);
-/* Get periodic advertising event scheduled time */
-int ble_ll_adv_sync_sched_get(struct ble_ll_adv_sm *advsm,
-                              uint32_t *start_time, uint32_t *end_time);
+int ble_ll_adv_padv_event_start_get(struct ble_ll_adv_sm *advsm,
+                                    uint32_t *event_start,
+                                    uint8_t *event_start_rem_us);
 
 #if MYNEWT_VAL(BLE_LL_ISO_BROADCASTER)
 struct ble_ll_iso_big;

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -5337,19 +5337,18 @@ ble_ll_adv_sync_get(uint8_t handle)
 }
 
 int
-ble_ll_adv_sync_sched_get(struct ble_ll_adv_sm *advsm, uint32_t *start_time,
-                          uint32_t *end_time)
+ble_ll_adv_padv_event_start_get(struct ble_ll_adv_sm *advsm,
+                                uint32_t *event_start,
+                                uint8_t *event_start_rem_us)
 {
-    struct ble_ll_adv_sync *sync;
-
     if (!advsm || !advsm->periodic_adv_active) {
-        return -EIO;
+        return -EINVAL;
     }
 
-    sync = SYNC_CURRENT(advsm);
-
-    *start_time = sync->sch.start_time + g_ble_ll_sched_offset_ticks;
-    *end_time = sync->sch.end_time;
+    *event_start = advsm->padv_event_start;
+    if (event_start_rem_us) {
+        *event_start_rem_us = advsm->padv_event_start_rem_us;
+    }
 
     return 0;
 }


### PR DESCRIPTION
This modifies padv event start time calculations to use single event
start time as anchor and calculate subsequent event start times as an
offset from that event.

This virtually removes drift due to rounding errors and avoids relative
drift of padv vs. BIG events.