### PR TITLE
nimble/ll: Add vs hci cmd with additional scan cfg

### DIFF
--- a/nimble/controller/include/controller/ble_ll_scan.h
+++ b/nimble/controller/include/controller/ble_ll_scan.h
@@ -99,6 +99,14 @@ struct ble_ll_scan_pdu_data {
     uint8_t adva[BLE_DEV_ADDR_LEN];
 };
 
+struct ble_ll_scan_vs_config {
+    uint8_t ignore_legacy : 1;
+    uint8_t ignore_ext : 1;
+    uint8_t rssi_filter : 1;
+
+    int8_t rssi_threshold;
+};
+
 struct ble_ll_scan_addr_data {
     uint8_t *adva;
     uint8_t *targeta;
@@ -155,6 +163,10 @@ struct ble_ll_scan_sm
 #if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
     /* Connection sm for initiator scan */
     struct ble_ll_conn_sm *connsm;
+#endif
+
+#if MYNEWT_VAL(BLE_LL_HCI_VS_SET_SCAN_CFG)
+    struct ble_ll_scan_vs_config vs_config;
 #endif
 };
 
@@ -258,6 +270,10 @@ int
 ble_ll_scan_rx_filter(uint8_t own_addr_type, uint8_t scan_filt_policy,
                       struct ble_ll_scan_addr_data *addrd, uint8_t *scan_ok);
 int ble_ll_scan_rx_check_init(struct ble_ll_scan_addr_data *addrd);
+
+#if MYNEWT_VAL(BLE_LL_HCI_VS_SET_SCAN_CFG)
+int ble_ll_scan_set_vs_config(uint32_t flags, int8_t rssi_threshold);
+#endif
 
 #ifdef __cplusplus
 }

--- a/nimble/controller/src/ble_ll_hci_vs.c
+++ b/nimble/controller/src/ble_ll_hci_vs.c
@@ -356,6 +356,37 @@ ble_ll_hci_vs_set_local_irk(uint16_t ocf, const uint8_t *cmdbuf, uint8_t cmdlen,
 }
 #endif
 
+#if MYNEWT_VAL(BLE_LL_HCI_VS_SET_SCAN_CFG)
+static int
+ble_ll_hci_vs_set_scan_cfg(uint16_t ocf, const uint8_t *cmdbuf, uint8_t cmdlen,
+                           uint8_t *rspbuf, uint8_t *rsplen)
+{
+    const struct ble_hci_vs_set_scan_cfg_cp *cmd = (const void *)cmdbuf;
+    uint32_t flags;
+    int rc;
+
+    if (cmdlen != sizeof(*cmd)) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
+    }
+
+    flags = le32toh(cmd->flags);
+
+    if ((flags & BLE_HCI_VS_SET_SCAN_CFG_FLAG_NO_LEGACY) &&
+        (flags & BLE_HCI_VS_SET_SCAN_CFG_FLAG_NO_EXT)) {
+        return BLE_ERR_INV_HCI_CMD_PARMS;
+    }
+
+    rc = ble_ll_scan_set_vs_config(flags, cmd->rssi_threshold);
+    if (rc != 0) {
+        return BLE_ERR_CMD_DISALLOWED;
+    }
+
+    *rsplen = 0;
+
+    return 0;
+}
+#endif
+
 static struct ble_ll_hci_vs_cmd g_ble_ll_hci_vs_cmds[] = {
     BLE_LL_HCI_VS_CMD(BLE_HCI_OCF_VS_RD_STATIC_ADDR,
                       ble_ll_hci_vs_rd_static_addr),
@@ -385,6 +416,10 @@ static struct ble_ll_hci_vs_cmd g_ble_ll_hci_vs_cmds[] = {
 #if MYNEWT_VAL(BLE_LL_HCI_VS_LOCAL_IRK)
     BLE_LL_HCI_VS_CMD(BLE_HCI_OCF_VS_SET_LOCAL_IRK,
                       ble_ll_hci_vs_set_local_irk),
+#endif
+#if MYNEWT_VAL(BLE_LL_HCI_VS_SET_SCAN_CFG)
+    BLE_LL_HCI_VS_CMD(BLE_HCI_OCF_VS_SET_SCAN_CFG,
+                      ble_ll_hci_vs_set_scan_cfg)
 #endif
 };
 

--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -422,6 +422,17 @@ syscfg.defs:
         value: 0
         restrictions:
             - BLE_LL_HCI_VS if 1
+    BLE_LL_HCI_VS_SET_SCAN_CFG:
+        description: >
+            Enables HCI command to set global PDU filter for scanner.
+            It allows: 
+            - ignoring extended or legacy PDUs while scanning,
+            - setting minimal RSSI filter on primary channel
+        value: 0
+        restrictions:
+            - BLE_LL_HCI_VS if 1
+            - BLE_LL_CFG_FEAT_LL_EXT_ADV if 1
+            - BLE_LL_ROLE_OBSERVER if 1
 
 
     BLE_LL_HCI_VS_EVENT_ON_ASSERT:

--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -1396,6 +1396,16 @@ struct ble_hci_vs_set_local_irk_cp {
     uint8_t irk[16];
 } __attribute__((packed));
 
+#define BLE_HCI_VS_SET_SCAN_CFG_FLAG_NO_LEGACY               (0x00000001)
+#define BLE_HCI_VS_SET_SCAN_CFG_FLAG_NO_EXT                  (0x00000002)
+#define BLE_HCI_VS_SET_SCAN_CFG_FLAG_RSSI_FILTER             (0x00000004)
+
+#define BLE_HCI_OCF_VS_SET_SCAN_CFG                     (MYNEWT_VAL(BLE_HCI_VS_OCF_OFFSET) + (0x000B))
+struct ble_hci_vs_set_scan_cfg_cp {
+    uint32_t flags;
+    int8_t rssi_threshold;
+} __attribute__((packed));
+
 /* Command Specific Definitions */
 /* --- Set controller to host flow control (OGF 0x03, OCF 0x0031) --- */
 #define BLE_HCI_CTLR_TO_HOST_FC_OFF         (0)


### PR DESCRIPTION
This allows to configure scanner to ignore either
legacy or extended packets. If scan is enabled
command returns command disallowed error.