### PR TITLE
apps/auracast_usb: Fix default value for BIG PHY

### DIFF
--- a/apps/auracast_usb/syscfg.yml
+++ b/apps/auracast_usb/syscfg.yml
@@ -44,7 +44,7 @@ syscfg.defs:
 
     BIG_PHY:
         description:
-        value: 3
+        value: 2
     BIG_NUM_BIS:
         description: Max number of BISes used
         value: 2


### PR DESCRIPTION
Should be 2M.