### PR TITLE
porting: fix missing include for stdio

### DIFF
--- a/porting/npl/freertos/include/nimble/nimble_npl_os_log.h
+++ b/porting/npl/freertos/include/nimble/nimble_npl_os_log.h
@@ -21,6 +21,7 @@
 #define _NIMBLE_NPL_OS_LOG_H_
 
 #include <stdarg.h>
+#include <stdio.h>
 
 /* Example on how to use macro to generate module logging functions */
 #define BLE_NPL_LOG_IMPL(lvl) \


### PR DESCRIPTION
It is needed for vprinf