### PR TITLE
apps/bttester: Refactor reporting supported commands

### DIFF
--- a/apps/bttester/src/btp/bttester.h
+++ b/apps/bttester/src/btp/bttester.h
@@ -93,6 +93,9 @@ struct btp_handler {
 void tester_register_command_handlers(uint8_t service,
                                       const struct btp_handler *handlers,
                                       size_t num);
+
+uint16_t tester_supported_commands(uint8_t service, uint8_t *cmds);
+
 void
 tester_send_buf(uint8_t service, uint8_t opcode, uint8_t index,
                 struct os_mbuf *buf);

--- a/apps/bttester/src/btp_bap.c
+++ b/apps/bttester/src/btp_bap.c
@@ -139,18 +139,8 @@ supported_commands(const void *cmd, uint16_t cmd_len,
 {
     struct btp_bap_read_supported_commands_rp *rp = rsp;
 
-    /* octet 0 */
-    tester_set_bit(rp->data, BTP_BAP_READ_SUPPORTED_COMMANDS);
-    tester_set_bit(rp->data, BTP_BAP_BROADCAST_SOURCE_SETUP);
-    tester_set_bit(rp->data, BTP_BAP_BROADCAST_SOURCE_RELEASE);
-    tester_set_bit(rp->data, BTP_BAP_BROADCAST_ADV_START);
-    tester_set_bit(rp->data, BTP_BAP_BROADCAST_ADV_STOP);
-
-    /* octet 1 */
-    tester_set_bit(rp->data, BTP_BAP_BROADCAST_SOURCE_START);
-    tester_set_bit(rp->data, BTP_BAP_BROADCAST_SOURCE_STOP);
-
-    *rsp_len = sizeof(*rp) + 2;
+    *rsp_len = tester_supported_commands(BTP_SERVICE_ID_BAP, rp->data);
+    *rsp_len += sizeof(*rp);
 
     return BTP_STATUS_SUCCESS;
 }

--- a/apps/bttester/src/btp_core.c
+++ b/apps/bttester/src/btp_core.c
@@ -35,12 +35,8 @@ supported_commands(const void *cmd, uint16_t cmd_len,
 {
     struct btp_core_read_supported_commands_rp *rp = rsp;
 
-    tester_set_bit(rp->data, BTP_CORE_READ_SUPPORTED_COMMANDS);
-    tester_set_bit(rp->data, BTP_CORE_READ_SUPPORTED_SERVICES);
-    tester_set_bit(rp->data, BTP_CORE_REGISTER_SERVICE);
-    tester_set_bit(rp->data, BTP_CORE_UNREGISTER_SERVICE);
-
-    *rsp_len = sizeof(*rp) + 1;
+    *rsp_len = tester_supported_commands(BTP_SERVICE_ID_CORE, rp->data);
+    *rsp_len += sizeof(*rp);
 
     return BTP_STATUS_SUCCESS;
 }

--- a/apps/bttester/src/btp_gap.c
+++ b/apps/bttester/src/btp_gap.c
@@ -128,55 +128,8 @@ supported_commands(const void *cmd, uint16_t cmd_len,
 {
     struct btp_gap_read_supported_commands_rp *rp = rsp;
 
-    /* octet 0 */
-    tester_set_bit(rp->data, BTP_GAP_READ_SUPPORTED_COMMANDS);
-    tester_set_bit(rp->data, BTP_GAP_READ_CONTROLLER_INDEX_LIST);
-    tester_set_bit(rp->data, BTP_GAP_READ_CONTROLLER_INFO);
-    tester_set_bit(rp->data, BTP_GAP_SET_CONNECTABLE);
-
-    /* octet 1 */
-    tester_set_bit(rp->data, BTP_GAP_SET_DISCOVERABLE);
-    tester_set_bit(rp->data, BTP_GAP_SET_BONDABLE);
-    tester_set_bit(rp->data, BTP_GAP_START_ADVERTISING);
-    tester_set_bit(rp->data, BTP_GAP_STOP_ADVERTISING);
-    tester_set_bit(rp->data, BTP_GAP_START_DISCOVERY);
-    tester_set_bit(rp->data, BTP_GAP_STOP_DISCOVERY);
-    tester_set_bit(rp->data, BTP_GAP_CONNECT);
-    tester_set_bit(rp->data, BTP_GAP_DISCONNECT);
-
-    /* octet 2 */
-    tester_set_bit(rp->data, BTP_GAP_SET_IO_CAP);
-    tester_set_bit(rp->data, BTP_GAP_PAIR);
-    tester_set_bit(rp->data, BTP_GAP_UNPAIR);
-    tester_set_bit(rp->data, BTP_GAP_PASSKEY_ENTRY);
-    tester_set_bit(rp->data, BTP_GAP_PASSKEY_CONFIRM);
-    tester_set_bit(rp->data, BTP_GAP_START_DIRECT_ADV);
-    tester_set_bit(rp->data, BTP_GAP_CONN_PARAM_UPDATE);
-
-    /* octet 3 */
-    tester_set_bit(rp->data, BTP_GAP_OOB_LEGACY_SET_DATA);
-    tester_set_bit(rp->data, BTP_GAP_OOB_SC_GET_LOCAL_DATA);
-    tester_set_bit(rp->data, BTP_GAP_OOB_SC_SET_REMOTE_DATA);
-    tester_set_bit(rp->data, BTP_GAP_SET_MITM);
-    tester_set_bit(rp->data, BTP_GAP_SET_FILTER_ACCEPT_LIST);
-
-    /* octet 4 */
-#if MYNEWT_VAL(BLE_PERIODIC_ADV)
-    tester_set_bit(rp->data, GAP_SET_EXT_ADV);
-    tester_set_bit(rp->data, GAP_PADV_CONFIGURE);
-    tester_set_bit(rp->data, GAP_PADV_START);
-    tester_set_bit(rp->data, GAP_PADV_SET_DATA);
-    tester_set_bit(rp->data, GAP_PADV_CREATE_SYNC);
-#endif
-#if MYNEWT_VAL(BLE_PERIODIC_ADV_SYNC_TRANSFER)
-    tester_set_bit(rp->data, GAP_PADV_SYNC_TRANSFER_SET_INFO);
-    tester_set_bit(rp->data, GAP_PADV_SYNC_TRANSFER_START);
-    tester_set_bit(rp->data, GAP_PADV_SYNC_TRANSFER_START);
-#endif
-
-    *rsp_len = sizeof(*rp) + 4 +
-               (MYNEWT_VAL(BLE_PERIODIC_ADV) ||
-                MYNEWT_VAL(BLE_PERIODIC_ADV_SYNC_TRANSFER) ? 1 : 0);
+    *rsp_len = tester_supported_commands(BTP_SERVICE_ID_GAP, rp->data);
+    *rsp_len += sizeof(*rp);
 
     return BTP_STATUS_SUCCESS;
 }

--- a/apps/bttester/src/btp_gatt.c
+++ b/apps/bttester/src/btp_gatt.c
@@ -1960,38 +1960,8 @@ supported_commands(const void *cmd, uint16_t cmd_len,
 {
     struct btp_gatt_read_supported_commands_rp *rp = rsp;
 
-    /* octet 0 */
-    tester_set_bit(rp->data, BTP_GATT_READ_SUPPORTED_COMMANDS);
-    tester_set_bit(rp->data, BTP_GATT_START_SERVER);
-
-    /* octet 1 */
-    tester_set_bit(rp->data, BTP_GATT_EXCHANGE_MTU);
-    tester_set_bit(rp->data, BTP_GATT_DISC_ALL_PRIM_SVCS);
-    tester_set_bit(rp->data, BTP_GATT_DISC_PRIM_UUID);
-    tester_set_bit(rp->data, BTP_GATT_FIND_INCLUDED);
-    tester_set_bit(rp->data, BTP_GATT_DISC_ALL_CHRC);
-    tester_set_bit(rp->data, BTP_GATT_DISC_CHRC_UUID);
-
-    /* octet 2 */
-    tester_set_bit(rp->data, BTP_GATT_DISC_ALL_DESC);
-    tester_set_bit(rp->data, BTP_GATT_READ);
-    tester_set_bit(rp->data, BTP_GATT_READ_LONG);
-    tester_set_bit(rp->data, BTP_GATT_READ_MULTIPLE);
-    tester_set_bit(rp->data, BTP_GATT_WRITE_WITHOUT_RSP);
-#if 0
-    tester_set_bit(rp->data, BTP_GATT_SIGNED_WRITE_WITHOUT_RSP);
-#endif
-    tester_set_bit(rp->data, BTP_GATT_WRITE);
-
-    /* octet 3 */
-    tester_set_bit(rp->data, BTP_GATT_WRITE_LONG);
-    tester_set_bit(rp->data, BTP_GATT_CFG_NOTIFY);
-    tester_set_bit(rp->data, BTP_GATT_CFG_INDICATE);
-    tester_set_bit(rp->data, BTP_GATT_GET_ATTRIBUTES);
-    tester_set_bit(rp->data, BTP_GATT_GET_ATTRIBUTE_VALUE);
-    tester_set_bit(rp->data, BTP_GATT_CHANGE_DATABASE);
-
-    *rsp_len = sizeof(*rp) + 4;
+    *rsp_len = tester_supported_commands(BTP_SERVICE_ID_GATT, rp->data);
+    *rsp_len += sizeof(*rp);
 
     return BTP_STATUS_SUCCESS;
 }

--- a/apps/bttester/src/btp_gatt_cl.c
+++ b/apps/bttester/src/btp_gatt_cl.c
@@ -1491,35 +1491,8 @@ supported_commands(const void *cmd, uint16_t cmd_len,
 {
     struct btp_gattc_read_supported_commands_rp *rp = rsp;
 
-    SYS_LOG_DBG("");
-
-    /* octet 0 */
-    tester_set_bit(rp->data, BTP_GATTC_READ_SUPPORTED_COMMANDS);
-    tester_set_bit(rp->data, BTP_GATTC_EXCHANGE_MTU);
-    tester_set_bit(rp->data, BTP_GATTC_DISC_ALL_PRIM_SVCS);
-    tester_set_bit(rp->data, BTP_GATTC_DISC_PRIM_UUID);
-    tester_set_bit(rp->data, BTP_GATTC_FIND_INCLUDED);
-    tester_set_bit(rp->data, BTP_GATTC_DISC_ALL_CHRC);
-    tester_set_bit(rp->data, BTP_GATTC_DISC_CHRC_UUID);
-    /* octet 1 */
-    tester_set_bit(rp->data, BTP_GATTC_DISC_ALL_DESC);
-    tester_set_bit(rp->data, BTP_GATTC_READ);
-    tester_set_bit(rp->data, BTP_GATTC_READ_UUID);
-    tester_set_bit(rp->data, BTP_GATTC_READ_LONG);
-    tester_set_bit(rp->data, BTP_GATTC_READ_MULTIPLE);
-    tester_set_bit(rp->data, BTP_GATTC_WRITE_WITHOUT_RSP);
-#if 0
-    tester_set_bit(rp->data, BTP_GATTC_SIGNED_WRITE_WITHOUT_RSP);
-#endif
-    tester_set_bit(rp->data, BTP_GATTC_WRITE);
-    /* octet 2 */
-    tester_set_bit(rp->data, BTP_GATTC_WRITE_LONG);
-    tester_set_bit(rp->data, BTP_GATTC_RELIABLE_WRITE);
-    tester_set_bit(rp->data, BTP_GATTC_CFG_NOTIFY);
-    tester_set_bit(rp->data, BTP_GATTC_CFG_INDICATE);
-    tester_set_bit(rp->data, BTP_GATTC_READ_MULTIPLE_VAR);
-
-    *rsp_len = sizeof(*rp) + 3;
+    *rsp_len = tester_supported_commands(BTP_SERVICE_ID_GATTC, rp->data);
+    *rsp_len += sizeof(*rp);
 
     return BTP_STATUS_SUCCESS;
 }

--- a/apps/bttester/src/btp_l2cap.c
+++ b/apps/bttester/src/btp_l2cap.c
@@ -678,15 +678,8 @@ supported_commands(const void *cmd, uint16_t cmd_len,
 {
     struct btp_l2cap_read_supported_commands_rp *rp = rsp;
 
-    /* octet 0 */
-    tester_set_bit(rp->data, BTP_L2CAP_READ_SUPPORTED_COMMANDS);
-    tester_set_bit(rp->data, BTP_L2CAP_CONNECT);
-    tester_set_bit(rp->data, BTP_L2CAP_DISCONNECT);
-    tester_set_bit(rp->data, BTP_L2CAP_SEND_DATA);
-    tester_set_bit(rp->data, BTP_L2CAP_LISTEN);
-    /* octet 1 */
-    tester_set_bit(rp->data, BTP_L2CAP_CREDITS);
-    *rsp_len = sizeof(*rp) + 2;
+    *rsp_len = tester_supported_commands(BTP_SERVICE_ID_L2CAP, rp->data);
+    *rsp_len += sizeof(*rp);
 
     return BTP_STATUS_SUCCESS;
 }

--- a/apps/bttester/src/btp_mesh.c
+++ b/apps/bttester/src/btp_mesh.c
@@ -94,32 +94,8 @@ supported_commands(const void *cmd, uint16_t cmd_len,
 {
     struct btp_mesh_read_supported_commands_rp *rp = rsp;
 
-    /* octet 0 */
-    tester_set_bit(rp->data, BTP_MESH_READ_SUPPORTED_COMMANDS);
-    tester_set_bit(rp->data, BTP_MESH_CONFIG_PROVISIONING);
-    tester_set_bit(rp->data, BTP_MESH_PROVISION_NODE);
-    tester_set_bit(rp->data, BTP_MESH_INIT);
-    tester_set_bit(rp->data, BTP_MESH_RESET);
-    tester_set_bit(rp->data, BTP_MESH_INPUT_NUMBER);
-    tester_set_bit(rp->data, BTP_MESH_INPUT_STRING);
-    /* octet 1 */
-    tester_set_bit(rp->data, BTP_MESH_IVU_TEST_MODE);
-    tester_set_bit(rp->data, BTP_MESH_IVU_TOGGLE_STATE);
-    tester_set_bit(rp->data, BTP_MESH_NET_SEND);
-    tester_set_bit(rp->data, BTP_MESH_HEALTH_GENERATE_FAULTS);
-    tester_set_bit(rp->data, BTP_MESH_HEALTH_CLEAR_FAULTS);
-    tester_set_bit(rp->data, BTP_MESH_LPN);
-    tester_set_bit(rp->data, BTP_MESH_LPN_POLL);
-    tester_set_bit(rp->data, BTP_MESH_MODEL_SEND);
-    /* octet 2 */
-#if MYNEWT_VAL(BLE_MESH_TESTING)
-    tester_set_bit(rp->data, BTP_MESH_LPN_SUBSCRIBE);
-    tester_set_bit(rp->data, BTP_MESH_LPN_UNSUBSCRIBE);
-    tester_set_bit(rp->data, BTP_MESH_RPL_CLEAR);
-#endif /* CONFIG_BT_TESTING */
-    tester_set_bit(rp->data, BTP_MESH_PROXY_IDENTITY);
-
-    *rsp_len = sizeof(*rp) + 3;
+    *rsp_len = tester_supported_commands(BTP_SERVICE_ID_GAP, rp->data);
+    *rsp_len += sizeof(*rp);
 
     return BTP_STATUS_SUCCESS;
 }

--- a/apps/bttester/src/btp_pacs.c
+++ b/apps/bttester/src/btp_pacs.c
@@ -266,13 +266,8 @@ supported_commands(const void *cmd, uint16_t cmd_len,
 {
     struct btp_pacs_read_supported_commands_rp *rp = rsp;
 
-    /* octet 0 */
-    tester_set_bit(rp->data, BTP_PACS_READ_SUPPORTED_COMMANDS);
-    tester_set_bit(rp->data, BTP_PACS_UPDATE_CHARACTERISTIC);
-    tester_set_bit(rp->data, BTP_PACS_SET_AVAILABLE_CONTEXTS);
-    tester_set_bit(rp->data, BTP_PACS_SET_SUPPORTED_CONTEXTS);
-
-    *rsp_len = sizeof(*rp) + 1;
+    *rsp_len = tester_supported_commands(BTP_SERVICE_ID_PACS, rp->data);
+    *rsp_len += sizeof(*rp);
 
     return BTP_STATUS_SUCCESS;
 }

--- a/apps/bttester/src/bttester.c
+++ b/apps/bttester/src/bttester.c
@@ -377,3 +377,22 @@ tester_rsp(uint8_t service, uint8_t opcode, uint8_t status)
     os_eventq_put(&avail_queue,
                   CONTAINER_OF(cmd, struct btp_buf, data)->ev);
 }
+
+uint16_t
+tester_supported_commands(uint8_t service, uint8_t *cmds)
+{
+    uint8_t opcode_max = 0;
+
+    assert(service <= BTP_SERVICE_ID_MAX);
+
+    for (size_t i = 0; i < service_handler[service].num; i++) {
+        const struct btp_handler *handler = &service_handler[service].handlers[i];
+        tester_set_bit(cmds, handler->opcode);
+
+        if (handler->opcode > opcode_max) {
+            opcode_max = handler->opcode;
+        }
+    }
+
+    return (opcode_max / 8) + 1;
+}


### PR DESCRIPTION
Implement new way for reporting supported commands. Now only commands with registered handler will
be present in the queried response.