### PR TITLE
Fix a build warning caused by using undeclared ARRAY_SIZE macro

### DIFF
--- a/nimble/host/store/config/src/ble_store_config.c
+++ b/nimble/host/store/config/src/ble_store_config.c
@@ -24,6 +24,7 @@
 #include "syscfg/syscfg.h"
 #include "host/ble_hs.h"
 #include "base64/base64.h"
+#include "os/util.h"
 #include "store/config/ble_store_config.h"
 #include "ble_store_config_priv.h"
 


### PR DESCRIPTION
Use of undeclared ARRAY_SIZE macro causes build warning. Add include to "os/util.h" in ble_store_config.c file.