### PR TITLE
apps/bleprph: Adjust OS main stack

### DIFF
--- a/apps/bleprph/syscfg.yml
+++ b/apps/bleprph/syscfg.yml
@@ -62,7 +62,7 @@ syscfg.vals:
     CONFIG_MGMT: 1
 
     # OS main/default task
-    OS_MAIN_STACK_SIZE: 512
+    OS_MAIN_STACK_SIZE: 768
 
     # Lots of smaller mbufs are required for smp using typical BLE ATT MTU
     # values.


### PR DESCRIPTION
Mcumgr image upload may require a bit more stack than current default. Make sure we are on safe side with default.