### PR TITLE
apps: bttester: Implement notify / Remove set_mult

### DIFF
--- a/apps/bttester/src/btp/btp_gatt.h
+++ b/apps/bttester/src/btp/btp_gatt.h
@@ -320,6 +320,13 @@ struct btp_gatt_set_mult_val_cmd {
     uint8_t data[0];
 } __packed;
 
+#define BTP_GATT_NOTIFY_MULTIPLE        0x21
+struct btp_gatt_notify_mult_val_cmd {
+    ble_addr_t addr;
+    uint16_t count;
+    uint16_t handles[0];
+} __packed;
+
 /* GATT events */
 #define BTP_GATT_EV_NOTIFICATION        0x80
 struct btp_gatt_notification_ev {

--- a/apps/bttester/src/btp/btp_gatt.h
+++ b/apps/bttester/src/btp/btp_gatt.h
@@ -314,12 +314,6 @@ struct btp_gatt_change_database_cmd {
     uint8_t visibility;
 } __packed;
 
-#define BTP_GATT_SET_MULT_VALUE        0x20
-struct btp_gatt_set_mult_val_cmd {
-    uint16_t count;
-    uint8_t data[0];
-} __packed;
-
 #define BTP_GATT_NOTIFY_MULTIPLE        0x21
 struct btp_gatt_notify_mult_val_cmd {
     ble_addr_t addr;

--- a/apps/bttester/src/btp_gatt.c
+++ b/apps/bttester/src/btp_gatt.c
@@ -93,7 +93,7 @@ struct find_attr_data {
 
 struct notify_mult_cb_data {
     size_t tuple_cnt;
-    uint16_t handles[0];
+    uint16_t handles[8];
 };
 
 static int
@@ -1914,6 +1914,38 @@ done:
 }
 
 static uint8_t
+notify_mult(const void *cmd, uint16_t cmd_len,
+            void *rsp, uint16_t *rsp_len)
+{
+    const struct btp_gatt_notify_mult_val_cmd *cp = cmd;
+    struct notify_mult_cb_data cb_data;
+    int i;
+
+
+    if (cmd_len < sizeof(*cp) ||
+        (cmd_len != (sizeof(*cp) +
+        (le16toh(cp->count) * sizeof(cp->handles[0]))))) {
+
+        return BTP_STATUS_FAILED;
+    }
+
+    if (le16toh(cp->count) > sizeof(cb_data.handles)) {
+        SYS_LOG_ERR("Too many handles to notify");
+        return BTP_STATUS_FAILED;
+    }
+
+    for (i = 0; i < cp->count; i++) {
+        cb_data.handles[i] = le16toh(cp->handles[i]);
+    }
+
+    cb_data.tuple_cnt = cp->count;
+
+    ble_gap_conn_foreach_handle(notify_multiple, (void *)&cb_data);
+
+    return BTP_STATUS_SUCCESS;
+}
+
+static uint8_t
 change_database(const void *cmd, uint16_t cmd_len,
                 void *rsp, uint16_t *rsp_len)
 {
@@ -2099,6 +2131,11 @@ static const struct btp_handler handlers[] = {
         .opcode = BTP_GATT_SET_MULT_VALUE,
         .expect_len = BTP_HANDLER_LENGTH_VARIABLE,
         .func = set_mult,
+    },
+    {
+        .opcode = BTP_GATT_NOTIFY_MULTIPLE,
+        .expect_len = BTP_HANDLER_LENGTH_VARIABLE,
+        .func = notify_mult,
     },
 };
 

--- a/apps/bttester/src/btp_gatt.c
+++ b/apps/bttester/src/btp_gatt.c
@@ -1871,49 +1871,6 @@ notify_multiple(uint16_t conn_handle, void *arg)
 }
 
 static uint8_t
-set_mult(const void *cmd, uint16_t cmd_len,
-         void *rsp, uint16_t *rsp_len)
-{
-    const struct btp_gatt_set_mult_val_cmd *cp = cmd;
-    struct ble_gatt_notif tuples[16];
-    int i;
-    int rc = 0;
-    int data_idx = 0;
-    uint16_t data_len;
-    struct notify_mult_cb_data cb_data;
-
-    for (i = 0; i < cp->count; i++) {
-        tuples[i].handle = get_le16(cp->data + data_idx);
-        data_idx += 2;
-        tuples[i].value = ble_hs_mbuf_att_pkt();
-        if (tuples[i].value == NULL) {
-            rc = ENOMEM;
-            goto done;
-        }
-
-        data_len = get_le16(cp->data + data_idx);
-        data_idx += 2;
-
-        os_mbuf_append(tuples[i].value, cp->data + data_idx, data_len);
-        data_idx += data_len;
-    }
-
-    for (i = 0; i < cp->count; i++) {
-        ble_att_svr_write_local(tuples[i].handle, tuples[i].value);
-        cb_data.handles[i] = tuples[i].handle;
-    }
-
-    cb_data.tuple_cnt = cp->count;
-    ble_gap_conn_foreach_handle(notify_multiple, (void *)&cb_data);
-done:
-    if (rc != 0) {
-        return BTP_STATUS_FAILED;
-    }
-
-    return BTP_STATUS_SUCCESS;
-}
-
-static uint8_t
 notify_mult(const void *cmd, uint16_t cmd_len,
             void *rsp, uint16_t *rsp_len)
 {
@@ -2126,11 +2083,6 @@ static const struct btp_handler handlers[] = {
         .opcode = BTP_GATT_GET_ATTRIBUTE_VALUE,
         .expect_len = sizeof(struct btp_gatt_get_attribute_value_cmd),
         .func = get_attr_val,
-    },
-    {
-        .opcode = BTP_GATT_SET_MULT_VALUE,
-        .expect_len = BTP_HANDLER_LENGTH_VARIABLE,
-        .func = set_mult,
     },
     {
         .opcode = BTP_GATT_NOTIFY_MULTIPLE,


### PR DESCRIPTION
Add functionality to utilize BTP notify multiple command.
Previous notify handling via set_mult parses non-existent data.