### PR TITLE
drivers/nrf5x/phy: use nrf52_clock_hfxo_request|release if PEBBLEOS

### DIFF
--- a/nimble/drivers/nrf5x/src/ble_phy.c
+++ b/nimble/drivers/nrf5x/src/ble_phy.c
@@ -2319,7 +2319,7 @@ ble_phy_dtm_carrier(uint8_t rf_channel)
 void
 ble_phy_rfclk_enable(void)
 {
-#if MYNEWT || defined(RIOT_VERSION)
+#if MYNEWT || defined(RIOT_VERSION) || defined(PEBBLEOS)
 #ifdef NRF52_SERIES
     nrf52_clock_hfxo_request();
 #endif
@@ -2334,7 +2334,7 @@ ble_phy_rfclk_enable(void)
 void
 ble_phy_rfclk_disable(void)
 {
-#if MYNEWT || defined(RIOT_VERSION)
+#if MYNEWT || defined(RIOT_VERSION) || defined(PEBBLEOS)
 #ifdef NRF52_SERIES
     nrf52_clock_hfxo_release();
 #endif


### PR DESCRIPTION
On PebbleOS we need reference counted access to HFXO because other parts of the system rely on it (I2S). It seems like this needs a more generic solution (maybe a porting layer function?), as on a sufficiently complex system this will likely be needed. For now adding PEBBLEOS define check, similar to what was done for RIOT.