### PR TITLE
porting/npl/nuttx: fix compile error

### DIFF
--- a/porting/npl/nuttx/src/os_callout.c
+++ b/porting/npl/nuttx/src/os_callout.c
@@ -122,7 +122,7 @@ ble_npl_callout_is_active(struct ble_npl_callout *c)
 int
 ble_npl_callout_inited(struct ble_npl_callout *c)
 {
-    return (c->c_timer != NULL);
+    return (c->c_timer != 0);
 }
 
 ble_npl_error_t


### PR DESCRIPTION
porting/npl/nuttx/src/os_callout.c:125:24: error: comparison between pointer and integer [-Werror]
  125 |     return (c->c_timer != NULL);
      |                        ^~
cc1: all warnings being treated as errors