### PR TITLE
nimble/ll: Avoid dereferencing an invalid pointer

### DIFF
--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -1341,7 +1341,8 @@ conn_tx_pdu:
         (CONN_IS_PERIPHERAL(connsm) && (md == 0) &&
          (connsm->cons_rxd_bad_crc == 0) &&
          ((connsm->last_rxd_hdr_byte & BLE_LL_DATA_HDR_MD_MASK) == 0) &&
-         !ble_ll_ctrl_is_terminate_ind(hdr_byte, m->om_data[0]))) {
+         ((connsm->flags.empty_pdu_txd) ||
+          !ble_ll_ctrl_is_terminate_ind(hdr_byte, m->om_data[0])))) {
         /* We will end the connection event */
         end_transition = BLE_PHY_TRANSITION_NONE;
         txend_func = ble_ll_conn_wait_txend;


### PR DESCRIPTION
In [ble_ll_conn.c](https://github.com/apache/mynewt-nimble/blob/master/nimble/controller/src/ble_ll_conn.c#L1294), the data pointer in the mbuf of outgoing empty packets is set to an invalid value (pointing right after `struct ble_ll_empty_pdu` on the stack). The invalid pointer is then dereferenced to check if the outgoing packet is a terminate_ind:

```c
conn_tx_pdu:
    if (connsm->flags.empty_pdu_txd) {
        /*
         * This looks strange, but we dont use the data pointer in the mbuf
         * when we have an empty pdu.
         */
        m = (struct os_mbuf *)&empty_pdu;
        m->om_data = (uint8_t *)&empty_pdu;
        m->om_data += BLE_MBUF_MEMBLOCK_OVERHEAD;
        ble_hdr = &empty_pdu.ble_hdr;
        ble_hdr->txinfo.num_data_pkt = 0;
        ble_hdr->txinfo.offset = 0;
        ble_hdr->txinfo.pyld_len = 0;
    }

//...

    if ((connsm->flags.terminate_ind_rxd) ||
        (CONN_IS_PERIPHERAL(connsm) && (md == 0) &&
         (connsm->cons_rxd_bad_crc == 0) &&
         ((connsm->last_rxd_hdr_byte & BLE_LL_DATA_HDR_MD_MASK) == 0) &&
         !ble_ll_ctrl_is_terminate_ind(hdr_byte, m->om_data[0]))) {
        /* We will end the connection event */
        end_transition = BLE_PHY_TRANSITION_NONE;
        txend_func = ble_ll_conn_wait_txend;
    }
```

This PR adds a simple check to avoid dereferencing the pointer when an empty packet is sent.