### PR TITLE
nimble/btp: Implement missing BAP layer commands & events

### DIFF
--- a/apps/bttester/src/btp/btp_bap.h
+++ b/apps/bttester/src/btp/btp_bap.h
@@ -29,7 +29,7 @@
 
 /* BAP Service */
 /* commands */
-#define BTP_BAP_READ_SUPPORTED_COMMANDS         0x01
+#define BTP_BAP_READ_SUPPORTED_COMMANDS 0x01
 struct btp_bap_read_supported_commands_rp {
     uint8_t data[0];
 } __packed;
@@ -58,70 +58,244 @@ struct bap_broadcast_source_setup_rp {
     uint8_t broadcast_id[3];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SOURCE_RELEASE        0x05
+#define BTP_BAP_BROADCAST_SOURCE_RELEASE 0x05
 struct bap_bap_broadcast_source_release_cmd {
     uint8_t broadcast_id[3];
 } __packed;
 
-#define BTP_BAP_BROADCAST_ADV_START             0x06
+#define BTP_BAP_BROADCAST_ADV_START 0x06
 struct bap_bap_broadcast_adv_start_cmd {
     uint8_t broadcast_id[3];
 } __packed;
 
-#define BTP_BAP_BROADCAST_ADV_STOP              0x07
+#define BTP_BAP_BROADCAST_ADV_STOP 0x07
 struct bap_bap_broadcast_adv_stop_cmd {
     uint8_t broadcast_id[3];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SOURCE_START          0x08
+#define BTP_BAP_BROADCAST_SOURCE_START 0x08
 struct bap_bap_broadcast_source_start_cmd {
     uint8_t broadcast_id[3];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SOURCE_STOP           0x09
+#define BTP_BAP_BROADCAST_SOURCE_STOP 0x09
 struct bap_bap_broadcast_source_stop_cmd {
     uint8_t broadcast_id[3];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SINK_SETUP            0x0a
+#define BTP_BAP_BROADCAST_SINK_SETUP 0x0a
+struct btp_bap_broadcast_sink_setup_cmd {
+} __packed;
 
-#define BTP_BAP_BROADCAST_SINK_STOP             0x0f
+#define BTP_BAP_BROADCAST_SINK_RELEASE 0x0b
+struct btp_bap_broadcast_sink_release_cmd {
+} __packed;
+
+#define BTP_BAP_BROADCAST_SCAN_START 0x0c
+struct btp_bap_broadcast_scan_start_cmd {
+} __packed;
+
+#define BTP_BAP_BROADCAST_SCAN_STOP 0x0d
+struct btp_bap_broadcast_scan_stop_cmd {
+} __packed;
+
+#define BTP_BAP_BROADCAST_SINK_SYNC 0x0e
+struct btp_bap_broadcast_sink_sync_cmd {
+    ble_addr_t addr;
+    uint8_t broadcast_id[3];
+    uint8_t advertiser_sid;
+    uint16_t skip;
+    uint16_t sync_timeout;
+    uint8_t past_avail;
+    uint8_t src_id;
+} __packed;
+
+#define BTP_BAP_BROADCAST_SINK_STOP 0x0f
 struct btp_bap_broadcast_sink_stop_cmd {
     ble_addr_t address;
     uint8_t broadcast_id[3];
 } __packed;
 
-#define BTP_BAP_SET_BROADCAST_CODE              0x17
+#define BTP_BAP_BROADCAST_SINK_BIS_SYNC 0x10
+struct btp_bap_broadcast_sink_bis_sync_cmd {
+    ble_addr_t address;
+    uint8_t broadcast_id[3];
+    uint32_t requested_bis_sync;
+} __packed;
+
+#define BTP_BAP_DISCOVER_SCAN_DELEGATOR 0x11
+struct btp_bap_discover_scan_delegator_cmd {
+    ble_addr_t address;
+} __packed;
+
+#define BTP_BAP_BROADCAST_ASSISTANT_SCAN_START 0x12
+struct btp_bap_broadcast_assistant_scan_start_cmd {
+    ble_addr_t address;
+} __packed;
+
+#define BTP_BAP_BROADCAST_ASSISTANT_SCAN_STOP 0x13
+struct btp_bap_broadcast_assistant_scan_stop_cmd {
+    ble_addr_t address;
+} __packed;
+
+#define BTP_BAP_ADD_BROADCAST_SRC 0x14
+struct btp_bap_add_broadcast_src_cmd {
+    ble_addr_t address;
+    ble_addr_t broadcaster_address;
+    uint8_t advertiser_sid;
+    uint8_t broadcast_id[3];
+    uint8_t padv_sync;
+    uint16_t padv_interval;
+    uint8_t num_subgroups;
+    uint8_t subgroups[0];
+} __packed;
+
+#define BTP_BAP_REMOVE_BROADCAST_SRC 0x15
+struct btp_bap_remove_broadcast_src_cmd {
+    ble_addr_t address;
+    uint8_t source_id;
+} __packed;
+
+#define BTP_BAP_MODIFY_BROADCAST_SRC 0x16
+struct btp_bap_modify_broadcast_src_cmd {
+    ble_addr_t address;
+    uint8_t source_id;
+    uint8_t padv_sync;
+    uint16_t padv_interval;
+    uint8_t num_subgroups;
+    uint8_t subgroups[0];
+} __packed;
+
+#define BTP_BAP_SET_BROADCAST_CODE 0x17
 struct btp_bap_set_broadcast_code_cmd {
     ble_addr_t addr;
     uint8_t source_id;
     uint8_t broadcast_code[16];
 } __packed;
 
-#define BTP_BAP_BROADCAST_SINK_RELEASE          0x0b
-#define BTP_BAP_BROADCAST_SCAN_START            0x0c
-#define BTP_BAP_BROADCAST_SCAN_STOP             0x0d
-#define BTP_BAP_BROADCAST_SINK_SYNC             0x0e
-#define BTP_BAP_BROADCAST_SINK_BIS_SYNC         0x10
-#define BTP_BAP_DISCOVER_SCAN_DELEGATOR         0x11
-#define BTP_BAP_BROADCAST_ASSISTANT_SCAN_START  0x12
-#define BTP_BAP_BROADCAST_ASSISTANT_SCAN_STOP   0x13
-#define BTP_BAP_ADD_BROADCAST_SRC               0x14
-#define BTP_BAP_REMOVE_BROADCAST_SRC            0x15
-#define BTP_BAP_MODIFY_BROADCAST_SRC            0x16
-#define BTP_BAP_SET_BROADCAST_CODE              0x17
-#define BTP_BAP_SEND_PAST                       0x18
+#define BTP_BAP_SEND_PAST 0x18
+struct btp_bap_send_past_cmd {
+    ble_addr_t address;
+    uint8_t src_id;
+} __packed;
 
-#define BTP_BAP_EV_DISCOVERY_COMPLETED          0x80
-#define BTP_BAP_EV_CODEC_CAP_FOUND              0x81
-#define BTP_BAP_EV_ASE_FOUND                    0x82
-#define BTP_BAP_EV_STREAM_RECEIVED              0x83
-#define BTP_BAP_EV_BAA_FOUND                    0x84
-#define BTP_BAP_EV_BIS_FOUND                    0x85
-#define BTP_BAP_EV_BIS_SYNCED                   0x86
-#define BTP_BAP_EV_BIS_STREAM_RECEIVED          0x87
-#define BTP_BAP_EV_SCAN_DELEGATOR_FOUND         0x88
-#define BTP_BAP_EV_BROADCAST_RECEIVE_STATE      0x89
-#define BTP_BAP_EV_PA_SYNC_REQ                  0x8a
+#define BTP_BAP_BROADCAST_SOURCE_SETUP_V2 0x19
+struct btp_bap_broadcast_source_setup_v2_cmd {
+    uint8_t broadcast_id[3];
+    uint8_t streams_per_subgroup;
+    uint8_t subgroups;
+    uint8_t sdu_interval[3];
+    uint8_t framing;
+    uint16_t max_sdu;
+    uint8_t retransmission_num;
+    uint16_t max_transport_latency;
+    uint8_t presentation_delay[3];
+    uint8_t coding_format;
+    uint16_t vid;
+    uint16_t cid;
+    uint8_t cc_ltvs_len;
+    uint8_t cc_ltvs[];
+} __packed;
+struct btp_bap_broadcast_source_setup_v2_rp {
+    uint32_t gap_settings;
+} __packed;
+
+#define BTP_BAP_EV_DISCOVERY_COMPLETED 0x80
+struct btp_bap_discovery_completed_ev {
+    ble_addr_t address;
+    uint8_t status;
+} __packed;
+
+#define BTP_BAP_EV_CODEC_CAP_FOUND 0x81
+struct btp_bap_codec_cap_found_ev {
+    ble_addr_t address;
+    uint8_t dir;
+    uint8_t coding_format;
+    uint16_t frequencies;
+    uint8_t frame_durations;
+    uint32_t octets_per_frame;
+    uint8_t channel_counts;
+} __packed;
+
+#define BTP_BAP_EV_ASE_FOUND 0x82
+struct btp_bap_ase_found_ev {
+    ble_addr_t address;
+    uint8_t dir;
+    uint8_t ase_id;
+} __packed;
+
+#define BTP_BAP_EV_STREAM_RECEIVED 0x83
+struct btp_bap_stream_received_ev {
+    ble_addr_t address;
+    uint8_t ase_id;
+    uint8_t data_len;
+    uint8_t data[];
+} __packed;
+
+#define BTP_BAP_EV_BAA_FOUND 0x84
+struct btp_bap_baa_found_ev {
+    ble_addr_t address;
+    uint8_t broadcast_id[3];
+    uint8_t advertiser_sid;
+    uint16_t padv_interval;
+} __packed;
+
+#define BTP_BAP_EV_BIS_FOUND 0x85
+struct btp_bap_bis_found_ev {
+    ble_addr_t address;
+    uint8_t broadcast_id[3];
+    uint8_t presentation_delay[3];
+    uint8_t subgroup_id;
+    uint8_t bis_id;
+    uint8_t coding_format;
+    uint16_t vid;
+    uint16_t cid;
+    uint8_t cc_ltvs_len;
+    uint8_t cc_ltvs[];
+} __packed;
+
+#define BTP_BAP_EV_BIS_SYNCED 0x86
+struct btp_bap_bis_synced_ev {
+    ble_addr_t address;
+    uint8_t broadcast_id[3];
+    uint8_t bis_id;
+} __packed;
+
+#define BTP_BAP_EV_BIS_STREAM_RECEIVED 0x87
+struct btp_bap_bis_stream_received_ev {
+    ble_addr_t address;
+    uint8_t broadcast_id[3];
+    uint8_t bis_id;
+    uint8_t data_len;
+    uint8_t data[];
+} __packed;
+
+#define BTP_BAP_EV_SCAN_DELEGATOR_FOUND 0x88
+struct btp_bap_scan_delegator_found_ev {
+    ble_addr_t address;
+} __packed;
+
+#define BTP_BAP_EV_BROADCAST_RECEIVE_STATE 0x89
+struct btp_bap_broadcast_receive_state_ev {
+    ble_addr_t address;
+    uint8_t source_id;
+    ble_addr_t broadcaster_address;
+    uint8_t advertiser_sid;
+    uint8_t broadcast_id[3];
+    uint8_t pa_sync_state;
+    uint8_t big_encryption;
+    uint8_t num_subgroups;
+    uint8_t subgroups[0];
+} __packed;
+
+#define BTP_BAP_EV_PA_SYNC_REQ 0x8a
+struct btp_bap_pa_sync_req_ev {
+    ble_addr_t address;
+    uint8_t source_id;
+    uint8_t advertiser_sid;
+    uint8_t broadcast_id[3];
+    uint8_t past_avail;
+    uint16_t pa_interval;
+} __packed;
 
 #endif /* H_BTP_BAP_                        */


### PR DESCRIPTION
Bring BAP commands and events up to date with their corresponding counterparts in Auto-PTS.