### PR TITLE
ci: Auto label PR's with needs-ci-approval

### DIFF
--- a/.github/workflows/add_ci_label.yml
+++ b/.github/workflows/add_ci_label.yml
@@ -1,0 +1,94 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Informative CI status
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Get author's effective repo permission: admin|maintain|write|triage|read|none
+            let permission = 'unknown';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                ...context.repo,
+                username: pr.user.login,
+              });
+              permission = data.permission || 'unknown';
+            } catch (e) {
+              permission = 'none';
+              core.warning(`Could not fetch collaborator permission: ${e.status || ''} ${e.message}`);
+            }
+
+            const trusted = ['admin','maintain','write'].includes(permission);
+
+            const info = {
+              number: pr.number,
+              title: pr.title,
+              author: pr.user.login,
+              author_association: pr.author_association,
+              author_permission: permission,
+              trusted_by_permission: trusted,
+              base_repo: pr.base.repo.full_name,
+              head_repo: pr.head.repo.full_name,
+              is_fork: !!pr.head.repo.fork,
+            };
+            core.info('PR author info:\n' + JSON.stringify(info, null, 2));
+
+            // Only add the label if the author does NOT have write-level permission
+            if (!trusted) {
+              const label = 'needs-ci-approval';
+              try {
+                // Ensure the label exists (422 = already exists)
+                try {
+                  await github.request('POST /repos/{owner}/{repo}/labels', {
+                    ...context.repo,
+                    name: label,
+                    color: 'E3650b',
+                  });
+                } catch (e) {
+                  if (e.status !== 422) throw e;
+                }
+
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: context.issue.number,
+                  labels: [label],
+                });
+                core.info(`Added '${label}' to PR #${context.issue.number}`);
+              } catch (e) {
+                core.setFailed(`Failed to label PR: ${e.status || ''} ${e.message}`);
+              }
+            } else {
+              core.info('Author has write-level permission; not adding label.');
+            }


### PR DESCRIPTION
The default GitHub status for PR's workflows might
be misleading as not all jobs were run, but
GitHub still marks checks as passed.
Add a workflow that labels PRs if they
still need jobs to be run.
Skips labeling PR's for users with write privileges.