### PR TITLE
nimble/host: Add support for storing client supported features values

### DIFF
--- a/apps/btshell/src/cmd.c
+++ b/apps/btshell/src/cmd.c
@@ -2267,6 +2267,7 @@ static const struct parse_arg_kv_pair cmd_keystore_entry_type[] = {
     { "msec",       BLE_STORE_OBJ_TYPE_PEER_SEC },
     { "ssec",       BLE_STORE_OBJ_TYPE_OUR_SEC },
     { "cccd",       BLE_STORE_OBJ_TYPE_CCCD },
+    { "csf",        BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT },
     { NULL }
 };
 
@@ -2388,6 +2389,9 @@ cmd_keystore_add(int argc, char **argv)
         case BLE_STORE_OBJ_TYPE_CCCD:
             rc = ble_store_write_cccd(&value.cccd);
             break;
+        case BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT:
+            rc = ble_store_write_peer_cl_sup_feat(&value.feat);
+            break;
         default:
             rc = ble_store_write(obj_type, &value);
     }
@@ -2396,7 +2400,7 @@ cmd_keystore_add(int argc, char **argv)
 
 #if MYNEWT_VAL(SHELL_CMD_HELP)
 static const struct shell_param keystore_add_params[] = {
-    {"type", "entry type, usage: =<msec|ssec|cccd>"},
+    {"type", "entry type, usage: =<msec|ssec|cccd|csf>"},
     {"addr_type", "usage: =<public|random>"},
     {"addr", "usage: =<XX:XX:XX:XX:XX:XX>"},
     {"ediv", "usage: =<UINT16>"},
@@ -2441,7 +2445,7 @@ cmd_keystore_del(int argc, char **argv)
 
 #if MYNEWT_VAL(SHELL_CMD_HELP)
 static const struct shell_param keystore_del_params[] = {
-    {"type", "entry type, usage: =<msec|ssec|cccd>"},
+    {"type", "entry type, usage: =<msec|ssec|cccd|csf>"},
     {"addr_type", "usage: =<public|random>"},
     {"addr", "usage: =<XX:XX:XX:XX:XX:XX>"},
     {"ediv", "usage: =<UINT16>"},
@@ -2504,6 +2508,14 @@ cmd_keystore_iterator(int obj_type,
             console_printf("    flags:           0x%02x\n", val->cccd.flags);
             console_printf("    changed:         %d\n", val->cccd.value_changed);
             break;
+        case BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT:
+
+            console_printf("Key: ");
+            console_printf("addr_type=%u ", val->feat.peer_addr.type);
+            print_addr(val->feat.peer_addr.val);
+            console_printf("\n");
+            console_printf("Enabled features: 0x%02x\n", val->feat.peer_cl_sup_feat[0]);
+            break;
     }
     return 0;
 }
@@ -2531,7 +2543,7 @@ cmd_keystore_show(int argc, char **argv)
 
 #if MYNEWT_VAL(SHELL_CMD_HELP)
 static const struct shell_param keystore_show_params[] = {
-    {"type", "entry type, usage: =<msec|ssec|cccd>"},
+    {"type", "entry type, usage: =<msec|ssec|cccd|csf>"},
     {NULL, NULL}
 };
 

--- a/nimble/host/include/host/ble_gatt.h
+++ b/nimble/host/include/host/ble_gatt.h
@@ -201,6 +201,14 @@ struct ble_hs_cfg;
 
 /** @} */
 
+/**
+ * @brief Size of the GATT Client Supported Features characteristic.
+ *
+ */
+#define BLE_GATT_CHR_CLI_SUP_FEAT_SZ 1
+
+/** @} */
+
 /*** @client. */
 /** Represents a GATT error. */
 struct ble_gatt_error {

--- a/nimble/host/include/host/ble_store.h
+++ b/nimble/host/include/host/ble_store.h
@@ -41,13 +41,13 @@ extern "C" {
  * @{
  */
 /** Object type: Our security material. */
-#define BLE_STORE_OBJ_TYPE_OUR_SEC                 1
+#define BLE_STORE_OBJ_TYPE_OUR_SEC 1
 
 /** Object type: Peer security material. */
-#define BLE_STORE_OBJ_TYPE_PEER_SEC                2
+#define BLE_STORE_OBJ_TYPE_PEER_SEC 2
 
 /** Object type: Client Characteristic Configuration Descriptor. */
-#define BLE_STORE_OBJ_TYPE_CCCD                    3
+#define BLE_STORE_OBJ_TYPE_CCCD 3
 
 /** Object type: Peer Client Supported Features. */
 #define BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT 4

--- a/nimble/host/include/host/ble_store.h
+++ b/nimble/host/include/host/ble_store.h
@@ -29,6 +29,7 @@
 
 #include <inttypes.h>
 #include "nimble/ble.h"
+#include "host/ble_gatt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,13 +41,16 @@ extern "C" {
  * @{
  */
 /** Object type: Our security material. */
-#define BLE_STORE_OBJ_TYPE_OUR_SEC      1
+#define BLE_STORE_OBJ_TYPE_OUR_SEC                 1
 
 /** Object type: Peer security material. */
-#define BLE_STORE_OBJ_TYPE_PEER_SEC     2
+#define BLE_STORE_OBJ_TYPE_PEER_SEC                2
 
 /** Object type: Client Characteristic Configuration Descriptor. */
-#define BLE_STORE_OBJ_TYPE_CCCD         3
+#define BLE_STORE_OBJ_TYPE_CCCD                    3
+
+/** Object type: Peer Client Supported Features. */
+#define BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT 4
 
 /** @} */
 
@@ -155,6 +159,33 @@ struct ble_store_value_cccd {
 };
 
 /**
+ * Used as a key for lookups of stored client supported features of specific
+ * peer. This struct corresponds to the BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT
+ * store object type.
+ */
+struct ble_store_key_cl_sup_feat {
+    /**
+     * Key by peer identity address;
+     * peer_addr=BLE_ADDR_NONE means don't key off peer.
+     */
+    ble_addr_t peer_addr;
+
+    /** Number of results to skip; 0 means retrieve the first match. */
+    uint8_t idx;
+};
+
+/**
+ * Represents a stored client supported features of specific peer. This struct
+ * corresponds to the BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT store object type.
+ */
+struct ble_store_value_cl_sup_feat {
+    /** The peer address associated with the stored supported features. */
+    ble_addr_t peer_addr;
+    /** Client supported features of a specific peer. */
+    uint8_t peer_cl_sup_feat[BLE_GATT_CHR_CLI_SUP_FEAT_SZ];
+};
+
+/**
  * Used as a key for store lookups.  This union must be accompanied by an
  * object type code to indicate which field is valid.
  */
@@ -163,6 +194,8 @@ union ble_store_key {
     struct ble_store_key_sec sec;
     /** Key for Client Characteristic Configuration Descriptor store lookups. */
     struct ble_store_key_cccd cccd;
+    /** Key for Peer Client Supported Features store lookpus. */
+    struct ble_store_key_cl_sup_feat feat;
 };
 
 /**
@@ -174,6 +207,8 @@ union ble_store_value {
     struct ble_store_value_sec sec;
     /** Stored Client Characteristic Configuration Descriptor. */
     struct ble_store_value_cccd cccd;
+    /** Stored Client Supported Features. */
+    struct ble_store_value_cl_sup_feat feat;
 };
 
 /** Represents an event associated with the BLE Store. */
@@ -556,6 +591,60 @@ int ble_store_write_cccd(const struct ble_store_value_cccd *value);
  */
 int ble_store_delete_cccd(const struct ble_store_key_cccd *key);
 
+/**
+ * @brief Reads Client Supported Features value from a storage
+ *
+ * This function reads client supported features value from a storage based
+ * on the provied key and stores the retrieved value in the specified output
+ * structure.
+ *
+ * @param key                   A pointer to a 'ble_store_key_cl_sup_feat'
+ *                                  struct representing the key to identify
+ *                                  Client Supported Features value to be read.
+ * @param out_value             A pointer to a 'ble_store_value_cl_sup_feat'
+ *                                  struct to store the Client Supported
+ *                                  Features value read from a storage
+ *
+ * @return                      0 if the Client Supported Features values was
+ *                                  successfully read and stored in the
+ *                                  'out_value' structure;
+ *                              Non-zero on error
+ */
+int ble_store_read_peer_cl_sup_feat(const struct ble_store_key_cl_sup_feat *key,
+                                    struct ble_store_value_cl_sup_feat *out_value);
+
+/**
+ * @brief Writes a Client Supported Features value to a storage.
+ *
+ * This function writes a Client Supported Features value to a storage based on
+ * the provided value
+ *
+ * @param value                 A pointer to a 'ble_store_value_cl_sup_feat'
+ *                                  structure representing the Client Supported
+ *                                  Features value to be written to a storage.
+ *
+ * @return                      0 if the value was successfully written to
+ *                                  a storage;
+ *                              Non-zero on error.
+ */
+int ble_store_write_peer_cl_sup_feat(const struct ble_store_value_cl_sup_feat *value);
+
+/**
+ * @brief Deletes a Client Supported Features value from a storage.
+ *
+ * This function deletes a Client Supported Features value from a storage based
+ * on the provided key.
+ *
+ * @param key                   A pointer to a 'ble_store_key_cl_sup_feat'
+ *                                  structure identifying the Client Supported
+ *                                  Features value to be deleted from
+ *                                  a storage.
+ *
+ * @return                      0 if the Client Supported Features value was
+ *                                  successfully written to a storage;
+ *                              Non-zero on error.
+ */
+int ble_store_delete_peer_cl_sup_feat(const struct ble_store_key_cl_sup_feat *key);
 
 /**
  * @brief Generates a storage key for a security material entry from its value.
@@ -587,6 +676,24 @@ void ble_store_key_from_value_sec(struct ble_store_key_sec *out_key,
 void ble_store_key_from_value_cccd(struct ble_store_key_cccd *out_key,
                                    const struct ble_store_value_cccd *value);
 
+/**
+ * @brief Generates a storage key for a Client Supported Features entry from
+ * its value
+ *
+ * This function generates a storage key for a Client Supported Features value
+ * entry based on the provided value.
+ *
+ * @param out_key               A pointer to a 'ble_store_key_cl_sup_feat'
+ *                                  structure where the generated key will be
+ *                                  stored.
+ * @param value                 A pointer to a 'ble_store_value_cl_sup_feat'
+ *                                  structure containing the Client Supported
+ *                                  Features value from which the key will be
+ *                                  generated.
+ */
+void ble_store_key_from_value_peer_cl_sup_feat(
+    struct ble_store_key_cl_sup_feat *out_key,
+    const struct ble_store_value_cl_sup_feat *value);
 
 /**
  * @brief Generates a storage key from a value based on the object type.

--- a/nimble/host/src/ble_gatt_priv.h
+++ b/nimble/host/src/ble_gatt_priv.h
@@ -88,7 +88,6 @@ extern STATS_SECT_DECL(ble_gatts_stats) ble_gatts_stats;
 
 #define BLE_GATT_CHR_DECL_SZ_16         5
 #define BLE_GATT_CHR_DECL_SZ_128        19
-#define BLE_GATT_CHR_CLI_SUP_FEAT_SZ    1
 /**
  * For now only 3 bits in first octet are defined
  *

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -1717,6 +1717,9 @@ int
 ble_gatts_peer_cl_sup_feat_update(uint16_t conn_handle, struct os_mbuf *om)
 {
     struct ble_hs_conn *conn;
+    struct ble_store_value_cl_sup_feat store_feat;
+    struct ble_store_key_cl_sup_feat feat_key;
+    struct ble_store_value_cl_sup_feat feat_val;
     uint8_t feat[BLE_GATT_CHR_CLI_SUP_FEAT_SZ] = {};
     uint16_t len;
     int rc = 0;
@@ -1744,8 +1747,8 @@ ble_gatts_peer_cl_sup_feat_update(uint16_t conn_handle, struct os_mbuf *om)
     ble_hs_lock();
     conn = ble_hs_conn_find(conn_handle);
     if (conn == NULL) {
-        rc = BLE_ATT_ERR_UNLIKELY;
-        goto done;
+        ble_hs_unlock();
+        return BLE_ATT_ERR_UNLIKELY;
     }
 
     /**
@@ -1755,15 +1758,44 @@ ble_gatts_peer_cl_sup_feat_update(uint16_t conn_handle, struct os_mbuf *om)
     for (i = 0; i < BLE_GATT_CHR_CLI_SUP_FEAT_SZ; i++) {
         if ((conn->bhc_gatt_svr.peer_cl_sup_feat[i] & feat[i]) !=
             conn->bhc_gatt_svr.peer_cl_sup_feat[i]) {
-            rc = BLE_ATT_ERR_VALUE_NOT_ALLOWED;
-            goto done;
+            ble_hs_unlock();
+            return BLE_ATT_ERR_VALUE_NOT_ALLOWED;
         }
     }
 
     memcpy(conn->bhc_gatt_svr.peer_cl_sup_feat, feat, BLE_GATT_CHR_CLI_SUP_FEAT_SZ);
 
-done:
     ble_hs_unlock();
+
+    if (conn->bhc_sec_state.bonded) {
+        feat_key.peer_addr = conn->bhc_peer_addr;
+        feat_key.idx = 0;
+
+        rc = ble_store_read_peer_cl_sup_feat(&feat_key, &feat_val);
+
+        if (rc == BLE_HS_ENOENT) {
+            /* Assume the values were not stored yet */
+            store_feat.peer_addr = conn->bhc_peer_addr;
+            memcpy(store_feat.peer_cl_sup_feat, feat, BLE_GATT_CHR_CLI_SUP_FEAT_SZ);
+            ble_store_write_peer_cl_sup_feat(&store_feat);
+            rc = 0;
+        } else if (rc == 0) {
+            /* Found cl_sup_feat for this peer, check for disabling already
+             * enabled features */
+            for (i = 0; i < BLE_GATT_CHR_CLI_SUP_FEAT_SZ; i++) {
+                if ((feat_val.peer_cl_sup_feat[i] & feat[i]) !=
+                    feat_val.peer_cl_sup_feat[i]) {
+                    return BLE_ATT_ERR_VALUE_NOT_ALLOWED;
+                }
+            }
+            /* The peer is only adding new features. Add it's cl_sup_feat to
+             * storage. */
+            store_feat.peer_addr = conn->bhc_peer_addr;
+            memcpy(store_feat.peer_cl_sup_feat, feat, BLE_GATT_CHR_CLI_SUP_FEAT_SZ);
+            ble_store_write_peer_cl_sup_feat(&store_feat);
+        }
+    }
+
     return rc;
 }
 
@@ -1856,11 +1888,13 @@ ble_gatts_tx_notifications(void)
 void
 ble_gatts_bonding_established(uint16_t conn_handle)
 {
+    struct ble_store_value_cl_sup_feat feat_value;
     struct ble_store_value_cccd cccd_value;
     struct ble_gatts_clt_cfg *clt_cfg;
     struct ble_gatts_conn *gatt_srv;
     struct ble_hs_conn *conn;
     int i;
+    int rc;
 
     ble_hs_lock();
 
@@ -1872,6 +1906,20 @@ ble_gatts_bonding_established(uint16_t conn_handle)
     cccd_value.peer_addr.type =
         ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);
     gatt_srv = &conn->bhc_gatt_svr;
+
+    feat_value.peer_addr = conn->bhc_peer_addr;
+    feat_value.peer_addr.type =
+        ble_hs_misc_peer_addr_type_to_id(conn->bhc_peer_addr.type);
+
+    memcpy(feat_value.peer_cl_sup_feat, gatt_srv->peer_cl_sup_feat,
+           BLE_GATT_CHR_CLI_SUP_FEAT_SZ);
+
+    ble_hs_unlock();
+    rc = ble_store_write_peer_cl_sup_feat(&feat_value);
+    if (rc != 0) {
+        BLE_HS_LOG(ERROR, "Failed to persist client supported features, rc=%d\n", rc);
+    }
+    ble_hs_lock();
 
     for (i = 0; i < gatt_srv->num_clt_cfgs; ++i) {
         clt_cfg = &gatt_srv->clt_cfgs[i];
@@ -1898,6 +1946,7 @@ ble_gatts_bonding_established(uint16_t conn_handle)
  * Called when bonding has been restored via the encryption procedure.  This
  * function:
  *     o Restores persisted CCCD entries for the connected peer.
+ *     o Restores persisted Client Supported Features for the connected peer.
  *     o Sends all pending notifications to the connected peer.
  *     o Sends up to one pending indication to the connected peer; schedules
  *       any remaining pending indications.
@@ -1907,6 +1956,8 @@ ble_gatts_bonding_restored(uint16_t conn_handle)
 {
     struct ble_store_value_cccd cccd_value;
     struct ble_store_key_cccd cccd_key;
+    struct ble_store_key_cl_sup_feat feat_key;
+    struct ble_store_value_cl_sup_feat feat_val;
     struct ble_gatts_clt_cfg *clt_cfg;
     struct ble_hs_conn *conn;
     uint8_t att_op;
@@ -1924,7 +1975,31 @@ ble_gatts_bonding_restored(uint16_t conn_handle)
     cccd_key.chr_val_handle = 0;
     cccd_key.idx = 0;
 
+    feat_key.peer_addr = conn->bhc_peer_addr;
+    feat_key.idx = 0;
+
     ble_hs_unlock();
+
+    rc = ble_store_read_peer_cl_sup_feat(&feat_key, &feat_val);
+    if (rc != 0) {
+        /* Entry not found or storage error:
+         * Set Peer Client Supported Featured to a safe default (0x00). */
+        ble_hs_lock();
+        conn = ble_hs_conn_find(conn_handle);
+        if (conn != NULL) {
+            memset(conn->bhc_gatt_svr.peer_cl_sup_feat, 0, BLE_GATT_CHR_CLI_SUP_FEAT_SZ);
+        }
+        ble_hs_unlock();
+    } else {
+        /* success reading stored Client Supported Features for this peer */
+        ble_hs_lock();
+        conn = ble_hs_conn_find(conn_handle);
+        if (conn != NULL) {
+            memcpy(conn->bhc_gatt_svr.peer_cl_sup_feat,
+                   feat_val.peer_cl_sup_feat, BLE_GATT_CHR_CLI_SUP_FEAT_SZ);
+        }
+        ble_hs_unlock();
+    }
 
     while (1) {
         rc = ble_store_read_cccd(&cccd_key, &cccd_value);

--- a/nimble/host/src/ble_store.c
+++ b/nimble/host/src/ble_store.c
@@ -250,6 +250,42 @@ ble_store_write_peer_sec(const struct ble_store_value_sec *value_sec)
 }
 
 int
+ble_store_read_peer_cl_sup_feat(const struct ble_store_key_cl_sup_feat *key,
+                                struct ble_store_value_cl_sup_feat *out_value)
+{
+    union ble_store_value *store_value;
+    union ble_store_key *store_key;
+    int rc;
+
+    store_key = (void *)key;
+    store_value = (void *)out_value;
+    rc = ble_store_read(BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT, store_key, store_value);
+    return rc;
+}
+
+int
+ble_store_write_peer_cl_sup_feat(const struct ble_store_value_cl_sup_feat *value)
+{
+    union ble_store_value *store_value;
+    int rc;
+
+    store_value = (void *)value;
+    rc = ble_store_write(BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT, store_value);
+    return rc;
+}
+
+int
+ble_store_delete_peer_cl_sup_feat(const struct ble_store_key_cl_sup_feat *key)
+{
+    union ble_store_key *store_key;
+    int rc;
+
+    store_key = (void *)key;
+    rc = ble_store_delete(BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT, store_key);
+    return rc;
+}
+
+int
 ble_store_read_cccd(const struct ble_store_key_cccd *key,
                     struct ble_store_value_cccd *out_value)
 {
@@ -303,6 +339,14 @@ ble_store_key_from_value_sec(struct ble_store_key_sec *out_key,
 }
 
 void
+ble_store_key_from_value_peer_cl_sup_feat(struct ble_store_key_cl_sup_feat *out_key,
+                                          const struct ble_store_value_cl_sup_feat *value)
+{
+    out_key->peer_addr = value->peer_addr;
+    out_key->idx = 0;
+}
+
+void
 ble_store_key_from_value(int obj_type,
                          union ble_store_key *out_key,
                          const union ble_store_value *value)
@@ -316,6 +360,9 @@ ble_store_key_from_value(int obj_type,
     case BLE_STORE_OBJ_TYPE_CCCD:
         ble_store_key_from_value_cccd(&out_key->cccd, &value->cccd);
         break;
+
+    case BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT:
+        ble_store_key_from_value_peer_cl_sup_feat(&out_key->feat, &value->feat);
 
     default:
         BLE_HS_DBG_ASSERT(0);
@@ -345,6 +392,10 @@ ble_store_iterate(int obj_type,
     case BLE_STORE_OBJ_TYPE_CCCD:
         key.cccd.peer_addr = *BLE_ADDR_ANY;
         pidx = &key.cccd.idx;
+        break;
+    case BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT:
+        key.feat.peer_addr = *BLE_ADDR_ANY;
+        pidx = &key.feat.idx;
         break;
     default:
         BLE_HS_DBG_ASSERT(0);
@@ -390,6 +441,7 @@ ble_store_clear(void)
         BLE_STORE_OBJ_TYPE_OUR_SEC,
         BLE_STORE_OBJ_TYPE_PEER_SEC,
         BLE_STORE_OBJ_TYPE_CCCD,
+        BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT,
     };
     union ble_store_key key;
     int obj_type;

--- a/nimble/host/src/ble_store_util.c
+++ b/nimble/host/src/ble_store_util.c
@@ -109,6 +109,14 @@ ble_store_util_delete_peer(const ble_addr_t *peer_id_addr)
         return rc;
     }
 
+    memset(&key, 0, sizeof key);
+    key.feat.peer_addr = *peer_id_addr;
+
+    rc = ble_store_util_delete_all(BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT, &key);
+    if (rc != 0) {
+        return rc;
+    }
+
     return 0;
 }
 
@@ -192,6 +200,7 @@ ble_store_util_status_rr(struct ble_store_status_event *event, void *arg)
         switch (event->overflow.obj_type) {
         case BLE_STORE_OBJ_TYPE_OUR_SEC:
         case BLE_STORE_OBJ_TYPE_PEER_SEC:
+        case BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT:
             return ble_gap_unpair_oldest_peer();
         case BLE_STORE_OBJ_TYPE_CCCD:
             /* Try unpairing oldest peer except current peer */

--- a/nimble/host/store/config/src/ble_store_config_conf.c
+++ b/nimble/host/store/config/src/ble_store_config_conf.c
@@ -57,6 +57,12 @@ static struct conf_handler ble_store_config_conf_handler = {
 #define BLE_STORE_CONFIG_CCCD_SET_ENCODE_SZ \
     (MYNEWT_VAL(BLE_STORE_MAX_CCCDS) * BLE_STORE_CONFIG_CCCD_ENCODE_SZ + 1)
 
+#define BLE_STORE_CONFIG_CL_SUP_FEAT_ENCODE_SZ                                \
+    BASE64_ENCODE_SIZE(sizeof(struct ble_store_value_cl_sup_feat))
+
+#define BLE_STORE_CONFIG_CL_SUP_FEAT_SET_ENCODE_SZ                            \
+    (MYNEWT_VAL(BLE_STORE_MAX_BONDS) * BLE_STORE_CONFIG_CL_SUP_FEAT_ENCODE_SZ + 1)
+
 static void
 ble_store_config_serialize_arr(const void *arr, int obj_sz, int num_objs,
                                char *out_buf, int buf_sz)
@@ -118,6 +124,11 @@ ble_store_config_conf_set(int argc, char **argv, char *val)
                     sizeof *ble_store_config_cccds,
                     &ble_store_config_num_cccds);
             return rc;
+        } else if (strcmp(argv[0], "feat") == 0) {
+            rc = ble_store_config_deserialize_arr(val, ble_store_config_feats,
+                                                  sizeof *ble_store_config_feats,
+                                                  &ble_store_config_num_feats);
+            return rc;
         }
     }
     return OS_ENOENT;
@@ -130,6 +141,7 @@ ble_store_config_conf_export(void (*func)(char *name, char *val),
     union {
         char sec[BLE_STORE_CONFIG_SEC_SET_ENCODE_SZ];
         char cccd[BLE_STORE_CONFIG_CCCD_SET_ENCODE_SZ];
+        char feat[BLE_STORE_CONFIG_CL_SUP_FEAT_SET_ENCODE_SZ];
     } buf;
 
     ble_store_config_serialize_arr(ble_store_config_our_secs,
@@ -152,6 +164,11 @@ ble_store_config_conf_export(void (*func)(char *name, char *val),
                                    buf.cccd,
                                    sizeof buf.cccd);
     func("ble_hs/cccd", buf.cccd);
+
+    ble_store_config_serialize_arr(
+        ble_store_config_feats, sizeof *ble_store_config_feats,
+        ble_store_config_num_feats, buf.feat, sizeof buf.feat);
+    func("ble_hs/feat", buf.feat);
 
     return 0;
 }
@@ -216,6 +233,23 @@ ble_store_config_persist_cccds(void)
                                    buf,
                                    sizeof buf);
     rc = conf_save_one("ble_hs/cccd", buf);
+    if (rc != 0) {
+        return BLE_HS_ESTORE_FAIL;
+    }
+
+    return 0;
+}
+
+int
+ble_store_config_persist_feats(void)
+{
+    char buf[BLE_STORE_CONFIG_CL_SUP_FEAT_SET_ENCODE_SZ];
+    int rc;
+
+    ble_store_config_serialize_arr(ble_store_config_feats,
+                                   sizeof *ble_store_config_feats,
+                                   ble_store_config_num_feats, buf, sizeof buf);
+    rc = conf_save_one("ble_hs/feat", buf);
     if (rc != 0) {
         return BLE_HS_ESTORE_FAIL;
     }

--- a/nimble/host/store/config/src/ble_store_config_priv.h
+++ b/nimble/host/store/config/src/ble_store_config_priv.h
@@ -36,11 +36,15 @@ extern struct ble_store_value_cccd
     ble_store_config_cccds[MYNEWT_VAL(BLE_STORE_MAX_CCCDS)];
 extern int ble_store_config_num_cccds;
 
+extern struct ble_store_value_cl_sup_feat ble_store_config_feats[MYNEWT_VAL(BLE_STORE_MAX_BONDS)];
+extern int ble_store_config_num_feats;
+
 #if MYNEWT_VAL(BLE_STORE_CONFIG_PERSIST)
 
 int ble_store_config_persist_our_secs(void);
 int ble_store_config_persist_peer_secs(void);
 int ble_store_config_persist_cccds(void);
+int ble_store_config_persist_feats(void);
 void ble_store_config_conf_init(void);
 
 #else
@@ -48,6 +52,11 @@ void ble_store_config_conf_init(void);
 static inline int ble_store_config_persist_our_secs(void)   { return 0; }
 static inline int ble_store_config_persist_peer_secs(void)  { return 0; }
 static inline int ble_store_config_persist_cccds(void)      { return 0; }
+static inline int
+ble_store_config_persist_feats(void)
+{
+    return 0;
+}
 static inline void ble_store_config_conf_init(void)         { }
 
 #endif /* MYNEWT_VAL(BLE_STORE_CONFIG_PERSIST) */

--- a/nimble/host/test/src/ble_gatts_cl_sup_feat_test.c
+++ b/nimble/host/test/src/ble_gatts_cl_sup_feat_test.c
@@ -1,0 +1,335 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string.h>
+#include <errno.h>
+#include "testutil/testutil.h"
+#include "nimble/ble.h"
+#include "host/ble_uuid.h"
+#include "ble_hs_test.h"
+#include "ble_hs_test_util.h"
+#include "../src/ble_gatt_priv.h"
+
+#define BLE_GATTS_TEST_CL_SUP_FEAT_CHR_UUID 0x1111
+#define BLE_GATT_TEST_CL_SUP_FEAT_CHR_SZ    1
+
+/* Client supported features bit positions*/
+#define BLE_GATT_TEST_CLI_SUP_FEAT_ROBUST_CACHING_BIT 0x00
+#define BLE_GATT_TEST_CLI_SUP_FEAT_EATT_BIT           0x01
+#define BLE_GATT_TEST_CLI_SUP_FEAT_MULT_NTF_BIT       0x02
+
+/* --- Client Supported Features masks --- */
+#define BLE_GATT_TEST_CLI_SUP_FEAT_NONE_MASK            0x00
+#define BLE_GATT_TEST_CLI_SUP_FEAT_ROBUST_CACHING_MASK  0x01
+#define BLE_GATT_TEST_CLI_SUP_FEAT_EATT_MASK            0x02
+#define BLE_GATT_TEST_CLI_SUP_FEAT_MULT_NTF_MASK        0x04
+#define BLE_GATT_TEST_CLI_SUP_FEAT_ROBUST_EATT_MASK     0x03
+#define BLE_GATT_TEST_CLI_SUP_FEAT_ROBUST_MULT_NTF_MASK 0x05
+#define BLE_GATT_TEST_CLI_SUP_FEAT_EATT_MULT_NTF_MASK   0x06
+#define BLE_GATT_TEST_CLI_SUP_FEAT_ALL_MASK             0x07
+
+static uint8_t ble_gatts_cl_sup_feat_test_peer_addr[6] = { 1, 2, 3, 4, 5, 6 };
+
+static int
+ble_gatts_cl_sup_feat_test_misc_access(uint16_t conn_handle, uint16_t attr_handle,
+                                       struct ble_gatt_access_ctxt *ctxt, void *arg)
+{
+    uint8_t supported_feat;
+    int rc;
+
+    TEST_ASSERT(conn_handle != 0xffff);
+
+    if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+        rc = ble_gatts_peer_cl_sup_feat_get(conn_handle, &supported_feat, 1);
+        if (rc == 0) {
+            rc = os_mbuf_append(ctxt->om, &supported_feat, 1);
+        }
+        return rc;
+    }
+
+    if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+        rc = ble_gatts_peer_cl_sup_feat_update(conn_handle, ctxt->om);
+        return rc;
+    }
+
+    return BLE_ATT_ERR_UNLIKELY;
+}
+
+static const struct ble_gatt_svc_def ble_gatts_cl_sup_feat_test_svcs[] = {
+    {
+     .type = BLE_GATT_SVC_TYPE_PRIMARY,
+     .uuid = BLE_UUID16_DECLARE(0x1234),
+     .characteristics =
+            (struct ble_gatt_chr_def[]){
+                {
+                    .uuid = BLE_UUID16_DECLARE(BLE_GATTS_TEST_CL_SUP_FEAT_CHR_UUID),
+                    .access_cb = ble_gatts_cl_sup_feat_test_misc_access,
+                    .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE,
+                },
+                { 0 } },
+     },
+    { 0 }
+};
+
+static uint16_t ble_gatts_cl_sup_feat_test_chr_def_handle;
+static uint16_t ble_gatts_cl_sup_feat_test_chr_val_handle;
+static uint8_t ble_gatts_cl_sup_feat_test_chr_val[BLE_GATT_TEST_CL_SUP_FEAT_CHR_SZ] = { 0 };
+
+static void
+ble_gatts_notify_test_misc_reg_cb(struct ble_gatt_register_ctxt *ctxt, void *arg)
+{
+    uint16_t uuid16;
+
+    if (ctxt->op == BLE_GATT_REGISTER_OP_CHR) {
+        uuid16 = ble_uuid_u16(ctxt->chr.chr_def->uuid);
+        switch (uuid16) {
+        case BLE_GATTS_TEST_CL_SUP_FEAT_CHR_UUID:
+            ble_gatts_cl_sup_feat_test_chr_def_handle = ctxt->chr.def_handle;
+            ble_gatts_cl_sup_feat_test_chr_val_handle = ctxt->chr.val_handle;
+            break;
+
+        default:
+            TEST_ASSERT_FATAL(0);
+            break;
+        }
+    }
+}
+
+static void
+ble_gatts_cl_sup_feat_test_misc_init(uint16_t *out_conn_handle, int bonding)
+{
+    ble_hs_test_util_init();
+
+    ble_hs_test_util_reg_svcs(ble_gatts_cl_sup_feat_test_svcs,
+                              ble_gatts_notify_test_misc_reg_cb, NULL);
+    TEST_ASSERT_FATAL(ble_gatts_cl_sup_feat_test_chr_def_handle != 0);
+
+    ble_hs_test_util_create_conn(1, ble_gatts_cl_sup_feat_test_peer_addr, NULL, NULL);
+    *out_conn_handle = 1;
+}
+
+static void
+ble_gatts_cl_sup_feat_test_perform_bonding(uint16_t conn_handle)
+{
+    struct ble_hs_conn *conn;
+
+    ble_hs_lock();
+    conn = ble_hs_conn_find(conn_handle);
+    TEST_ASSERT_FATAL(conn != NULL);
+    conn->bhc_sec_state.encrypted = 1;
+    conn->bhc_sec_state.authenticated = 1;
+    conn->bhc_sec_state.bonded = 1;
+    ble_hs_unlock();
+}
+
+TEST_CASE_SELF(ble_gatts_cl_sup_feat_test_bond_then_write)
+{
+    uint16_t conn_handle = 1;
+    uint16_t conn_handle_2 = 2;
+    uint8_t out_feat = 0;
+    int rc;
+
+    ble_gatts_cl_sup_feat_test_misc_init(&conn_handle, 0);
+
+    ble_gatts_cl_sup_feat_test_perform_bonding(conn_handle);
+    ble_gatts_bonding_established(conn_handle);
+
+    /* Peer with trusted relationship enables EATT in Client Supported
+     * Features Characteristic */
+    ble_gatts_cl_sup_feat_test_chr_val[0] = BLE_GATT_TEST_CLI_SUP_FEAT_EATT_MASK;
+    ble_hs_test_util_rx_att_write_req(
+        conn_handle, ble_gatts_cl_sup_feat_test_chr_val_handle,
+        ble_gatts_cl_sup_feat_test_chr_val, BLE_GATT_TEST_CL_SUP_FEAT_CHR_SZ);
+
+    ble_hs_test_util_conn_disconnect(conn_handle);
+    ble_hs_test_util_create_conn(conn_handle_2,
+                                 ble_gatts_cl_sup_feat_test_peer_addr, NULL, NULL);
+
+    ble_gatts_cl_sup_feat_test_perform_bonding(conn_handle_2);
+    ble_gatts_bonding_restored(conn_handle_2);
+
+    /* Verify Client Supported Features value is persisted for this peer after
+     * reconnection.*/
+    rc = ble_gatts_peer_cl_sup_feat_get(conn_handle_2, &out_feat, 1);
+
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(out_feat == BLE_GATT_TEST_CLI_SUP_FEAT_EATT_MASK);
+}
+
+TEST_CASE_SELF(ble_gatts_cl_sup_feat_test_write_then_bond)
+{
+    uint16_t conn_handle = 1;
+    uint16_t new_conn_handle = 2;
+    uint8_t out_feat = 0;
+    int rc;
+
+    ble_gatts_cl_sup_feat_test_misc_init(&conn_handle, 0);
+
+    /* Peer enables Robust Caching in Client Supported Features Characteristic
+     * prior to bonding*/
+    ble_gatts_cl_sup_feat_test_chr_val[0] =
+        BLE_GATT_TEST_CLI_SUP_FEAT_ROBUST_CACHING_MASK;
+    ble_hs_test_util_rx_att_write_req(
+        conn_handle, ble_gatts_cl_sup_feat_test_chr_val_handle,
+        ble_gatts_cl_sup_feat_test_chr_val, BLE_GATT_TEST_CL_SUP_FEAT_CHR_SZ);
+
+    /* Bonding should result in maintaining last known Client Supported
+     * Features value for this peer */
+    ble_gatts_cl_sup_feat_test_perform_bonding(conn_handle);
+    ble_gatts_bonding_established(conn_handle);
+
+    ble_hs_test_util_conn_disconnect(conn_handle);
+    ble_hs_test_util_create_conn(new_conn_handle,
+                                 ble_gatts_cl_sup_feat_test_peer_addr, NULL, NULL);
+
+    ble_gatts_cl_sup_feat_test_perform_bonding(new_conn_handle);
+    ble_gatts_bonding_restored(new_conn_handle);
+
+    /* Verify Client Supported Features value is persisted for this peer after
+     * reconnection.*/
+    rc = ble_gatts_peer_cl_sup_feat_get(new_conn_handle, &out_feat, 1);
+
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(out_feat == BLE_GATT_TEST_CLI_SUP_FEAT_ROBUST_CACHING_MASK);
+}
+
+TEST_CASE_SELF(ble_gatts_cl_sup_feat_test_unbonded_no_persist)
+{
+    uint16_t conn_handle = 1;
+    uint16_t new_conn_handle = 2;
+    uint8_t out_feat = 0xFF; /* Initialize to dummy value */
+    int rc;
+
+    ble_gatts_cl_sup_feat_test_misc_init(&conn_handle, 0);
+
+    /* Peer enables EATT in Client Supported Features Characteristic */
+    ble_gatts_cl_sup_feat_test_chr_val[0] = BLE_GATT_TEST_CLI_SUP_FEAT_EATT_MASK;
+    ble_hs_test_util_rx_att_write_req(
+        conn_handle, ble_gatts_cl_sup_feat_test_chr_val_handle,
+        ble_gatts_cl_sup_feat_test_chr_val, BLE_GATT_TEST_CL_SUP_FEAT_CHR_SZ);
+
+    /* Disconnect (there was no bonding) */
+    ble_hs_test_util_conn_disconnect(conn_handle);
+
+    ble_hs_test_util_create_conn(new_conn_handle,
+                                 ble_gatts_cl_sup_feat_test_peer_addr, NULL, NULL);
+
+    /* Verify Client Supported Features value wasn't persisted */
+    rc = ble_gatts_peer_cl_sup_feat_get(new_conn_handle, &out_feat, 1);
+
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(out_feat == 0x00);
+}
+
+TEST_CASE_SELF(ble_gatts_cl_sup_feat_test_enable_new_feature_across_sessions)
+{
+    uint16_t conn_handle = 1;
+    uint16_t conn_handle_2 = 2;
+    uint16_t conn_handle_3 = 3;
+    uint8_t out_feat = 0;
+    int rc;
+
+    ble_gatts_cl_sup_feat_test_misc_init(&conn_handle, 0);
+
+    ble_gatts_cl_sup_feat_test_perform_bonding(conn_handle);
+    ble_gatts_bonding_established(conn_handle);
+
+    /* Peer with trusted relationship enables EATT and MULT NTF in Client
+     * Supported Features Characteristic */
+    ble_gatts_cl_sup_feat_test_chr_val[0] =
+        BLE_GATT_TEST_CLI_SUP_FEAT_EATT_MULT_NTF_MASK;
+    ble_hs_test_util_rx_att_write_req(
+        conn_handle, ble_gatts_cl_sup_feat_test_chr_val_handle,
+        ble_gatts_cl_sup_feat_test_chr_val, BLE_GATT_TEST_CL_SUP_FEAT_CHR_SZ);
+
+    ble_hs_test_util_conn_disconnect(conn_handle);
+    ble_hs_test_util_create_conn(conn_handle_2,
+                                 ble_gatts_cl_sup_feat_test_peer_addr, NULL, NULL);
+
+    ble_gatts_cl_sup_feat_test_perform_bonding(conn_handle_2);
+    ble_gatts_bonding_restored(conn_handle_2);
+
+    /* After rebonding, peer enables all features in Client Supported Features
+     * Characteristic */
+    ble_gatts_cl_sup_feat_test_chr_val[0] = BLE_GATT_TEST_CLI_SUP_FEAT_ALL_MASK;
+    ble_hs_test_util_rx_att_write_req(
+        conn_handle_2, ble_gatts_cl_sup_feat_test_chr_val_handle,
+        ble_gatts_cl_sup_feat_test_chr_val, BLE_GATT_TEST_CL_SUP_FEAT_CHR_SZ);
+
+    ble_hs_test_util_conn_disconnect(conn_handle_2);
+    ble_hs_test_util_create_conn(conn_handle_3,
+                                 ble_gatts_cl_sup_feat_test_peer_addr, NULL, NULL);
+
+    ble_gatts_cl_sup_feat_test_perform_bonding(conn_handle_3);
+    ble_gatts_bonding_restored(conn_handle_3);
+
+    /* Verify Client Supported Features value is persisted for this peer after
+     * reconnection i.e. all features should be enabled. */
+    rc = ble_gatts_peer_cl_sup_feat_get(conn_handle_3, &out_feat, 1);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(out_feat == BLE_GATT_TEST_CLI_SUP_FEAT_ALL_MASK);
+}
+
+TEST_CASE_SELF(ble_gatts_cl_sup_feat_test_reject_disabling_already_enabled)
+{
+    uint16_t conn_handle = 1;
+    uint16_t new_conn_handle = 2;
+    uint8_t out_feat = 0;
+    int rc;
+
+    ble_gatts_cl_sup_feat_test_misc_init(&conn_handle, 0);
+
+    ble_gatts_cl_sup_feat_test_perform_bonding(conn_handle);
+    ble_gatts_bonding_established(conn_handle);
+
+    /* Peer with trusted relationship enables EATT and MULT NTF in Client
+     * Supported Features Characteristic */
+    ble_gatts_cl_sup_feat_test_chr_val[0] =
+        BLE_GATT_TEST_CLI_SUP_FEAT_EATT_MULT_NTF_MASK;
+    ble_hs_test_util_rx_att_write_req(
+        conn_handle, ble_gatts_cl_sup_feat_test_chr_val_handle,
+        ble_gatts_cl_sup_feat_test_chr_val, BLE_GATT_TEST_CL_SUP_FEAT_CHR_SZ);
+
+    ble_hs_test_util_conn_disconnect(conn_handle);
+    ble_hs_test_util_create_conn(new_conn_handle,
+                                 ble_gatts_cl_sup_feat_test_peer_addr, NULL, NULL);
+
+    ble_gatts_cl_sup_feat_test_perform_bonding(new_conn_handle);
+    ble_gatts_bonding_restored(new_conn_handle);
+
+    /* Attempt to disable EATT feature */
+    ble_gatts_cl_sup_feat_test_chr_val[0] = BLE_GATT_TEST_CLI_SUP_FEAT_MULT_NTF_BIT;
+    ble_hs_test_util_rx_att_write_req(
+        new_conn_handle, ble_gatts_cl_sup_feat_test_chr_val_handle,
+        ble_gatts_cl_sup_feat_test_chr_val, BLE_GATT_TEST_CL_SUP_FEAT_CHR_SZ);
+
+    /* Verify original features from storage weren't overwritten */
+    rc = ble_gatts_peer_cl_sup_feat_get(new_conn_handle, &out_feat, 1);
+    TEST_ASSERT(rc == 0);
+    TEST_ASSERT(out_feat == BLE_GATT_TEST_CLI_SUP_FEAT_EATT_MULT_NTF_MASK);
+}
+
+TEST_SUITE(ble_gatts_cl_sup_feat_suite)
+{
+    ble_gatts_cl_sup_feat_test_bond_then_write();
+    ble_gatts_cl_sup_feat_test_write_then_bond();
+    ble_gatts_cl_sup_feat_test_unbonded_no_persist();
+    ble_gatts_cl_sup_feat_test_enable_new_feature_across_sessions();
+    ble_gatts_cl_sup_feat_test_reject_disabling_already_enabled();
+}

--- a/nimble/host/test/src/ble_hs_test.c
+++ b/nimble/host/test/src/ble_hs_test.c
@@ -76,6 +76,7 @@ main(int argc, char **argv)
     ble_sm_sc_test_suite();
     ble_store_suite();
     ble_uuid_test_suite();
+    ble_gatts_cl_sup_feat_suite();
 
     return tu_any_failed;
 }

--- a/nimble/host/test/src/ble_hs_test.h
+++ b/nimble/host/test/src/ble_hs_test.h
@@ -58,5 +58,6 @@ TEST_SUITE_DECL(ble_sm_lgcy_test_suite);
 TEST_SUITE_DECL(ble_sm_sc_test_suite);
 TEST_SUITE_DECL(ble_store_suite);
 TEST_SUITE_DECL(ble_uuid_test_suite);
+TEST_SUITE_DECL(ble_gatts_cl_sup_feat_suite);
 
 #endif

--- a/nimble/host/test/src/ble_hs_test_util.c
+++ b/nimble/host/test/src/ble_hs_test_util.c
@@ -1923,6 +1923,9 @@ ble_hs_test_util_store_read(int obj_type, const union ble_store_key *key,
     case BLE_STORE_OBJ_TYPE_CCCD:
         ble_sm_test_store_key.cccd = key->cccd;
         break;
+    case BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT:
+        ble_sm_test_store_key.feat = key->feat;
+        break;
     default:
         return BLE_HS_ENOTSUP;
     }
@@ -1936,6 +1939,9 @@ ble_hs_test_util_store_read(int obj_type, const union ble_store_key *key,
         break;
     case BLE_STORE_OBJ_TYPE_CCCD:
         ble_sm_test_store_value.cccd = value->cccd;
+        break;
+    case BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT:
+        ble_sm_test_store_value.feat = value->feat;
         break;
     default:
         rc = BLE_HS_ENOTSUP;
@@ -1962,6 +1968,9 @@ ble_hs_test_util_store_write(int obj_type, const union ble_store_value *value)
     case BLE_STORE_OBJ_TYPE_CCCD:
         ble_sm_test_store_value.cccd = value->cccd;
         break;
+    case BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT:
+        ble_sm_test_store_value.feat = value->feat;
+        break;
     default:
         rc = BLE_HS_ENOTSUP;
         break;
@@ -1984,6 +1993,9 @@ ble_hs_test_util_store_delete(int obj_type, const union ble_store_key *key)
         break;
     case BLE_STORE_OBJ_TYPE_CCCD:
         ble_sm_test_store_key.cccd = key->cccd;
+        break;
+    case BLE_STORE_OBJ_TYPE_PEER_CL_SUP_FEAT:
+        ble_sm_test_store_key.feat = key->feat;
         break;
     default:
         return BLE_HS_ENOTSUP;


### PR DESCRIPTION
Implements the core mechanism for storing and maintaining Client Supported Features for peers with a trusted relationship. This successfully resolves Host qualification test case GATT/SR/GAS/BV-04-C.

Alongside the core stack changes, storage layer has been extended with a new object type, and a comprehensive unit test suite (ble_gatts_cl_sup_feat_suite) has been added