### PR TITLE
controller: add missing os/util.h include

### DIFF
--- a/nimble/controller/src/ble_ll_hci_vs.c
+++ b/nimble/controller/src/ble_ll_hci_vs.c
@@ -27,6 +27,7 @@
 #include "controller/ble_ll_scan.h"
 #include "controller/ble_hw.h"
 #include "controller/ble_fem.h"
+#include "os/util.h"
 #include "ble_ll_conn_priv.h"
 #include "ble_ll_priv.h"
 #include "controller/ble_ll_resolv.h"


### PR DESCRIPTION
ble_ll_hci_vs.c module uses ARRAY_SIZE, defined in os/util.h.