### PR TITLE
nimble: Push BLE HS shutdown later in the process

### DIFF
--- a/nimble/host/pkg.yml
+++ b/nimble/host/pkg.yml
@@ -53,4 +53,4 @@ pkg.req_apis:
     - stats
 
 pkg.down.BLE_HS_STOP_ON_SHUTDOWN:
-    ble_hs_shutdown: 200
+    ble_hs_shutdown: 900


### PR DESCRIPTION
Since the completion of BLE HS shutdown itself invokes a system reset, it prevented the stats from being persisted; therefore the BLE HS shutdown is pushed to the end of the shutdown process.