### PR TITLE
debug: Declare as printf-style, remove empty statement

### DIFF
--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1619,8 +1619,6 @@ ble_gatts_peer_cl_sup_feat_update(uint16_t conn_handle, struct os_mbuf *om)
     int rc = 0;
     int i;
 
-    BLE_HS_LOG(DEBUG, "");
-
     if (!om) {
         return BLE_ATT_ERR_INSUFFICIENT_RES;
     }

--- a/porting/npl/riot/include/nimble/nimble_npl_os_log.h
+++ b/porting/npl/riot/include/nimble/nimble_npl_os_log.h
@@ -24,6 +24,7 @@
 
 /* Example on how to use macro to generate module logging functions */
 #define BLE_NPL_LOG_IMPL(lvl) \
+        __attribute__((__format__ (__printf__, 1, 0))) \
         static inline void _BLE_NPL_LOG_CAT(BLE_NPL_LOG_MODULE, \
                 _BLE_NPL_LOG_CAT(_, lvl))(const char *fmt, ...)\
         {                               \


### PR DESCRIPTION
This resolves the -Wformat-nonliteral warning by (which complains about non-literals used as printf formatters, unless the containing function itself is also printf style), and a stray leftover empty debug statement discovered by that warning: -Wformat-nonliteral is a bit of a false postive here because due to the level prefix, the empty printf is not *really* empty, but it is accurate enough in that it does not provide any valuable details.

---

This was found when building the latest nimble with RIOT, which has relatively strict warnings on – and while those are often disabled for projects that don't usually build with the strict warnings, since the debug header gets included in public headers, it spreads to many compilation units. Applying the attribute(format) is also in line with RIOT's [code style](https://github.com/RIOT-OS/RIOT/blob/master/CODING_CONVENTIONS.md#-wformat-nonliteral), which while not directly applicable, is tangentially relevant as the header file is specifically part of the RIOT port.

If there is actual information that should be shown in the removed DEBUG line, I'm happy to alter the patch to include it.