### PR TITLE
nimble/ll: Fix offset calculation in BIGInfo

### DIFF
--- a/nimble/controller/src/ble_ll_adv.c
+++ b/nimble/controller/src/ble_ll_adv.c
@@ -2191,7 +2191,6 @@ ble_ll_adv_sync_pdu_make(uint8_t *dptr, void *pducb_arg, uint8_t *hdr_byte)
                                                   sync->sch.start_time +
                                                   g_ble_ll_sched_offset_ticks,
                                                   sync->sch.remainder);
-        BLE_LL_ASSERT(biginfo_len > 0);
 
         dptr += biginfo_len;
     }


### PR DESCRIPTION
Offset calculation in BIGInfo assumes BIG event start time is always after AUX_SYNC_IND since BIG should be advanced to next event by the time AUX_SYNC_IND is sent. However, if AUX_SYNC_IND is scheduled close to BIG event this may not happend and thus calculated offset is invalid.

This makes sure that we always use BIG event after AUX_SYNC_IND to calculate offset.