### PR TITLE
host: att: convert BLE_HS_ATT_SVR_QUEUED_WRITE_TMO to system ticks

### DIFF
--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -2425,7 +2425,7 @@ ble_att_svr_insert_prep_entry(uint16_t conn_handle,
 
 #if BLE_HS_ATT_SVR_QUEUED_WRITE_TMO != 0
     conn->bhc_att_svr.basc_prep_timeout_at =
-        ble_npl_time_get() + BLE_HS_ATT_SVR_QUEUED_WRITE_TMO;
+        ble_npl_time_get() + ble_npl_time_ms_to_ticks32(BLE_HS_ATT_SVR_QUEUED_WRITE_TMO);
 
     ble_hs_timer_resched();
 #endif


### PR DESCRIPTION
The value of BLE_HS_ATT_SVR_QUEUED_WRITE_TMO is the expiry time for incoming ATT queued writes in ms. When used it needs to be converted to system ticks.