### PR TITLE
porting: add missing call to ble_ll_init

### DIFF
--- a/porting/nimble/src/nimble_port.c
+++ b/porting/nimble/src/nimble_port.c
@@ -31,6 +31,9 @@ static struct ble_npl_eventq g_eventq_dflt;
 
 extern void os_msys_init(void);
 extern void os_mempool_module_init(void);
+#if NIMBLE_CFG_CONTROLLER
+extern void ble_ll_init(void);
+#endif
 
 void
 nimble_port_init(void)
@@ -40,6 +43,11 @@ nimble_port_init(void)
     /* Initialize the global memory pool */
     os_mempool_module_init();
     os_msys_init();
+
+#if NIMBLE_CFG_CONTROLLER
+    ble_ll_init();
+#endif
+
     /* Initialize transport */
     ble_transport_init();
     /* Initialize the host */


### PR DESCRIPTION
`nimble_port_init()` needs to call ble_ll_init() when controller is enabled.