### PR TITLE
Skip style-check workflow if label is present

### DIFF
--- a/.github/workflows/compliance_check.yml
+++ b/.github/workflows/compliance_check.yml
@@ -19,7 +19,9 @@
 
 name: Compliance check
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   style_check:
@@ -33,7 +35,23 @@ jobs:
         shell: bash
         run: |
              python -m pip install clang-format
+
+      - name: Check label
+        id: label_check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labelName = 'skip-style-check';
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const hasLabel = labels.data.some(label => label.name === labelName);
+            core.setOutput('skip', hasLabel);
+
       - name: check style
+        if: steps.label_check.outputs.skip != 'true'
         shell: bash
         run: |
           set +e


### PR DESCRIPTION
This update adds a label-based conditional to the compliance_check.yml GitHub Actions workflow. If a pull request includes the label `skip-style-check`, the style check step will be skipped.

This allows maintainers to bypass formatting validation in exceptional cases, such as bulk updates or style-irrelevant changes.