### PR TITLE
port: Call ble_ll_init

### DIFF
--- a/porting/nimble/src/nimble_port.c
+++ b/porting/nimble/src/nimble_port.c
@@ -31,10 +31,12 @@ static struct ble_npl_eventq g_eventq_dflt;
 
 extern void os_msys_init(void);
 extern void os_mempool_module_init(void);
+extern void ble_ll_init(void);
 
 void
 nimble_port_init(void)
 {
+    ble_ll_init();
     /* Initialize default event queue */
     ble_npl_eventq_init(&g_eventq_dflt);
     /* Initialize the global memory pool */


### PR DESCRIPTION
For the RIOT port, when upgrading from 0.15 to 0.18, I had to manually call ble_ll_init; as per [a comment](https://github.com/RIOT-OS/RIOT/pull/21108#issuecomment-2567406816) from @sjanc, this is better done in the nimble_port_init call, where this PR moves it.

This is being tested in RIOT, where the patch is being applied in the 0.18 branch.