### PR TITLE
nimble/ll: Use RPA from global local IRK on active scan for legacy PDU

### DIFF
--- a/nimble/controller/src/ble_ll_scan.c
+++ b/nimble/controller/src/ble_ll_scan.c
@@ -288,8 +288,12 @@ ble_ll_scan_req_pdu_prepare(struct ble_ll_scan_sm *scansm,
             ble_ll_resolv_get_priv_addr(rl, 1, rpa);
             scana = rpa;
         } else {
-            ble_ll_scan_refresh_nrpa(scansm);
-            scana = scansm->scan_nrpa;
+            if (ble_ll_resolv_local_rpa_get(scansm->own_addr_type & 0x01, rpa) == 0) {
+                scana = rpa;
+            } else {
+                ble_ll_scan_refresh_nrpa(scansm);
+                scana = scansm->scan_nrpa;
+            }
         }
 
         hdr_byte |= BLE_ADV_PDU_HDR_TXADD_RAND;


### PR DESCRIPTION
Local IRK, if set, is used to generate local RPA in use cases where own address type was set to 0x02 or 0x03 but peer address is not added to resolving list.

If no IRK is set (or set to all-zero), the controller uses NRPA.

This is already done for AUX_SCAN_REQ and legacy PDU was accidentally omitted in previous PR.