### PR TITLE
nimble:host:mesh:src:cfg_cli.c: Fix error In function 'mod_member_list_handle

### DIFF
--- a/nimble/host/mesh/src/cfg_cli.c
+++ b/nimble/host/mesh/src/cfg_cli.c
@@ -465,7 +465,7 @@ static int mod_member_list_handle(struct bt_mesh_msg_ctx *ctx,
 				  struct os_mbuf *buf, bool vnd,
 				  struct mod_member_list_param *param)
 {
-	uint16_t elem_addr, mod_id, cid;
+	uint16_t elem_addr, mod_id, cid = 0;
 	uint8_t status;
 	int i;
 


### PR DESCRIPTION
Assigning a zero value to the variable cid.

```
Error: repos/apache-mynewt-nimble/nimble/host/mesh/src/cfg_cli.c: In function 'mod_member_list_handle':
repos/apache-mynewt-nimble/nimble/host/mesh/src/cfg_cli.c:486:18: error: 'cid' may be used uninitialized [-Werror=maybe-uninitialized]
  486 |             (vnd && param->cid != cid)) {
      |             ~~~~~^~~~~~~~~~~~~~~~~~~~~
repos/apache-mynewt-nimble/nimble/host/mesh/src/cfg_cli.c:468:37: note: 'cid' was declared here
  468 |         uint16_t elem_addr, mod_id, cid;
      |                                     ^~~
cc1: all warnings being treated as errors

Traceback (most recent call last):
  File "C:\Users\jakub\repo\auto-pts\autopts\bot\mynewt.py", line 131, in apply_config
    build_and_flash(args.project_path, board_type, overlay, args.debugger_snr)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\jakub\repo\auto-pts\autopts\ptsprojects\boards\nordic_pca10056.py", line 80, in build_and_flash
    check_call('newt build bttester'.split(), cwd=project_path)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\jakub\repo\auto-pts\autopts\bot\mynewt.py", line 44, in check_call
    return bot.common.check_call(cmd, env, cwd, shell)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\jakub\repo\auto-pts\autopts\bot\common.py", line 931, in check_call
    return subprocess.check_call(cmd, env=env, cwd=cwd, shell=shell, executable=executable)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\jakub\AppData\Local\Programs\Python\Python313\Lib\subprocess.py", line 421, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'wsl.exe --cd /usr/local/dev/mynewt_workspace/my_project_nrf -- /bin/bash -i -c "newt build bttester"' returned non-zero exit status 1.
```
