### PR TITLE
nimble/host: fix ble_svc_gatt_cl_sup_feat_access

### DIFF
--- a/nimble/host/services/gatt/src/ble_svc_gatt.c
+++ b/nimble/host/services/gatt/src/ble_svc_gatt.c
@@ -113,8 +113,9 @@ ble_svc_gatt_cl_sup_feat_access(uint16_t conn_handle, uint16_t attr_handle,
         return 0;
     }
     if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
-        if (ble_gatts_peer_cl_sup_feat_update(conn_handle, ctxt->om)) {
-            return BLE_ATT_ERR_UNLIKELY;
+        rc = ble_gatts_peer_cl_sup_feat_update(conn_handle, ctxt->om);
+        if (rc != 0) {
+            return rc;
         }
     }
 


### PR DESCRIPTION
Fix ble_svc_gatt_cl_sup_feat_access. If an error occured while client writes to client supported features only BLE_ATT_ERR_UNLIKELY was returned.
This is needed for GATT/SR/GAS/BV-05-C qualification test case but requires https://github.com/apache/mynewt-nimble/pull/2098 to be tested