### PR TITLE
apps: bttester: fix compilation error

### DIFF
--- a/nimble/host/mesh/src/cfg_cli.c
+++ b/nimble/host/mesh/src/cfg_cli.c
@@ -465,7 +465,7 @@ static int mod_member_list_handle(struct bt_mesh_msg_ctx *ctx,
 				  struct os_mbuf *buf, bool vnd,
 				  struct mod_member_list_param *param)
 {
-	uint16_t elem_addr, mod_id, cid;
+	uint16_t elem_addr, mod_id, cid = 0;
 	uint8_t status;
 	int i;
 


### PR DESCRIPTION
Fixes compilation error:
Error: repos/apache-mynewt-nimble/nimble/host/mesh/src/cfg_cli.c: In function 'mod_member_list_handle':
repos/apache-mynewt-nimble/nimble/host/mesh/src/cfg_cli.c:486:18: error: 'cid' may be used uninitialized [-Werror=maybe-uninitialized]
  486 |             (vnd && param->cid != cid)) {
      |             ~~~~~^~~~~~~~~~~~~~~~~~~~~
repos/apache-mynewt-nimble/nimble/host/mesh/src/cfg_cli.c:468:37:
note: 'cid' was declared here
  468 |         uint16_t elem_addr, mod_id, cid;
      |                                     ^~~