### PR TITLE
nimble/host: Fix SMP command allocation

### DIFF
--- a/nimble/host/src/ble_sm_cmd.c
+++ b/nimble/host/src/ble_sm_cmd.c
@@ -29,18 +29,20 @@ void *
 ble_sm_cmd_get(uint8_t opcode, size_t len, struct os_mbuf **txom)
 {
     struct ble_sm_hdr *hdr;
+    void *data;
 
     *txom = ble_hs_mbuf_l2cap_pkt();
     if (*txom == NULL) {
         return NULL;
     }
 
-    if (os_mbuf_extend(*txom, sizeof(*hdr) + len) == NULL) {
+    data = os_mbuf_extend(*txom, sizeof(*hdr) + len);
+    if (data == NULL) {
         os_mbuf_free_chain(*txom);
         return NULL;
     }
 
-    hdr = (struct ble_sm_hdr *)(*txom)->om_data;
+    hdr = (struct ble_sm_hdr *)data;
 
     hdr->opcode = opcode;
 


### PR DESCRIPTION
os_mbuf_extend can allocate new mbuf if there's not enough space in txom for complete SMP command. In such case we write SMP command data to the original mbuf which doesn't have om_len updated instead to newly created mbuf. This can happen especially for SMP Public Key if block size is not large enough to fit pkthdr and 65 bytes of command data.

We should use pointer returned from os_mbuf_extend as a SMP command data pointer as this always points to added space.