### PR TITLE
apps/blehci: Enable HCI vs event on assert for all asserts

### DIFF
--- a/apps/blehci/src/main.c
+++ b/apps/blehci/src/main.c
@@ -18,6 +18,17 @@
  */
 
 #include "os/mynewt.h"
+#if MYNEWT_VAL(BLE_CONTROLLER)
+#include "controller/ble_ll.h"
+#endif
+
+#if MYNEWT_VAL(OS_ASSERT_CB)
+void
+os_assert_cb(const char *file, int line, const char *func, const char *e)
+{
+    ble_ll_assert(file, line);
+}
+#endif
 
 int
 mynewt_main(int argc, char **argv)

--- a/apps/blehci/syscfg.yml
+++ b/apps/blehci/syscfg.yml
@@ -24,6 +24,9 @@ syscfg.vals:
     LOG_IMPLEMENTATION: stub
     STATS_IMPLEMENTATION: full
 
+syscfg.vals.BLE_LL_HCI_VS_EVENT_ON_ASSERT:
+    OS_ASSERT_CB: 1
+
 syscfg.vals.'!BLE_TRANSPORT_NETCORE':
     # Use UART by default if not built on netcore
     BLE_TRANSPORT_HS: uart


### PR DESCRIPTION
If HCI vs event on assert is enabled we can log all asserts, not only those wrapped in BLE_LL_ASSERT.