### PR TITLE
apps: bttester: refactor notifications and indications

### DIFF
--- a/apps/bttester/src/btp_gatt.c
+++ b/apps/bttester/src/btp_gatt.c
@@ -78,13 +78,9 @@
 static uint8_t gatt_svr_pts_static_long_val[300];
 static uint8_t gatt_svr_pts_static_val[30];
 static uint8_t gatt_svr_pts_static_short_val;
-static uint8_t notify_state;
-static uint8_t indicate_state;
 static uint16_t myconn_handle;
-static struct os_callout notify_tx_timer;
 uint16_t notify_handle;
 uint16_t notify_handle_alt;
-uint8_t notify_value = 90;
 
 struct find_attr_data {
     ble_uuid_any_t *uuid;
@@ -2130,54 +2126,6 @@ fail:
     return 0;
 }
 
-void
-notify_test_stop(void)
-{
-    os_callout_stop(&notify_tx_timer);
-}
-
-void
-notify_test_reset(void)
-{
-    int rc;
-
-    rc = os_callout_reset(&notify_tx_timer, OS_TICKS_PER_SEC);
-    assert(rc == 0);
-}
-
-void
-notify_test(struct os_event *ev)
-{
-    static uint8_t ntf[1];
-    struct os_mbuf *om;
-    int rc;
-
-    if (!notify_state && !indicate_state) {
-        notify_test_stop();
-        notify_value = 90;
-        return;
-    }
-
-    ntf[0] = notify_value;
-
-    notify_value++;
-    if (notify_value == 160) {
-        notify_value = 90;
-    }
-
-    om = ble_hs_mbuf_from_flat(ntf, sizeof(ntf));
-
-    if (notify_state) {
-        rc = ble_gatts_notify_custom(myconn_handle, notify_handle, om);
-        assert(rc == 0);
-    }
-
-    if (indicate_state) {
-        rc = ble_gatts_indicate_custom(myconn_handle, notify_handle, om);
-        assert(rc == 0);
-    }
-}
-
 int
 tester_gatt_subscribe_ev(uint16_t conn_handle,
                          uint16_t attr_handle,
@@ -2198,22 +2146,10 @@ tester_gatt_subscribe_ev(uint16_t conn_handle,
 
     if (cur_notify) {
         SYS_LOG_INF("Subscribed to notifications");
-        if (attr_handle == notify_handle) {
-            notify_state = cur_notify;
-        }
     }
 
     if (cur_indicate) {
         SYS_LOG_INF("Subscribed to indications");
-        if (attr_handle == notify_handle) {
-            indicate_state = cur_indicate;
-        }
-    }
-
-    if (notify_state || indicate_state) {
-        notify_test_reset();
-    } else {
-        notify_test_stop();
     }
 
     return 0;
@@ -2291,9 +2227,6 @@ gatt_svr_init(void)
 uint8_t
 tester_init_gatt(void)
 {
-    os_callout_init(&notify_tx_timer, os_eventq_dflt_get(),
-                    notify_test, NULL);
-
     tester_register_command_handlers(BTP_SERVICE_ID_GATT, handlers,
                                      ARRAY_SIZE(handlers));
 

--- a/apps/bttester/src/btp_gatt.c
+++ b/apps/bttester/src/btp_gatt.c
@@ -1928,6 +1928,51 @@ notify_mult(const void *cmd, uint16_t cmd_len,
 }
 
 static uint8_t
+set_val(const void *cmd, uint16_t cmd_len, void *rsp, uint16_t *rsp_len)
+{
+    const struct btp_gatt_set_value_cmd *cp = cmd;
+    struct os_mbuf *om;
+    uint8_t cccd_value;
+    uint16_t handle;
+    int rc = 0;
+
+    SYS_LOG_DBG("");
+
+    if ((cmd_len < sizeof(*cp)) || (cmd_len != sizeof(*cp) + htole16(cp->len))) {
+        return BTP_STATUS_FAILED;
+    }
+
+    handle = cp->attr_id;
+    om = ble_hs_mbuf_from_flat(cp->value, cp->len);
+    if (!om) {
+        return BTP_STATUS_FAILED;
+    }
+
+    ble_att_svr_write_local(handle, om);
+
+    rc = ble_gatts_read_cccd(myconn_handle, handle, &cccd_value);
+
+    if (rc != 0) {
+        return BTP_STATUS_FAILED;
+    }
+
+    /* Indications take precedence over notifications if both are enabled */
+    if (cccd_value & BLE_GATT_CCCD_INDICATE) {
+        /* Handles 0x02 (Indicate) and 0x03 (Notify & Indicate) */
+        rc = ble_gatts_indicate(myconn_handle, handle);
+    } else if (cccd_value & BLE_GATT_CCCD_NOTIFY) {
+        /* Handles 0x01 (Notify only) */
+        rc = ble_gatts_notify(myconn_handle, handle);
+    }
+
+    if (rc != 0) {
+        return BTP_STATUS_FAILED;
+    }
+
+    return BTP_STATUS_SUCCESS;
+}
+
+static uint8_t
 change_database(const void *cmd, uint16_t cmd_len,
                 void *rsp, uint16_t *rsp_len)
 {
@@ -1976,6 +2021,11 @@ static const struct btp_handler handlers[] = {
      .opcode = BTP_GATT_EXCHANGE_MTU,
      .expect_len = sizeof(struct btp_gatt_exchange_mtu_cmd),
      .func = exchange_mtu,
+     },
+    {
+     .opcode = BTP_GATT_SET_VALUE,
+     .expect_len = BTP_HANDLER_LENGTH_VARIABLE,
+     .func = set_val,
      },
     {
      .opcode = BTP_GATT_DISC_ALL_PRIM_SVCS,


### PR DESCRIPTION
 Removes os_callout_init from tester_init_gatt and variables and funcitons related to it. Notifications/indications were sent right after peer has subscribed for notification (or indication). This will be now handled by calling set_value btp command
Note: this can be tested by running GATT/SR/GAN/BV-01-C or GATT/SR/GAI/BV-01-C test case but will require changes from https://github.com/auto-pts/auto-pts/pull/1361 to be merged
