### PR TITLE
nimble/host: Add support for Anonymous address type

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -2404,7 +2404,8 @@ ble_gap_wl_tx_add(const ble_addr_t *addr)
 {
     struct ble_hci_le_add_whte_list_cp cmd;
 
-    if (addr->type > BLE_ADDR_RANDOM) {
+    if (addr->type > BLE_ADDR_RANDOM &&
+        addr->type != BLE_ADDR_ANONYMOUS) {
         return BLE_HS_EINVAL;
     }
 
@@ -2459,7 +2460,8 @@ ble_gap_wl_set(const ble_addr_t *addrs, uint8_t white_list_count)
 
     for (i = 0; i < white_list_count; i++) {
         if (addrs[i].type != BLE_ADDR_PUBLIC &&
-            addrs[i].type != BLE_ADDR_RANDOM) {
+            addrs[i].type != BLE_ADDR_RANDOM &&
+            addrs[i].type != BLE_ADDR_ANONYMOUS) {
 
             rc = BLE_HS_EINVAL;
             goto done;

--- a/nimble/include/nimble/ble.h
+++ b/nimble/include/nimble/ble.h
@@ -359,6 +359,12 @@ enum ble_error_codes
  */
 #define BLE_ADDR_RANDOM_ID   (0x03)
 
+/**
+ * Bluetooth Device Address Type: Anonymous
+ * (Corresponds to devices sending anonymous advertisements).
+ */
+#define BLE_ADDR_ANONYMOUS   (0xFF)
+
 /** @} */
 
 /**


### PR DESCRIPTION
Devices can send anonymous address type during advertising.  Added support for this address type which is needed while Adding device to filter accept list

Core spec version 6.0, Vol 4 , Part E, section 7.8.16 lists Anonymous Address type as valid value for LE Add Device to Filter Accept List Command.  Current code doesn't consider this address type. 

![image](https://github.com/user-attachments/assets/3562dcce-e356-4ea2-8326-c53e28bdcf8b)
