### PR TITLE
nimble/eatt: Add manual EATT connection control to BTP tester

### DIFF
--- a/apps/bttester/src/btp/btp_gatt.h
+++ b/apps/bttester/src/btp/btp_gatt.h
@@ -320,6 +320,12 @@ struct btp_gatt_set_mult_val_cmd {
     uint8_t data[0];
 } __packed;
 
+#define BTP_GATT_EATT_CONNECT       0x1f
+struct btp_gatt_eatt_conn_cmd {
+    ble_addr_t address;
+    uint8_t num_channels;
+} __packed;
+
 /* GATT events */
 #define BTP_GATT_EV_NOTIFICATION        0x80
 struct btp_gatt_notification_ev {

--- a/apps/bttester/src/btp_gatt.c
+++ b/apps/bttester/src/btp_gatt.c
@@ -1951,6 +1951,20 @@ done:
 }
 
 static uint8_t
+eatt_conn(const void *cmd, uint16_t cmd_len,
+          void *rsp, uint16_t *rsp_len)
+{
+    uint16_t conn_handle;
+    const struct btp_gatt_eatt_conn_cmd *cp = cmd;
+
+    ble_gap_conn_find_handle_by_addr(&cp->address, &conn_handle);
+
+    ble_eatt_connect(conn_handle, cp->num_channels);
+
+    return BTP_STATUS_SUCCESS;
+}
+
+static uint8_t
 change_database(const void *cmd, uint16_t cmd_len,
                 void *rsp, uint16_t *rsp_len)
 {
@@ -2001,6 +2015,7 @@ supported_commands(const void *cmd, uint16_t cmd_len,
     tester_set_bit(rp->data, BTP_GATT_GET_ATTRIBUTES);
     tester_set_bit(rp->data, BTP_GATT_GET_ATTRIBUTE_VALUE);
     tester_set_bit(rp->data, BTP_GATT_CHANGE_DATABASE);
+    tester_set_bit(rp->data, BTP_GATT_EATT_CONNECT);
 
     *rsp_len = sizeof(*rp) + 4;
 
@@ -2136,6 +2151,11 @@ static const struct btp_handler handlers[] = {
         .opcode = BTP_GATT_SET_MULT_VALUE,
         .expect_len = BTP_HANDLER_LENGTH_VARIABLE,
         .func = set_mult,
+    },
+    {
+        .opcode = BTP_GATT_EATT_CONNECT,
+        .expect_len = sizeof(struct btp_gatt_eatt_conn_cmd),
+        .func = eatt_conn,
     },
 };
 


### PR DESCRIPTION
Added new BTP command `BTP_GATT_EATT_CONNECT` (opcode 0x1f) to trigger
  EATT connections with configurable L2CAP channels.

Implemented handler `eatt_conn()` that:
  * Calls `ble_eatt_connect()` with the requested channel count and proper address

Updated `supported_commands` response to advertise the new capability.

Enables testing scenarios requiring explicit control over EATT establishment and channel management.