### PR TITLE
nimble/host: Send GAP pairing complete event only for pairing

### DIFF
--- a/nimble/host/src/ble_sm.c
+++ b/nimble/host/src/ble_sm.c
@@ -944,7 +944,7 @@ ble_sm_process_result(uint16_t conn_handle, struct ble_sm_result *res,
 
         ble_hs_unlock();
 
-        if (res->enc_cb &&
+        if (proc && (proc->flags & BLE_SM_PROC_F_PAIRING) && res->enc_cb &&
             res->app_status != BLE_HS_ENOTCONN) {
             /* Do not send this event on broken connection */
             ble_gap_pairing_complete_event(conn_handle, res->sm_err);
@@ -1831,6 +1831,7 @@ ble_sm_pair_req_rx(uint16_t conn_handle, struct os_mbuf **om,
     if (proc != NULL) {
         proc->conn_handle = conn_handle;
         proc->state = BLE_SM_PROC_STATE_PAIR;
+        proc->flags = BLE_SM_PROC_F_PAIRING;
         ble_sm_insert(proc);
 
         proc->pair_req[0] = BLE_SM_OP_PAIR_REQ;
@@ -2575,7 +2576,7 @@ ble_sm_pair_initiate(uint16_t conn_handle)
     } else {
         proc->conn_handle = conn_handle;
         proc->state = BLE_SM_PROC_STATE_PAIR;
-        proc->flags |= BLE_SM_PROC_F_INITIATOR;
+        proc->flags |= BLE_SM_PROC_F_INITIATOR | BLE_SM_PROC_F_PAIRING;
 
         ble_hs_lock();
         ble_sm_insert(proc);

--- a/nimble/host/src/ble_sm_priv.h
+++ b/nimble/host/src/ble_sm_priv.h
@@ -216,6 +216,7 @@ struct ble_sm_dhkey_check {
 #define BLE_SM_PROC_F_AUTHENTICATED         0x08
 #define BLE_SM_PROC_F_SC                    0x10
 #define BLE_SM_PROC_F_BONDING               0x20
+#define BLE_SM_PROC_F_PAIRING               0x40
 
 #define BLE_SM_KE_F_ENC_INFO                0x01
 #define BLE_SM_KE_F_MASTER_ID               0x02


### PR DESCRIPTION
The pairing complete event was sent also for encryption restore procedure which is confusing. This makes sure that we only send that event in case actual pairing procedure was used.