### PR TITLE
nimble: Add option to select Core 6.1

### DIFF
--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -2379,6 +2379,7 @@ struct ble_hci_ev_le_subev_cs_test_end_complete {
 #define BLE_HCI_VER_BCS_5_3                 (12)
 #define BLE_HCI_VER_BCS_5_4                 (13)
 #define BLE_HCI_VER_BCS_6_0                 (14)
+#define BLE_HCI_VER_BCS_6_1                 (15)
 
 #define BLE_LMP_VER_BCS_1_0b                (0)
 #define BLE_LMP_VER_BCS_1_1                 (1)
@@ -2395,6 +2396,7 @@ struct ble_hci_ev_le_subev_cs_test_end_complete {
 #define BLE_LMP_VER_BCS_5_3                 (12)
 #define BLE_LMP_VER_BCS_5_4                 (13)
 #define BLE_LMP_VER_BCS_6_0                 (14)
+#define BLE_LMP_VER_BCS_6_1                 (15)
 
 /* selected HCI and LMP version */
 #if MYNEWT_VAL(BLE_VERSION) == 50
@@ -2415,6 +2417,9 @@ struct ble_hci_ev_le_subev_cs_test_end_complete {
 #elif MYNEWT_VAL(BLE_VERSION) == 60
 #define BLE_HCI_VER_BCS BLE_HCI_VER_BCS_6_0
 #define BLE_LMP_VER_BCS BLE_LMP_VER_BCS_6_0
+#elif MYNEWT_VAL(BLE_VERSION) == 61
+#define BLE_HCI_VER_BCS BLE_HCI_VER_BCS_6_1
+#define BLE_LMP_VER_BCS BLE_LMP_VER_BCS_6_1
 #else
 #error Unsupported BLE_VERSION selected
 #endif

--- a/nimble/syscfg.yml
+++ b/nimble/syscfg.yml
@@ -87,7 +87,7 @@ syscfg.defs:
             This allows to configure supported Bluetooth Core version. Some
             features may not be available if version is too low. Version is
             integer for easy comparison.
-        range: 50, 51, 52, 53, 54, 60
+        range: 50, 51, 52, 53, 54, 60, 61
         value: 50
     BLE_ISO:
         description: >


### PR DESCRIPTION
This allows to configure stack as Bluetooth Core 6.1.