### PR TITLE
apps: bttester: fix uart settings

### DIFF
--- a/apps/bttester/src/uart_pipe.c
+++ b/apps/bttester/src/uart_pipe.c
@@ -48,7 +48,7 @@ static struct uart_pipe_ring cr_rx;
 static uint8_t cr_rx_buf[MYNEWT_VAL(BTTESTER_BTP_DATA_SIZE_MAX)];
 static volatile bool uart_console_rx_stalled;
 
-struct os_event rx_ev;
+static struct os_event rx_ev;
 
 static inline int
 inc_and_wrap(int i, int max)
@@ -243,11 +243,11 @@ int
 bttester_pipe_init(void)
 {
     struct uart_conf uc = {
-        .uc_speed = MYNEWT_VAL(CONSOLE_UART_BAUD),
+        .uc_speed = MYNEWT_VAL(BTTESTER_UART_BAUD),
         .uc_databits = 8,
         .uc_stopbits = 1,
         .uc_parity = UART_PARITY_NONE,
-        .uc_flow_ctl = MYNEWT_VAL(CONSOLE_UART_FLOW_CONTROL),
+        .uc_flow_ctl = MYNEWT_VAL(BTTESTER_UART_FLOW_CONTROL),
         .uc_tx_char = uart_console_tx_char,
         .uc_rx_char = uart_console_rx_char,
     };
@@ -263,7 +263,7 @@ bttester_pipe_init(void)
 
     if (!uart_dev) {
         uart_dev =
-            (struct uart_dev *) os_dev_open(MYNEWT_VAL(CONSOLE_UART_DEV),
+            (struct uart_dev *) os_dev_open(MYNEWT_VAL(BTTESTER_UART_DEV),
                                             OS_TIMEOUT_NEVER, &uc);
         if (!uart_dev) {
             return -1;

--- a/apps/bttester/syscfg.yml
+++ b/apps/bttester/syscfg.yml
@@ -19,6 +19,18 @@
 # Package: apps/blemesh
 
 syscfg.defs:
+    BTTESTER_UART_BAUD:
+        description: 'Console UART baud rate.'
+        value: '115200'
+
+    BTTESTER_UART_FLOW_CONTROL:
+        description: 'Console UART flow control.'
+        value: 'UART_FLOW_CTL_RTS_CTS'
+
+    BTTESTER_UART_DEV:
+        description: 'Console UART device.'
+        value: '"uart0"'
+
     BTTESTER_PIPE_UART:
         description: 'Set communication pipe to UART'
         value: 1


### PR DESCRIPTION
uart_pipe.c from bttester app was using values copied directly from uart_console.c e.g. CONSOLE_UART_DEV, CONSOLE_UART_BAUD. This caused BTP malfunction when trying to receive logs over UART from bttester. BTTESTER_UART variables are now added to syscfg and applied in uart_pipe.c