### PR TITLE
nimble/ll: Fix race condition in aux scan

### DIFF
--- a/nimble/controller/src/ble_ll_scan_aux.c
+++ b/nimble/controller/src/ble_ll_scan_aux.c
@@ -682,10 +682,8 @@ ble_ll_hci_ev_send_ext_adv_report_for_ext(struct os_mbuf *rxpdu,
 }
 
 static void
-ble_ll_scan_aux_break_ev(struct ble_npl_event *ev)
+scan_aux_break(struct ble_ll_scan_aux_data *aux)
 {
-    struct ble_ll_scan_aux_data *aux = ble_npl_event_get_arg(ev);
-
     BLE_LL_ASSERT(aux);
 
     if (ble_ll_scan_aux_need_truncation(aux)) {
@@ -701,6 +699,21 @@ ble_ll_scan_aux_break_ev(struct ble_npl_event *ev)
     ble_ll_scan_chk_resume();
 }
 
+static void
+scan_aux_break_ev(struct ble_npl_event *ev)
+{
+    struct ble_ll_scan_aux_data *aux = ble_npl_event_get_arg(ev);
+
+    scan_aux_break(aux);
+}
+
+static void
+scan_aux_break_to_ll(struct ble_ll_scan_aux_data *aux)
+{
+    ble_npl_event_init(&aux->break_ev, scan_aux_break_ev, aux);
+    ble_ll_event_add(&aux->break_ev);
+}
+
 void
 ble_ll_scan_aux_break(struct ble_ll_scan_aux_data *aux)
 {
@@ -710,8 +723,7 @@ ble_ll_scan_aux_break(struct ble_ll_scan_aux_data *aux)
     }
 #endif
 
-    ble_npl_event_init(&aux->break_ev, ble_ll_scan_aux_break_ev, aux);
-    ble_ll_event_add(&aux->break_ev);
+    scan_aux_break_to_ll(aux);
 }
 
 static int
@@ -1766,7 +1778,19 @@ ble_ll_scan_aux_halt(void)
 void
 ble_ll_scan_aux_sched_remove(struct ble_ll_sched_item *sch)
 {
-    ble_ll_scan_aux_break(sch->cb_arg);
+    struct ble_ll_scan_aux_data *aux = sch->cb_arg;
+
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+    if (aux->flags & BLE_LL_SCAN_AUX_F_W4_CONNECT_RSP) {
+        ble_ll_conn_send_connect_req_cancel();
+    }
+#endif
+
+    if (ble_npl_event_is_queued(&aux->break_ev)) {
+        ble_ll_event_remove(&aux->break_ev);
+    }
+
+    scan_aux_break(aux);
 }
 
 void

--- a/nimble/controller/src/ble_ll_sched.c
+++ b/nimble/controller/src/ble_ll_sched.c
@@ -939,8 +939,8 @@ ble_ll_sched_rmv_elem_type(uint8_t type, sched_remove_cb_func remove_cb)
             continue;
         }
         TAILQ_REMOVE(&g_ble_ll_sched_q, entry, link);
-        remove_cb(entry);
         entry->enqueued = 0;
+        remove_cb(entry);
     }
 
     if (first_removed) {


### PR DESCRIPTION
This fixes race condition in aux scan what was observed on Harmony. During extended scan, the HCI Reset called, that stops the active scan and clears the scan state machine. The scan stop itself, if scan response is pending, and calls ble_ll_scan_aux_sched_remove that pokes the active scan backup (from LL via event queue). The problem is that the SM is cleared already when backoff is called, which causes an assert in ble_ll_scan_req_backoff function.

This change ensures the ble_ll_scan_req_backoff is called from ble_ll_reset() function context. ble_ll_reset is always called from LL task context.