### PR TITLE
nimble/host: Fix stopping host with pending connections

### DIFF
--- a/nimble/host/src/ble_hs_stop.c
+++ b/nimble/host/src/ble_hs_stop.c
@@ -71,13 +71,13 @@ ble_hs_stop_done(int status)
 
     ble_hs_stop_hci_reset();
 
+    /* Clear advertising, scanning and connection states. */
+    ble_gap_reset_state(0);
+
     /* After LL reset the controller loses its random address */
     ble_hs_id_reset();
 
     ble_hs_pvcy_reset();
-
-    /* Clear advertising, scanning and connection states. */
-    ble_gap_reset_state(0);
 
     ble_hs_unlock();
 


### PR DESCRIPTION
ble_gap_reset_state() may stil require valid local(own) addresses. So ID and RPAs should be cleaned only after that.