### PR TITLE
apps/dtm: Fix compilation error

### DIFF
--- a/apps/dtm/src/main.c
+++ b/apps/dtm/src/main.c
@@ -24,6 +24,7 @@
 #include "nimble/ble.h"
 #include "nimble/nimble_opt.h"
 #include "host/ble_hs.h"
+#include "host/ble_hs_hci.h"
 #include "host/ble_dtm.h"
 #include <img_mgmt/img_mgmt.h>
 #include <bootutil/image.h>

--- a/apps/dtm/syscfg.yml
+++ b/apps/dtm/syscfg.yml
@@ -27,3 +27,5 @@ syscfg.vals:
 
     BLE_LL_DTM: 1
     BLE_LL_DTM_EXTENSIONS: 1
+
+    BLE_HCI_VS: 1


### PR DESCRIPTION
Fixes error:
main.c:169:10: error: implicit declaration of function
	'ble_hs_hci_send_vs_cmd' [-Wimplicit-function-declaration]
  169 |     rc = ble_hs_hci_send_vs_cmd(BLE_HCI_OCF_VS_SET_TX_PWR,
      |          ^~~~~~~~~~~~~~~~~~~~~~