### PR TITLE
host: l2cap: convert BLE_L2CAP_RX_FRAG_TIMEOUT to system ticks

### DIFF
--- a/nimble/host/src/ble_l2cap.c
+++ b/nimble/host/src/ble_l2cap.c
@@ -289,7 +289,7 @@ ble_l2cap_rx_payload(struct ble_hs_conn *conn, struct ble_l2cap_chan *chan,
         /* More fragments remain. */
 #if MYNEWT_VAL(BLE_L2CAP_RX_FRAG_TIMEOUT) != 0
         conn->bhc_rx_timeout =
-            ble_npl_time_get() + MYNEWT_VAL(BLE_L2CAP_RX_FRAG_TIMEOUT);
+            ble_npl_time_get() + ble_npl_time_ms_to_ticks32(MYNEWT_VAL(BLE_L2CAP_RX_FRAG_TIMEOUT));
 
         ble_hs_timer_resched();
 #endif


### PR DESCRIPTION
The value of BLE_L2CAP_RX_FRAG_TIMEOUT is the expiry time for incoming data packets in ms. When used it needs to be converted to system ticks.