### PR TITLE
nimble/transport: Fix ISO HCI length parsing

### DIFF
--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -2426,7 +2426,7 @@ struct hci_data_hdr
 #define BLE_HCI_ISO_CONN_HANDLE_MASK        (0x07ff)
 #define BLE_HCI_ISO_PB_FLAG_MASK            (0x3000)
 #define BLE_HCI_ISO_TS_FLAG_MASK            (0x4000)
-#define BLE_HCI_ISO_LENGTH_MASK             (0x7fff)
+#define BLE_HCI_ISO_LENGTH_MASK             (0x3fff)
 #define BLE_HCI_ISO_SDU_LENGTH_MASK         (0x0fff)
 #define BLE_HCI_ISO_PKT_STATUS_FLAG_MASK    (0xC000)
 

--- a/nimble/transport/common/hci_h4/src/hci_h4.c
+++ b/nimble/transport/common/hci_h4/src/hci_h4.c
@@ -177,7 +177,7 @@ hci_h4_sm_w4_header(struct hci_h4_sm *h4sm, struct hci_h4_input_buffer *ib)
         }
 
         os_mbuf_append(h4sm->om, h4sm->hdr, h4sm->len);
-        h4sm->exp_len = (get_le16(&h4sm->hdr[2]) & 0x7fff) + 4;
+        h4sm->exp_len = BLE_HCI_ISO_LENGTH(get_le16(&h4sm->hdr[2])) + 4;
         break;
     default:
         assert(0);

--- a/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
+++ b/nimble/transport/nrf5340/src/nrf5340_ble_hci.c
@@ -23,6 +23,7 @@
 #include <sysinit/sysinit.h>
 #include <nimble/ble.h>
 #include <ipc_nrf5340/ipc_nrf5340.h>
+#include <nimble/hci_common.h>
 #include <nimble/transport.h>
 #include <nimble/transport/hci_ipc.h>
 
@@ -86,7 +87,7 @@ nrf5340_ble_hci_iso_tx(struct os_mbuf *om)
     int rc;
 
     hdr.type = HCI_IPC_TYPE_ISO;
-    hdr.length = 4 + get_le16(&om->om_data[2]);
+    hdr.length = 4 + BLE_HCI_ISO_LENGTH(get_le16(&om->om_data[2]));
 
     rc = ipc_nrf5340_write(IPC_TX_CHANNEL, &hdr, sizeof(hdr), false);
     if (rc == 0) {


### PR DESCRIPTION
Length in ISO HCI packets is 14 bits.