### PR TITLE
nimble/ll: Fix ISO BIG events scheduling

### DIFF
--- a/nimble/controller/src/ble_ll_iso_big.c
+++ b/nimble/controller/src/ble_ll_iso_big.c
@@ -611,7 +611,7 @@ ble_ll_iso_big_event_done(struct ble_ll_iso_big *big)
         big_sched_set(big);
 
         /* XXX this should always succeed since we preempt anything for now */
-        rc = ble_ll_sched_iso_big(&big->sch, 0, 0);
+        rc = ble_ll_sched_iso_big(&big->sch, 0, 1);
         assert(rc == 0);
     } while (rc < 0);
 

--- a/nimble/controller/src/ble_ll_iso_big.c
+++ b/nimble/controller/src/ble_ll_iso_big.c
@@ -610,9 +610,9 @@ ble_ll_iso_big_event_done(struct ble_ll_iso_big *big)
         big->anchor_offset++;
         big_sched_set(big);
 
-        /* XXX this should always succeed since we preempt anything for now */
+        /* This should always succeed since we preempt anything for now */
         rc = ble_ll_sched_iso_big(&big->sch, 0, 1);
-        assert(rc == 0);
+        BLE_LL_ASSERT(rc == 0);
     } while (rc < 0);
 
     ble_ll_iso_big_update_event_start(big, big_counter);


### PR DESCRIPTION
ISO events should have 'fixed' flag set for scheduling, except for the 1st one, so they can preempt any other event.