### PR TITLE
host: reset random address when starting

### DIFF
--- a/nimble/host/src/ble_hs_startup.c
+++ b/nimble/host/src/ble_hs_startup.c
@@ -22,6 +22,7 @@
 #include "host/ble_hs.h"
 #include "host/ble_hs_hci.h"
 #include "ble_hs_priv.h"
+#include "ble_hs_id_priv.h"
 
 #if !MYNEWT_VAL(BLE_CONTROLLER)
 static int
@@ -407,6 +408,8 @@ ble_hs_startup_go(void)
     if (rc != 0) {
         return rc;
     }
+
+    ble_hs_id_rnd_reset();
 
     rc = ble_hs_startup_read_local_ver_tx();
     if (rc != 0) {


### PR DESCRIPTION
I have observed that, when stopping the host and scheduling a new start, advertising fails (with error 530). This is because the static variable `ble_hs_id_rnd` is never reset, but, at least in case of nRF52, the LL random address is reset in ble_ll_reset(), which gets called when host starts up via ble_hs_startup_reset_tx().

I'm not sure the solution is strictly correct for all cases/controllers. `ble_hs_id_pub` is never reset either, so maybe a more generic solution is needed.