### PR TITLE
Exclude btshell cmd.c from clang formatting

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -51,6 +51,8 @@
 
 #define BTSHELL_MODULE "btshell"
 
+// clang-format off
+
 int
 cmd_parse_conn_start_end(uint16_t *out_conn, uint16_t *out_start,
                          uint16_t *out_end)
@@ -5067,6 +5069,7 @@ static const struct shell_cmd btshell_commands[] = {
     { 0 },
 };
 
+// clang-format on
 
 void
 cmd_init(void)


### PR DESCRIPTION
Formatting this file will result in extensive and non-necessary changes that make review and history tracking difficult.
To preserve clarity and minimize noise, this file is now excluded from clang-format.