### PR TITLE
nimble/host: Clear ATT queue on conn_free

### DIFF
--- a/nimble/host/src/ble_hs_conn.c
+++ b/nimble/host/src/ble_hs_conn.c
@@ -255,6 +255,11 @@ ble_hs_conn_free(struct ble_hs_conn *conn)
         os_mbuf_free_chain(OS_MBUF_PKTHDR_TO_MBUF(omp));
     }
 
+    while ((omp = STAILQ_FIRST(&conn->att_tx_q)) != NULL) {
+        STAILQ_REMOVE_HEAD(&conn->att_tx_q, omp_next);
+        os_mbuf_free_chain(OS_MBUF_PKTHDR_TO_MBUF(omp));
+    }
+
 #if MYNEWT_VAL(BLE_HS_DEBUG)
     memset(conn, 0xff, sizeof *conn);
 #endif


### PR DESCRIPTION
We need to free all mbufs enqueued on ATT queue when connection is freed, otherwise we may leak mbufs.