### PR TITLE
Format file check - disable exit on failure in workflow shell

### DIFF
--- a/.github/workflows/format_file_check.yml
+++ b/.github/workflows/format_file_check.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Check for changes & replace
         id: changed
         run: |
+          set +e
           if ! cmp -s ".clang-format-core" ".clang-format"; then
             echo "🔄 .clang-format has changed, updating..."
             diff -u .clang-format .clang-format-core


### PR DESCRIPTION
Add `set +e` to the format_file_check.yml
to allow non-critical commands (e.g., git diff)  to fail gracefully.
This prevents early termination and enables
custom handling of command exit codes when needed.