### PR TITLE
host/store: Fix null pointer dereference

### DIFF
--- a/nimble/host/store/config/src/ble_store_config_conf.c
+++ b/nimble/host/store/config/src/ble_store_config_conf.c
@@ -91,6 +91,11 @@ ble_store_config_conf_set(int argc, char **argv, char *val)
 {
     int rc;
 
+    /* Config returns NULL pointer if it reads an empty string. We change this back into an empty string. */
+    if (!val) {
+        val = "";
+    }
+
     if (argc == 1) {
         if (strcmp(argv[0], "our_sec") == 0) {
             rc = ble_store_config_deserialize_arr(


### PR DESCRIPTION
If config_fcb reads an empty string it returns NULL pointer. We should handle this in ble_store_config module