### PR TITLE
BTP Periodic Sync Transfer  & Sync established event refactor

### DIFF
--- a/apps/bttester/src/btp/btp_gap.h
+++ b/apps/bttester/src/btp/btp_gap.h
@@ -439,13 +439,8 @@ struct gap_periodic_report_ev {
 
 #define GAP_EV_PERIODIC_TRANSFER_RECEIVED   0x90
 struct gap_periodic_transfer_recieved_ev {
-    uint8_t status;
-    uint16_t sync_handle;
-    uint16_t conn_handle;
-    uint16_t service_data;
-    uint8_t sid;
     ble_addr_t adv_addr;
-    uint8_t adv_phy;
-    uint16_t per_adv_itvl;
-    uint8_t adv_clk_accuracy;
+    uint16_t sync_handle;
+    uint8_t status;
+    ble_addr_t peer_addr;
 } __packed;

--- a/apps/bttester/src/btp_gap.c
+++ b/apps/bttester/src/btp_gap.c
@@ -1293,17 +1293,18 @@ periodic_report(struct ble_gap_event *event)
 static void
 periodic_transfer_received(struct ble_gap_event *event)
 {
+    int rc;
+    struct ble_gap_conn_desc desc;
     struct gap_periodic_transfer_recieved_ev ev;
 
-    ev.status = event->periodic_transfer.status;
-    ev.sync_handle = event->periodic_transfer.sync_handle;
-    ev.conn_handle = event->periodic_transfer.conn_handle;
-    ev.service_data = event->periodic_transfer.service_data;
-    ev.sid = event->periodic_transfer.sid;
     ev.adv_addr = event->periodic_transfer.adv_addr;
-    ev.adv_phy = event->periodic_transfer.adv_phy;
-    ev.per_adv_itvl = event->periodic_transfer.per_adv_itvl;
-    ev.adv_clk_accuracy = event->periodic_transfer.adv_clk_accuracy;
+    ev.sync_handle = event->periodic_transfer.sync_handle;
+    ev.status = event->periodic_transfer.status;
+
+    rc = ble_gap_conn_find(ev.sync_handle, &desc);
+    assert(rc == 0);
+
+    ev.peer_addr = desc.peer_id_addr;
 
     tester_event(BTP_SERVICE_ID_GAP, GAP_EV_PERIODIC_TRANSFER_RECEIVED,
                  (uint8_t *) &ev, sizeof(ev));

--- a/apps/bttester/src/btp_gap.c
+++ b/apps/bttester/src/btp_gap.c
@@ -1249,10 +1249,17 @@ bond_lost(uint16_t conn_handle)
 static void
 sync_established(struct ble_gap_event *event)
 {
+    int rc;
+    struct ble_gap_conn_desc desc;
     struct gap_periodic_sync_est_ev ev;
 
     ev.status = event->periodic_sync.status;
     ev.sync_handle = event->periodic_sync.sync_handle;
+
+    rc = ble_gap_conn_find(ev.sync_handle, &desc);
+    assert(rc == 0);
+
+    ev.peer_addr = desc.peer_id_addr;
 
     tester_event(BTP_SERVICE_ID_GAP, GAP_EV_PERIODIC_SYNC_ESTABLISHED,
                  (uint8_t *) &ev, sizeof(ev));


### PR DESCRIPTION
Get BTP event up to speed with autopts requirements.
Fill missing field in sync established event.