### PR TITLE
nimble/ll: Simplify SyncInfo calculation

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -448,9 +448,14 @@ void ble_ll_conn_chan_map_update(void);
 /* required for unit testing */
 uint8_t ble_ll_conn_calc_dci(struct ble_ll_conn_sm *conn, uint16_t latency);
 
-/* used to get anchor point for connection event specified */
-void ble_ll_conn_get_anchor(struct ble_ll_conn_sm *connsm, uint16_t conn_event,
+/* get current event counter and anchor point */
+void ble_ll_conn_anchor_get(struct ble_ll_conn_sm *connsm, uint16_t *event_cntr,
                             uint32_t *anchor, uint8_t *anchor_usecs);
+
+/* get anchor point for specified connection event */
+void ble_ll_conn_anchor_event_cntr_get(struct ble_ll_conn_sm *connsm,
+                                       uint16_t event_cntr, uint32_t *anchor,
+                                       uint8_t *anchor_usecs);
 
 #if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 int ble_ll_conn_move_anchor(struct ble_ll_conn_sm *connsm, uint16_t offset);

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -2275,10 +2275,20 @@ ble_ll_conn_end(struct ble_ll_conn_sm *connsm, uint8_t ble_err)
                        connsm->event_cntr, (uint32_t)ble_err);
 }
 
+void
+ble_ll_conn_anchor_get(struct ble_ll_conn_sm *connsm, uint16_t *event_cntr,
+                       uint32_t *anchor, uint8_t *anchor_usecs)
+{
+    *event_cntr = connsm->event_cntr;
+    *anchor = connsm->anchor_point;
+    *anchor_usecs = connsm->anchor_point_usecs;
+}
+
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
 void
-ble_ll_conn_get_anchor(struct ble_ll_conn_sm *connsm, uint16_t conn_event,
-                       uint32_t *anchor, uint8_t *anchor_usecs)
+ble_ll_conn_anchor_event_cntr_get(struct ble_ll_conn_sm *connsm,
+                                  uint16_t event_cntr, uint32_t *anchor,
+                                  uint8_t *anchor_usecs)
 {
     uint32_t itvl;
 
@@ -2287,11 +2297,11 @@ ble_ll_conn_get_anchor(struct ble_ll_conn_sm *connsm, uint16_t conn_event,
     *anchor = connsm->anchor_point;
     *anchor_usecs = connsm->anchor_point_usecs;
 
-    if ((int16_t)(conn_event - connsm->event_cntr) < 0) {
-        itvl *= connsm->event_cntr - conn_event;
+    if ((int16_t)(event_cntr - connsm->event_cntr) < 0) {
+        itvl *= connsm->event_cntr - event_cntr;
         ble_ll_tmr_sub(anchor, anchor_usecs, itvl);
     } else {
-        itvl *= conn_event - connsm->event_cntr;
+        itvl *= event_cntr - connsm->event_cntr;
         ble_ll_tmr_add(anchor, anchor_usecs, itvl);
     }
 }

--- a/nimble/controller/src/ble_ll_sync.c
+++ b/nimble/controller/src/ble_ll_sync.c
@@ -2094,8 +2094,8 @@ ble_ll_sync_periodic_ind(struct ble_ll_conn_sm *connsm,
 
     /* get anchor for specified conn event */
     conn_event_count = get_le16(sync_ind + 20);
-    ble_ll_conn_get_anchor(connsm, conn_event_count, &sm->anchor_point,
-                           &sm->anchor_point_usecs);
+    ble_ll_conn_anchor_event_cntr_get(connsm, conn_event_count, &sm->anchor_point,
+                                      &sm->anchor_point_usecs);
 
     /* Set last anchor point */
     sm->last_anchor_point = sm->anchor_point - (last_pa_diff * sm->itvl_ticks);
@@ -2103,8 +2103,8 @@ ble_ll_sync_periodic_ind(struct ble_ll_conn_sm *connsm,
     /* calculate extra window widening */
     sync_conn_event_count = get_le16(sync_ind + 32);
     sca = sync_ind[24] >> 5;
-    ble_ll_conn_get_anchor(connsm, sync_conn_event_count, &sync_anchor,
-                           &sync_anchor_usecs);
+    ble_ll_conn_anchor_event_cntr_get(connsm, sync_conn_event_count, &sync_anchor,
+                                      &sync_anchor_usecs);
     ww_adjust = ble_ll_utils_calc_window_widening(connsm->anchor_point,
                                                   sync_anchor, sca);
 
@@ -2155,7 +2155,7 @@ ble_ll_sync_put_syncinfo(struct ble_ll_sync_sm *syncsm,
 
     /* get anchor for conn event that is before periodic_adv_event_start_time */
     while (LL_TMR_GT(anchor, syncsm->anchor_point)) {
-        ble_ll_conn_get_anchor(connsm, --conn_cnt, &anchor, &anchor_usecs);
+        ble_ll_conn_anchor_event_cntr_get(connsm, --conn_cnt, &anchor, &anchor_usecs);
     }
 
     offset = ble_ll_tmr_t2u(syncsm->anchor_point - anchor);


### PR DESCRIPTION
This simplifies calculation of SyncInfo used in AUX_ADV_IND and LL_PERIODIC_SYNC_IND to use the same code in both cases.

In case of LL Control PDU we do not "rewind" connsm to find proper connection event but instead "advance" padv event the same way as it was done for AUX_ADV_IND PDU.