### PR TITLE
controller: Add subrating condition in syscfg

### DIFF
--- a/nimble/controller/syscfg.yml
+++ b/nimble/controller/syscfg.yml
@@ -353,7 +353,7 @@ syscfg.defs:
             Enables support LE Enhanced Connection Update.
             This allows to use Conenction Subrate Update and Connection Subrate
             Request procedures to modify subrate paramters for a connection.
-        value: 0
+        value: MYNEWT_VAL(BLE_CONN_SUBRATING)
         restrictions:
             - '(BLE_VERSION >= 53) if 1'
 


### PR DESCRIPTION
Add condition for enabling subrating for controller based on value set in host configuration.