### PR TITLE
host: l2cap: avoid nested ble_hs_lock when disconnecting due to inval…

### DIFF
--- a/nimble/host/src/ble_hs_hci_evt.c
+++ b/nimble/host/src/ble_hs_hci_evt.c
@@ -1131,6 +1131,9 @@ ble_hs_hci_evt_acl_process(struct os_mbuf *om)
     ble_hs_lock();
 
     conn = ble_hs_conn_find(conn_handle);
+
+    ble_hs_unlock();
+
     if (conn == NULL) {
         /* Peer not connected; quietly discard packet. */
         rc = BLE_HS_ENOTCONN;
@@ -1140,8 +1143,6 @@ ble_hs_hci_evt_acl_process(struct os_mbuf *om)
         rc = ble_l2cap_rx(conn, &hci_hdr, om, &rx_cb, &reject_cid);
         om = NULL;
     }
-
-    ble_hs_unlock();
 
     switch (rc) {
     case 0:


### PR DESCRIPTION
When receiving L2CAP packet which checked to be invalid and a disconnection is required we get into a nested lock (the first is in ble_hs_hci_evt_acl_process which wraps ble_l2cap_rx and the second is inside ble_l2cap_sig_tx which is part of the ble_l2cap_disconnect API). Update the lock sequence to avoid it.

host: l2cap: avoid nested ble_hs_lock when disconnecting due to invalid packet

When receiving L2CAP packet which checked to be invalid and a disconnection is required we get into a nested lock (the first is in ble_hs_hci_evt_acl_process which wraps ble_l2cap_rx and the second is inside ble_l2cap_sig_tx which is part of the ble_l2cap_disconnect API). Update the lock sequence to avoid it.