### PR TITLE
nimble/ll: Add set ext adv params v2 command

### DIFF
--- a/nimble/controller/include/controller/ble_ll_adv.h
+++ b/nimble/controller/include/controller/ble_ll_adv.h
@@ -216,6 +216,11 @@ int ble_ll_adv_sync_big_remove(struct ble_ll_adv_sm *advsm,
                                struct ble_ll_iso_big *big);
 #endif /* BLE_LL_ISO_BROADCASTER */
 
+#if MYNEWT_VAL(BLE_VERSION) >= 54
+int ble_ll_adv_ext_set_param_v2(const uint8_t *cmdbuf, uint8_t len,
+                                uint8_t *rspbuf, uint8_t *rsplen);
+#endif
+
 /* Called to notify adv code about RPA rotation */
 void ble_ll_adv_rpa_timeout(void);
 

--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -3613,6 +3613,57 @@ done:
     return rc;
 }
 
+#if MYNEWT_VAL(BLE_VERSION) >= 54
+static uint8_t
+ble_ll_adv_ext_phy_mode_get(uint8_t phy, uint8_t phy_opt)
+{
+    if (phy != BLE_HCI_LE_PHY_CODED) {
+        return phy;
+    }
+
+    switch (phy_opt) {
+    case BLE_HCI_ADVERTISING_PHY_OPT_S2_PREF:
+    case BLE_HCI_ADVERTISING_PHY_OPT_S2_REQ:
+        return BLE_PHY_MODE_CODED_500KBPS;
+    case BLE_HCI_ADVERTISING_PHY_OPT_NO_PREF:
+    case BLE_HCI_ADVERTISING_PHY_OPT_S8_PREF:
+    case BLE_HCI_ADVERTISING_PHY_OPT_S8_REQ:
+        return BLE_PHY_MODE_CODED_125KBPS;
+    default:
+        BLE_LL_ASSERT(0);
+    }
+}
+
+int
+ble_ll_adv_ext_set_param_v2(const uint8_t *cmdbuf, uint8_t len,
+                            uint8_t *rspbuf, uint8_t *rsplen)
+{
+    const struct ble_hci_le_set_ext_adv_params_v2_cp *cmd = (const void *) cmdbuf;
+    struct ble_ll_adv_sm *advsm;
+    int rc;
+
+    if (len != sizeof(*cmd)) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
+    }
+
+    if ((cmd->pri_phy_opt > 4) || (cmd->sec_phy_opt > 4)) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
+    }
+
+    rc = ble_ll_adv_ext_set_param(cmdbuf, len - 2, rspbuf, rsplen);
+    if (rc != 0) {
+        return rc;
+    }
+
+    advsm = ble_ll_adv_sm_get(cmd->params_v1.adv_handle);
+
+    advsm->pri_phy = ble_ll_adv_ext_phy_mode_get(cmd->params_v1.pri_phy, cmd->pri_phy_opt);
+    advsm->sec_phy = ble_ll_adv_ext_phy_mode_get(cmd->params_v1.pri_phy, cmd->sec_phy_opt);
+
+    return rc;
+}
+#endif
+
 int
 ble_ll_adv_ext_set_adv_data(const uint8_t *cmdbuf, uint8_t cmdlen)
 {

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -1317,6 +1317,13 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
         rc = ble_ll_conn_hci_subrate_req(cmdbuf, len, rspbuf, rsplen);
         break;
 #endif
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+#if MYNEWT_VAL(BLE_VERSION) >= 54
+    case BLE_HCI_OCF_LE_SET_EXT_ADV_PARAM_V2:
+        rc = ble_ll_adv_ext_set_param_v2(cmdbuf, len, rspbuf, rsplen);
+        break;
+#endif
+#endif
 #if MYNEWT_VAL(BLE_LL_CHANNEL_SOUNDING)
     case BLE_HCI_OCF_LE_CS_RD_LOC_SUPP_CAP:
         rc = ble_ll_cs_hci_rd_loc_supp_cap(rspbuf, rsplen);

--- a/nimble/controller/src/ble_ll_hci_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_hci_supp_cmd.c
@@ -286,6 +286,9 @@ static const uint8_t octet_46 = OCTET(
     BIT(0) /* HCI LE Set Default Subrate */
     BIT(1) /* HCI LE Subrate Request */
 #endif
+#if MYNEWT_VAL(BLE_VERSION) >= 54 && MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+    BIT(2) /* HCI LE Set Extended Advertising Parameters [v2] */
+#endif
 );
 
 static const uint8_t g_ble_ll_hci_supp_cmds[64] = {

--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -3252,7 +3252,7 @@ ble_gap_ext_adv_params_tx_v2(uint8_t instance,
 
     memset(&cmd, 0, sizeof(cmd));
 
-    rc = ble_gap_set_ext_adv_params(&(cmd.cmd), instance, params, selected_tx_power);
+    rc = ble_gap_set_ext_adv_params(&(cmd.params_v1), instance, params, selected_tx_power);
 
     if (rc != 0) {
         return rc;

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1152,7 +1152,7 @@ struct ble_hci_le_subrate_req_cp {
 
 #define BLE_HCI_OCF_LE_SET_EXT_ADV_PARAM_V2             (0x007F)
 struct ble_hci_le_set_ext_adv_params_v2_cp {
-    struct ble_hci_le_set_ext_adv_params_cp cmd;
+    struct ble_hci_le_set_ext_adv_params_cp params_v1;
     uint8_t pri_phy_opt;
     uint8_t sec_phy_opt;
 } __attribute__((packed));

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1637,6 +1637,13 @@ struct ble_hci_vs_set_local_irk_cp {
 #define BLE_HCI_PRIVACY_NETWORK                     (0)
 #define BLE_HCI_PRIVACY_DEVICE                      (1)
 
+/* --- LE set advertising coded PHY options (OCF 0x007F) */
+#define BLE_HCI_ADVERTISING_PHY_OPT_NO_PREF      0x0
+#define BLE_HCI_ADVERTISING_PHY_OPT_S2_PREF      0x1
+#define BLE_HCI_ADVERTISING_PHY_OPT_S8_PREF      0x2
+#define BLE_HCI_ADVERTISING_PHY_OPT_S2_REQ       0x3
+#define BLE_HCI_ADVERTISING_PHY_OPT_S8_REQ       0x4
+
 /* Event Codes */
 #define BLE_HCI_EVCODE_INQUIRY_CMP          (0x01)
 #define BLE_HCI_EVCODE_INQUIRY_RESULT       (0x02)


### PR DESCRIPTION
This adds second version of Set Extended
Advertising Parameters command (7.8.53)
Introduced in Core Specification v5.4.