### PR TITLE
nimble/ll: Fix sync check in aux

### DIFF
--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -1412,8 +1412,8 @@ ble_ll_scan_aux_sync_check(struct os_mbuf *rxpdu,
     eh_data = &rxbuf[4];
 
     /* Need ADI and SyncInfo */
-    if (!(eh_flags & ((1 << BLE_LL_EXT_ADV_SYNC_INFO_BIT) |
-                      (1 << BLE_LL_EXT_ADV_DATA_INFO_BIT)))) {
+    if (!(eh_flags & (1 << BLE_LL_EXT_ADV_DATA_INFO_BIT)) ||
+        !(eh_flags & (1 << BLE_LL_EXT_ADV_SYNC_INFO_BIT))) {
         return;
     }
 


### PR DESCRIPTION
This fixes condition to check if AUX_ADV_IND has both ADI and SyncInfo before passing it to sync code.

Invalid condition allowed that either ADI *or* SyncInfo is present in whch case the offset to SyncInfo in PDU was calculated incorrectly and the resulting sync sm used random data and thus failed.