### PR TITLE
Characteristic value reading for notification/indication compromises security set-up

### DIFF
--- a/nimble/host/src/ble_att_priv.h
+++ b/nimble/host/src/ble_att_priv.h
@@ -217,6 +217,7 @@ void ble_att_svr_prep_clear(struct ble_att_prep_entry_list *prep_list);
 int ble_att_svr_read_handle(uint16_t conn_handle, uint16_t attr_handle,
                             uint16_t offset, struct os_mbuf *om,
                             uint8_t *out_att_err);
+int ble_att_svr_read_local_with_perms(uint16_t conn_handle, uint16_t attr_handle, struct os_mbuf **out_om);
 void ble_att_svr_reset(void);
 int ble_att_svr_init(void);
 

--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -496,7 +496,7 @@ ble_att_svr_read_handle(uint16_t conn_handle, uint16_t attr_handle,
 }
 
 int
-ble_att_svr_read_local(uint16_t attr_handle, struct os_mbuf **out_om)
+ble_att_svr_read_local_with_perms(uint16_t conn_handle, uint16_t attr_handle, struct os_mbuf **out_om)
 {
     struct os_mbuf *om;
     int rc;
@@ -507,18 +507,24 @@ ble_att_svr_read_local(uint16_t attr_handle, struct os_mbuf **out_om)
         goto err;
     }
 
-    rc = ble_att_svr_read_handle(BLE_HS_CONN_HANDLE_NONE, attr_handle, 0, om,
-                                 NULL);
+    rc = ble_att_svr_read_handle(conn_handle, attr_handle, 0, om, NULL);
     if (rc != 0) {
         goto err;
     }
 
     *out_om = om;
+
     return 0;
 
 err:
     os_mbuf_free_chain(om);
     return rc;
+}
+
+int
+ble_att_svr_read_local(uint16_t attr_handle, struct os_mbuf **out_om)
+{
+    return ble_att_svr_read_local_with_perms(BLE_HS_CONN_HANDLE_NONE, attr_handle, out_om);
 }
 
 static int

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -4368,11 +4368,27 @@ ble_gatts_notify_custom(uint16_t conn_handle, uint16_t chr_val_handle,
             rc = BLE_HS_ENOMEM;
             goto done;
         }
-        rc = ble_att_svr_read_handle(BLE_HS_CONN_HANDLE_NONE,
-                                     chr_val_handle, 0, txom, NULL);
+
+        rc = ble_att_svr_read_handle(conn_handle, chr_val_handle, 0, txom, NULL);
         if (rc != 0) {
-            /* Fatal error; application disallowed attribute read. */
-            rc = BLE_HS_EAPP;
+            switch (rc) {
+                case BLE_HS_ATT_ERR(BLE_ATT_ERR_INSUFFICIENT_ENC):
+                    rc = BLE_HS_EENCRYPT;
+                    break;
+
+                case BLE_HS_ATT_ERR(BLE_ATT_ERR_INSUFFICIENT_AUTHEN):
+                    rc = BLE_HS_EAUTHEN;
+                    break;
+
+                case BLE_HS_ATT_ERR(BLE_ATT_ERR_INSUFFICIENT_AUTHOR):
+                    rc = BLE_HS_EAUTHOR;
+                    break;
+
+                default:
+                    /* Fatal error; application disallowed attribute read. */
+                    rc = BLE_HS_EAPP;
+                    break;
+            }
             goto done;
         }
     }
@@ -4437,43 +4453,41 @@ ble_gatts_notify_multiple_custom(uint16_t conn_handle,
     struct os_mbuf *txom;
     struct ble_hs_conn *conn;
 
-    txom = ble_hs_mbuf_att_pkt();
-    if (txom == NULL) {
-        return BLE_HS_ENOMEM;
-    }
+    BLE_HS_LOG_DEBUG("conn_handle %d\n", conn_handle);
 
     conn = ble_hs_conn_find(conn_handle);
     if (conn == NULL) {
         return BLE_HS_ENOTCONN;
     }
 
-    /* Read missing values */
-    for (i = 0; i < chr_count; i++) {
-        if (tuples->handle == 0) {
-            rc = BLE_HS_EINVAL;
-            goto done;
-        }
-        if (tuples[i].value == NULL) {
-            rc = ble_att_svr_read_local(tuples[i].handle, &tuples[i].value);
-            if (rc != 0) {
-                goto done;
-            }
-        }
-    }
+    BLE_HS_LOG_DEBUG("ble_gatts_notify_multiple: peer_cl_sup_feat %d\n",
+                     conn->bhc_gatt_svr.peer_cl_sup_feat[0]);
 
-    /* If peer does not support fall back to multiple single value
-     * Notifications */
+    /* If peer does not support fall back to multiple single value Notifications */
     if ((conn->bhc_gatt_svr.peer_cl_sup_feat[0] & 0x04) == 0) {
         for (i = 0; i < chr_count; i++) {
-            rc = ble_att_clt_tx_notify(conn_handle, tuples[chr_count].handle,
-                               tuples[chr_count].value);
+            rc = ble_gatts_notify(conn_handle, tuples[i].handle);
             if (rc != 0) {
                 goto done;
             }
         }
+
+        return 0;
+    }
+
+    txom = ble_hs_mbuf_att_pkt();
+    if (txom == NULL) {
+        return BLE_HS_ENOMEM;
     }
 
     for (i = 0; i < chr_count; i++) {
+        if (tuples[i].value == NULL) {
+            rc = ble_att_svr_read_local_with_perms(conn_handle, tuples[i].handle, &tuples[i].value);
+            if (rc != 0) {
+                goto done;
+            }
+        }
+
         if (txom->om_len + tuples[i].value->om_len > mtu && cur_chr_cnt < 2) {
             rc = ble_att_clt_tx_notify(conn_handle, tuples[i].handle,
                                        tuples[i].value);
@@ -4520,28 +4534,9 @@ ble_gatts_notify_multiple(uint16_t conn_handle,
 #if !MYNEWT_VAL(BLE_GATT_NOTIFY_MULTIPLE)
     return BLE_HS_ENOTSUP;
 #endif
-    int rc, i;
+
+    int i;
     struct ble_gatt_notif tuples[num_handles];
-    struct ble_hs_conn *conn;
-
-    BLE_HS_LOG_DEBUG("conn_handle %d\n", conn_handle);
-    conn = ble_hs_conn_find(conn_handle);
-    if (conn == NULL) {
-        return BLE_HS_ENOTCONN;
-    }
-
-    /** Skip sending to client that doesn't support this feature */
-    BLE_HS_LOG_DEBUG("ble_gatts_notify_multiple: peer_cl_sup_feat %d\n",
-                     conn->bhc_gatt_svr.peer_cl_sup_feat[0]);
-    if ((conn->bhc_gatt_svr.peer_cl_sup_feat[0] & 0x04) == 0) {
-        for (i = 0; i < num_handles; i++) {
-            rc = ble_gatts_notify(conn_handle, chr_val_handles[i]);
-            if (rc != 0) {
-                return rc;
-            }
-        }
-        return 0;
-    }
 
     for (i = 0; i < num_handles; i++) {
         tuples[i].handle = chr_val_handles[i];
@@ -4549,8 +4544,7 @@ ble_gatts_notify_multiple(uint16_t conn_handle,
         BLE_HS_LOG(DEBUG, "handle 0x%02x\n", tuples[i].handle);
     }
 
-    rc = ble_gatts_notify_multiple_custom(conn_handle, num_handles, tuples);
-    return rc;
+    return ble_gatts_notify_multiple_custom(conn_handle, num_handles, tuples);
 }
 
 /**
@@ -4677,12 +4671,26 @@ ble_gatts_indicate_custom(uint16_t conn_handle, uint16_t chr_val_handle,
             goto done;
         }
 
-        rc = ble_att_svr_read_handle(BLE_HS_CONN_HANDLE_NONE, chr_val_handle,
-                                     0, txom, NULL);
+        rc = ble_att_svr_read_handle(conn_handle, chr_val_handle, 0, txom, NULL);
         if (rc != 0) {
-            /* Fatal error; application disallowed attribute read. */
-            BLE_HS_DBG_ASSERT(0);
-            rc = BLE_HS_EAPP;
+            switch (rc) {
+                case BLE_HS_ATT_ERR(BLE_ATT_ERR_INSUFFICIENT_ENC):
+                    rc = BLE_HS_EENCRYPT;
+                    break;
+
+                case BLE_HS_ATT_ERR(BLE_ATT_ERR_INSUFFICIENT_AUTHEN):
+                    rc = BLE_HS_EAUTHEN;
+                    break;
+
+                case BLE_HS_ATT_ERR(BLE_ATT_ERR_INSUFFICIENT_AUTHOR):
+                    rc = BLE_HS_EAUTHOR;
+                    break;
+
+                default:
+                    /* Fatal error; application disallowed attribute read. */
+                    rc = BLE_HS_EAPP;
+                    break;
+            }
             goto done;
         }
     }


### PR DESCRIPTION
If a GATT server provides the characteristic which requires encryption (`BLE_GATT_CHR_F_READ_ENC`) than a client should connect and pair with the server to read the characteristic. But if notification (`BLE_GATT_CHR_F_NOTIFY`) or indication (`BLE_GATT_CHR_F_INDICATE`) is enabled for the characteristic than the client could connect and subscribe to notifications/indications getting characteristic value even if the connection is not encrypted. So the security of the characteristic is compromised.

As I see it there are 3 alternatives for the solution:
1. Created CCCD should also has READ_ENC, WRITE_ENC (same as characteristic itself), so that the client shall pair before proceeding if encryption required.
2. Check permissions during reading (which is the current implementation). Nimble stack should respect permissions during reading for notifications (now it doesn't check permissions).
3. Application developer should ensure that connection parameters are correct for each notification. He should keep track on what characteristics what permissions require before calling `ble_gatts_notify`. But it's kind of weird.

```c
// service definitions
static struct ble_gatt_svc_def environmentService[] = {
    {
        .type = BLE_GATT_SVC_TYPE_PRIMARY,
        .uuid = BLE_UUID16_DECLARE(BLE_UUID_SERVICE_ENV_SENSING),
        .characteristics = (struct ble_gatt_chr_def[]) {
            {
                .uuid = BLE_UUID16_DECLARE(BLE_UUID_CHARACTERISTIC_TEMPERATURE),
                .access_cb = characteristicValue,
                .val_handle = &esTemperatureCharacteristicAttributeHandle,
                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_ENC | BLE_GATT_CHR_F_NOTIFY,
            },
            { 0 }
        },
    },
    { BLE_GATT_SVC_TYPE_END },
};

// nimble configuration
    ble_hs_cfg.sm_sc = 1;
    ble_hs_cfg.sm_bonding = 1;
    ble_hs_cfg.sm_our_key_dist |= BLE_SM_PAIR_KEY_DIST_ENC;
    ble_hs_cfg.sm_their_key_dist |= BLE_SM_PAIR_KEY_DIST_ENC;
    ble_hs_cfg.sm_our_key_dist |= BLE_SM_PAIR_KEY_DIST_ID;
    ble_hs_cfg.sm_their_key_dist |= BLE_SM_PAIR_KEY_DIST_ID;

    ble_hs_cfg.reset_cb = nimble_callback_on_reset;
    ble_hs_cfg.sync_cb = nimble_callback_on_sync;
    ble_hs_cfg.store_status_cb = ble_store_util_status_rr;

    ble_store_config_init();

    ble_svc_gap_init();
    ble_svc_gatt_init();

    error = ble_gatts_count_cfg(environmentService);
    if (error) {
        return error;
    }

    error = ble_gatts_add_svcs(environmentService);
    if (error) {
        return error;
    }

// set random temperature value and call notify at interval
ble_gatts_notify(conn_handle, esTemperatureCharacteristicAttributeHandle);
```

We could reproduce the behavior using nRF Connect app on Android. Start the device, open the app, connect to the advertising device.
1. If try to read temperature characteristic the Android will show pairing dialog. Value couldn't be read unless paired;
2. Subscribe to notification without reading the value. Android app subscribes and value is coming at each interval.

**Review:**
1. Current code doesn't check handle in `ble_gatts_notify_multiple`, so I removed it from `ble_gatts_notify_multiple_custom` as well. Eventually the handle is checked during reading.
2. I've made code more consistent. E.g. `ble_gatts_notify` calls `ble_gatts_notify_custom`, therefor I moved logic from `ble_gatts_notify_multiple` to `ble_gatts_notify_multiple_custom`, so it handles both cases. (As it did before, made it more DRY).
3. It seems there is a bug in the current implementation in `ble_gatts_notify_multiple_custom` when multiple notifications are not supported (iterating over passed handles-values structure taking out of border element on each iteration and also not returning after the for loop).

If this changes are ok, a consideration should be taken of the necessity of `ble_att_svr_read_local` function as it was used to bypass permission checks. And is not used in other functions.