### PR TITLE
nimble/ll: Fix connection  parameters update with CSS build in

### DIFF
--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -1099,8 +1099,13 @@ ble_ll_conn_hci_update(const uint8_t *cmdbuf, uint8_t len)
     /* Retrieve command data */
     hcu = &connsm->conn_param_req;
 #if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
-    hcu->conn_itvl_max = connsm->conn_itvl;
-    hcu->conn_itvl_min = connsm->conn_itvl;
+    if (ble_ll_sched_css_is_enabled()) {
+        hcu->conn_itvl_max = connsm->conn_itvl;
+        hcu->conn_itvl_min = connsm->conn_itvl;
+    } else {
+        hcu->conn_itvl_min = le16toh(cmd->conn_itvl_min);
+        hcu->conn_itvl_max = le16toh(cmd->conn_itvl_max);
+    }
 #else
     hcu->conn_itvl_min = le16toh(cmd->conn_itvl_min);
     hcu->conn_itvl_max = le16toh(cmd->conn_itvl_max);

--- a/nimble/controller/src/ble_ll_ctrl.c
+++ b/nimble/controller/src/ble_ll_ctrl.c
@@ -296,17 +296,18 @@ ble_ll_ctrl_conn_param_pdu_proc(struct ble_ll_conn_sm *connsm, uint8_t *dptr,
 #if MYNEWT_VAL(BLE_LL_CONN_STRICT_SCHED)
     /* Allow to change connection parameters only if conn_itvl can stay unchanged
      * and anchor point change is not requested */
-    if (ble_ll_sched_css_is_enabled() &&
-        connsm->conn_role == BLE_LL_CONN_ROLE_CENTRAL &&
-        ((connsm->conn_itvl < le16toh(req->interval_min)) ||
-         (connsm->conn_itvl > le16toh(req->interval_max)) ||
-         (le16toh(req->offset0) != 0xffff))) {
-        ble_err = BLE_ERR_INV_LMP_LL_PARM;
-        goto conn_param_pdu_exit;
-    }
+    if (ble_ll_sched_css_is_enabled()) {
+        if (connsm->conn_role == BLE_LL_CONN_ROLE_CENTRAL &&
+            ((connsm->conn_itvl < le16toh(req->interval_min)) ||
+             (connsm->conn_itvl > le16toh(req->interval_max)) ||
+             (le16toh(req->offset0) != 0xffff))) {
+            ble_err = BLE_ERR_INV_LMP_LL_PARM;
+            goto conn_param_pdu_exit;
+        }
 
-    req->interval_min = connsm->conn_itvl;
-    req->interval_max = connsm->conn_itvl;
+        req->interval_min = connsm->conn_itvl;
+        req->interval_max = connsm->conn_itvl;
+    }
 #endif
 
     /* Check if parameters are valid */


### PR DESCRIPTION
Interval should be clipped only if CSS is runtime enabled and not just compiled in.