### PR TITLE
nimble/ll: Fix handling HCI ACL data

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -344,6 +344,7 @@ struct ble_ll_conn_sm
     /* Packet transmit queue */
     struct os_mbuf *cur_tx_pdu;
     STAILQ_HEAD(conn_txq_head, os_mbuf_pkthdr) conn_txq;
+    uint8_t conn_txq_num_data_pkt;
     uint8_t conn_txq_num_zero_pkt;
 
     /* List entry for active/free connection pools */

--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -344,6 +344,7 @@ struct ble_ll_conn_sm
     /* Packet transmit queue */
     struct os_mbuf *cur_tx_pdu;
     STAILQ_HEAD(conn_txq_head, os_mbuf_pkthdr) conn_txq;
+    uint8_t conn_txq_num_zero_pkt;
 
     /* List entry for active/free connection pools */
     union {

--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -847,7 +847,7 @@ ble_ll_tx_pkt_in(void)
 
         /* Do some basic error checking */
         pb = handle & 0x3000;
-        if ((pkthdr->omp_len != length) || (pb > 0x1000) || (length == 0)) {
+        if ((pkthdr->omp_len != length) || (pb > 0x1000)) {
             /* This is a bad ACL packet. Count a stat and free it */
             STATS_INC(ble_ll_stats, bad_acl_hdr);
             os_mbuf_free_chain(om);
@@ -1548,7 +1548,7 @@ ble_ll_mbuf_init(struct os_mbuf *m, uint8_t pdulen, uint8_t hdr)
 
     /* Set BLE transmit header */
     ble_hdr = BLE_MBUF_HDR_PTR(m);
-    ble_hdr->txinfo.flags = 0;
+    ble_hdr->txinfo.num_data_pkt = 0;
     ble_hdr->txinfo.offset = 0;
     ble_hdr->txinfo.pyld_len = pdulen;
     ble_hdr->txinfo.hdr_byte = hdr;

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -2034,6 +2034,7 @@ ble_ll_conn_sm_new(struct ble_ll_conn_sm *connsm)
 
     /* Initialize transmit queue and ack/flow control elements */
     STAILQ_INIT(&connsm->conn_txq);
+    connsm->conn_txq_num_data_pkt = 0;
     connsm->conn_txq_num_zero_pkt = 0;
     connsm->cur_tx_pdu = NULL;
     connsm->tx_seqnum = 0;
@@ -4046,6 +4047,7 @@ ble_ll_conn_enqueue_pkt(struct ble_ll_conn_sm *connsm, struct os_mbuf *om,
     } else {
         STAILQ_INSERT_TAIL(&connsm->conn_txq, pkthdr, omp_next);
     }
+    connsm->conn_txq_num_data_pkt += num_pkt;
     OS_EXIT_CRITICAL(sr);
 }
 

--- a/nimble/controller/src/ble_ll_dtm.c
+++ b/nimble/controller/src/ble_ll_dtm.c
@@ -308,7 +308,7 @@ ble_ll_dtm_tx_create_ctx(uint8_t packet_payload, uint8_t len,
 
     /* Set BLE transmit header */
     ble_hdr = BLE_MBUF_HDR_PTR(m);
-    ble_hdr->txinfo.flags = 0;
+    ble_hdr->txinfo.num_data_pkt = 0;
     ble_hdr->txinfo.offset = 0;
     ble_hdr->txinfo.pyld_len = len;
     ble_hdr->txinfo.hdr_byte = packet_payload;

--- a/nimble/include/nimble/ble.h
+++ b/nimble/include/nimble/ble.h
@@ -120,7 +120,7 @@ struct ble_mbuf_hdr_rxinfo
 /* Transmit info. NOTE: no flags defined */
 struct ble_mbuf_hdr_txinfo
 {
-    uint8_t flags;
+    uint8_t num_data_pkt;
     uint8_t hdr_byte;
     uint16_t offset;
     uint16_t pyld_len;


### PR DESCRIPTION
This fixes handling of HCI ACL data in two scenarios:
- receiving zero payload HCI ACL data as a start packet
- sending nocp event with ncp=0 when no HCI data packets are enqueued