### PR TITLE
nimble/host: Enable address resolution if IRK is the same

### DIFF
--- a/nimble/host/src/ble_hs_pvcy.c
+++ b/nimble/host/src/ble_hs_pvcy.c
@@ -230,6 +230,12 @@ ble_hs_pvcy_set_our_irk(const uint8_t *irk)
         if (rc != 0) {
             return rc;
         }
+    } else {
+        /* Enable the address resolution if this is same IRK. */
+        rc = ble_hs_pvcy_set_resolve_enabled(1);
+        if (rc != 0) {
+            return rc;
+        }
     }
 
     return 0;


### PR DESCRIPTION
Address resolution should be enabled in case of setting same IRK.
It should not be assumed it is still enabled from last IRK set as host can disable it with command or send HCI reset to controller (for example with host stop/start) which disabled it.
Otherwise a central peer with RPA will fail to connect.