### PR TITLE
Trivial unit tests fixes

### DIFF
--- a/nimble/host/test/src/ble_att_svr_test.c
+++ b/nimble/host/test/src/ble_att_svr_test.c
@@ -1026,7 +1026,7 @@ TEST_CASE_SELF(ble_att_svr_test_read_mult)
     attrs[1].value_len = 20;
     memcpy(attrs[1].value,
            ((uint8_t[]){
-                22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39
+                20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39
            }),
            attrs[1].value_len);
     ble_att_svr_test_attr_r_2_len = attrs[1].value_len;

--- a/nimble/host/test/src/ble_gatts_notify_test.c
+++ b/nimble/host/test/src/ble_gatts_notify_test.c
@@ -474,9 +474,9 @@ static void
 ble_gatts_notify_test_misc_verify_tx_gen(uint16_t conn_handle, int attr_idx,
                                          uint8_t chr_flags)
 {
-    uint16_t attr_handle;
-    uint16_t attr_len;
-    void *attr_val;
+    uint16_t attr_handle = 0;
+    uint16_t attr_len = 0;
+    void *attr_val = NULL;
 
     switch (attr_idx) {
     case 1:

--- a/nimble/host/test/src/ble_gatts_reg_test.c
+++ b/nimble/host/test/src/ble_gatts_reg_test.c
@@ -261,7 +261,7 @@ ble_gatts_reg_test_misc_lookup_bad(struct ble_gatts_reg_test_entry *entry)
 static void
 ble_gatts_reg_test_misc_verify_entry(uint8_t op, const ble_uuid_t *uuid)
 {
-    struct ble_gatts_reg_test_entry *entry;
+    struct ble_gatts_reg_test_entry *entry = NULL;
     int i;
 
     for (i = 0; i < ble_gatts_reg_test_num_entries; i++) {


### PR DESCRIPTION
This fixes:
- one obvious error where memcpy touches unspecified memory
- second is not really a bug buf false positive warning about uninitialized variables. Since it it only unit test there is no harm in initializing local variable to silence compiler

