### PR TITLE
nimble/ll: Fix supported HCI commands

### DIFF
--- a/nimble/controller/src/ble_ll.c
+++ b/nimble/controller/src/ble_ll.c
@@ -1464,6 +1464,7 @@ ble_ll_read_supp_features(void)
     return g_ble_ll_data.ll_supp_features;
 }
 
+#if BLE_LL_HOST_CONTROLLED_FEATURES
 /**
  * Sets the features controlled by the host.
  *
@@ -1502,6 +1503,8 @@ ble_ll_set_host_feat(const uint8_t *cmdbuf, uint8_t len)
 
     return BLE_ERR_SUCCESS;
 }
+#endif
+
 /**
  * Flush a link layer packet queue.
  *

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -227,6 +227,9 @@ int ble_ll_conn_hci_wr_auth_pyld_tmo(const uint8_t *cmdbuf, uint8_t len,
                                      uint8_t *rspbuf, uint8_t *rsplen);
 int ble_ll_conn_hci_rd_auth_pyld_tmo(const uint8_t *cmdbuf, uint8_t len,
                                      uint8_t *rspbuf, uint8_t *rsplen);
+int ble_ll_conn_hci_cb_read_tx_pwr(const uint8_t *cmdbuf, uint8_t len,
+                                   uint8_t *rspbuf, uint8_t *rsplen);
+
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_SCA_UPDATE)
 int ble_ll_conn_req_peer_sca(const uint8_t *cmdbuf, uint8_t len,
                              uint8_t *rspbuf, uint8_t *rsplen);

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -1301,7 +1301,7 @@ ble_ll_hci_le_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
         }
         break;
 #endif /* BLE_LL_ISO */
-#if MYNEWT_VAL(BLE_VERSION) >= 52
+#if BLE_LL_HOST_CONTROLLED_FEATURES
     case BLE_HCI_OCF_LE_SET_HOST_FEATURE:
         rc = ble_ll_set_host_feat(cmdbuf, len);
         break;

--- a/nimble/controller/src/ble_ll_hci.c
+++ b/nimble/controller/src/ble_ll_hci.c
@@ -1541,6 +1541,11 @@ ble_ll_hci_ctlr_bb_cmd_proc(const uint8_t *cmdbuf, uint8_t len, uint16_t ocf,
             rc = ble_ll_reset();
         }
         break;
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+    case BLE_HCI_OCF_CB_READ_TX_PWR:
+        rc = ble_ll_conn_hci_cb_read_tx_pwr(cmdbuf, len, rspbuf, rsplen);
+        break;
+#endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_CTRL_TO_HOST_FLOW_CONTROL)
     case BLE_HCI_OCF_CB_SET_CTLR_TO_HOST_FC:
         rc = ble_ll_hci_cb_set_ctrlr_to_host_fc(cmdbuf, len);

--- a/nimble/controller/src/ble_ll_hci_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_hci_supp_cmd.c
@@ -45,6 +45,9 @@ static const uint8_t octet_5 = OCTET(
 );
 
 static const uint8_t octet_10 = OCTET(
+#if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+    BIT(2) /* HCI Read Transmit Power Level */
+#endif
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_CTRL_TO_HOST_FLOW_CONTROL)
     BIT(5) /* HCI Set Controller To Host Flow Control */
     BIT(6) /* HCI Host Buffer Size */

--- a/nimble/controller/src/ble_ll_hci_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_hci_supp_cmd.c
@@ -280,7 +280,7 @@ static const uint8_t octet_43 = OCTET(
 );
 
 static const uint8_t octet_44 = OCTET(
-#if MYNEWT_VAL(BLE_VERSION) >= 52
+#if BLE_LL_HOST_CONTROLLED_FEATURES
     BIT(1) /* HCI LE Set Host Feature */
 #endif
 );

--- a/nimble/controller/src/ble_ll_hci_supp_cmd.c
+++ b/nimble/controller/src/ble_ll_hci_supp_cmd.c
@@ -132,6 +132,14 @@ static const uint8_t octet_28 = OCTET(
 #endif
 );
 
+static const uint8_t octet_32 = OCTET(
+#if (MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)) && \
+    MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_PING)
+    BIT(4) /* HCI Read Authenticated Payload Timeout */
+    BIT(5) /* HCI Write Authenticated Payload Timeout */
+#endif
+);
+
 static const uint8_t octet_33 = OCTET(
 #if MYNEWT_VAL(BLE_LL_ROLE_PERIPHERAL) || MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
     BIT(4) /* HCI LE Remote Connection Parameter Request Reply */
@@ -328,7 +336,7 @@ static const uint8_t g_ble_ll_hci_supp_cmds[64] = {
     0,
     0,
     0,
-    0,
+    octet_32,
     octet_33,
     octet_34,
     octet_35,


### PR DESCRIPTION
We don't need to support this command if there are no host-controllable
features present in LL.