### PR TITLE
porting/linux: Fix warning about __USE_GNU redefinition

### DIFF
--- a/porting/npl/linux/src/os_atomic.c
+++ b/porting/npl/linux/src/os_atomic.c
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-#include <stdint.h>
 #define __USE_GNU
+
+#include <stdint.h>
 #include <pthread.h>
 
 #include "nimble/nimble_npl.h"


### PR DESCRIPTION
Simply define this before including any systema headers.

g -D_GNU_SOURCE  -o ../../../porting/npl/linux/src/os_atomic.o ../../
    ../porting/npl/linux/src/os_atomic.c
../../../porting/npl/linux/src/os_atomic.c:21:9: warning: "__USE_GNU" redefined
   21 | #define __USE_GNU
      |         ^~~~~~~~~
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdint.h:26,
                 from /usr/lib/gcc/x86_64-redhat-linux/14/include/stdint.h:9,
                 from ../../../porting/npl/linux/src/os_atomic.c:20:
/usr/include/features.h:409:10: note: this is the location of the previous definition
  409 | # define __USE_GNU      1
      |          ^~~~~~~~~