### PR TITLE
nimble: Use BLE_NPL_TIME_FOREVER for ble_npl_mutex_pend timeout

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -6965,7 +6965,7 @@ ble_gap_preempt_done(void)
     disc_preempted = 0;
 
     /* Protects slaves from accessing by multiple threads */
-    ble_npl_mutex_pend(&preempt_done_mutex, 0xFFFFFFFF);
+    ble_npl_mutex_pend(&preempt_done_mutex, BLE_NPL_TIME_FOREVER);
     memset(slaves, 0, sizeof(slaves));
 
     ble_hs_lock();

--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -164,7 +164,7 @@ ble_hs_lock_nested(void)
     }
 #endif
 
-    rc = ble_npl_mutex_pend(&ble_hs_mutex, 0xffffffff);
+    rc = ble_npl_mutex_pend(&ble_hs_mutex, BLE_NPL_TIME_FOREVER);
     BLE_HS_DBG_ASSERT_EVAL(rc == 0 || rc == OS_NOT_STARTED);
 }
 

--- a/nimble/transport/src/monitor.c
+++ b/nimble/transport/src/monitor.c
@@ -281,7 +281,7 @@ static FILE *btmon = (FILE *) &(struct File) {
 static void
 drops_tmp_cb(struct ble_npl_event *ev)
 {
-    ble_npl_mutex_pend(&lock, OS_TIMEOUT_NEVER);
+    ble_npl_mutex_pend(&lock, BLE_NPL_TIME_FOREVER);
 
     /*
      * There's no "nop" in btsnoop protocol so we just send empty system note
@@ -352,7 +352,7 @@ ble_monitor_init(void)
 int
 ble_monitor_send(uint16_t opcode, const void *data, size_t len)
 {
-    ble_npl_mutex_pend(&lock, OS_TIMEOUT_NEVER);
+    ble_npl_mutex_pend(&lock, BLE_NPL_TIME_FOREVER);
 
     monitor_write_header(opcode, len);
     monitor_write(data, len);
@@ -374,7 +374,7 @@ ble_monitor_send_om(uint16_t opcode, const struct os_mbuf *om)
         om_tmp = SLIST_NEXT(om_tmp, om_next);
     }
 
-    ble_npl_mutex_pend(&lock, OS_TIMEOUT_NEVER);
+    ble_npl_mutex_pend(&lock, BLE_NPL_TIME_FOREVER);
 
     monitor_write_header(opcode, length);
 
@@ -436,7 +436,7 @@ ble_monitor_log(int level, const char *fmt, ...)
 
     ulog.ident_len = sizeof(id);
 
-    ble_npl_mutex_pend(&lock, OS_TIMEOUT_NEVER);
+    ble_npl_mutex_pend(&lock, BLE_NPL_TIME_FOREVER);
 
     monitor_write_header(BLE_MONITOR_OPCODE_USER_LOGGING,
                          sizeof(ulog) + sizeof(id) + len + 1);


### PR DESCRIPTION
If no timeout is required we should use BLE_NPL_TIME_FOREVER when locking.