### PR TITLE
host/store: remove unneeded base64/base64.h include

### DIFF
--- a/nimble/host/store/config/src/ble_store_config.c
+++ b/nimble/host/store/config/src/ble_store_config.c
@@ -23,7 +23,6 @@
 #include "sysinit/sysinit.h"
 #include "syscfg/syscfg.h"
 #include "host/ble_hs.h"
-#include "base64/base64.h"
 #include "os/util.h"
 #include "store/config/ble_store_config.h"
 #include "ble_store_config_priv.h"


### PR DESCRIPTION
The include is not needed in ble_store_config.c. It also makes it impossible to compile config store without persistent storage out of mynewt.