### PR TITLE
nimble/ll: guard central-only functions

### DIFF
--- a/nimble/controller/include/controller/ble_ll_conn.h
+++ b/nimble/controller/include/controller/ble_ll_conn.h
@@ -468,8 +468,6 @@ int ble_ll_conn_move_anchor(struct ble_ll_conn_sm *connsm, uint16_t offset);
 struct ble_ll_scan_addr_data;
 struct ble_ll_scan_pdu_data;
 
-uint8_t ble_ll_conn_tx_connect_ind_pducb(uint8_t *dptr, void *pducb_arg,
-                                         uint8_t *hdr_byte);
 void ble_ll_conn_prepare_connect_ind(struct ble_ll_conn_sm *connsm,
                                      struct ble_ll_scan_pdu_data *pdu_data,
                                      struct ble_ll_scan_addr_data *addrd,

--- a/nimble/controller/src/ble_ll_conn.c
+++ b/nimble/controller/src/ble_ll_conn.c
@@ -3175,7 +3175,8 @@ ble_ll_conn_prepare_connect_ind(struct ble_ll_conn_sm *connsm,
     pdu_data->hdr_byte = hdr;
 }
 
-uint8_t
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+static uint8_t
 ble_ll_conn_tx_connect_ind_pducb(uint8_t *dptr, void *pducb_arg, uint8_t *hdr_byte)
 {
     struct ble_ll_conn_sm *connsm;
@@ -3209,6 +3210,7 @@ ble_ll_conn_tx_connect_ind_pducb(uint8_t *dptr, void *pducb_arg, uint8_t *hdr_by
 
     return 34;
 }
+#endif
 
 /**
  * Called when a schedule item overlaps the currently running connection

--- a/nimble/controller/src/ble_ll_conn_hci.c
+++ b/nimble/controller/src/ble_ll_conn_hci.c
@@ -42,7 +42,6 @@
  * event to the host. This is the os time at which we can send an event.
  */
 static ble_npl_time_t g_ble_ll_last_num_comp_pkt_evt;
-extern uint8_t *g_ble_ll_conn_comp_ev;
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 static const uint8_t ble_ll_conn_create_valid_phy_mask = (
@@ -62,6 +61,9 @@ static const uint8_t ble_ll_conn_create_required_phy_mask = (
 #endif
         0);
 #endif
+
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
+extern uint8_t *g_ble_ll_conn_comp_ev;
 
 /**
  * Allocate an event to send a connection complete event when initiating
@@ -87,6 +89,7 @@ ble_ll_init_alloc_conn_comp_ev(void)
 
     return rc;
 }
+#endif
 
 /**
  * Called to check that the connection parameters are within range
@@ -468,6 +471,7 @@ ble_ll_conn_hci_create_check_scan(struct ble_ll_conn_create_scan *p)
     return 0;
 }
 
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 static int
 ble_ll_conn_hci_create_check_params(struct ble_ll_conn_create_params *cc_params)
 {
@@ -640,6 +644,7 @@ ble_ll_conn_hci_create(const uint8_t *cmdbuf, uint8_t len)
 
     return rc;
 }
+#endif
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
 static void
@@ -663,6 +668,7 @@ ble_ll_conn_hci_ext_create_set_fb_params(uint8_t init_phy_mask,
 #endif
 }
 
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 static int
 ble_ll_conn_hci_ext_create_parse_params(const struct conn_params *params,
                                         uint8_t phy,
@@ -867,6 +873,7 @@ ble_ll_conn_hci_ext_create(const uint8_t *cmdbuf, uint8_t len)
 
     return rc;
 }
+#endif
 #endif
 
 static int
@@ -1265,6 +1272,7 @@ done:
     return rc;
 }
 
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 /* this is called from same context after cmd complete is send so it is
  * safe to use g_ble_ll_conn_comp_ev
  */
@@ -1318,6 +1326,7 @@ ble_ll_conn_create_cancel(void)
 
     return rc;
 }
+#endif
 
 /**
  * Called to process a HCI disconnect command

--- a/nimble/controller/src/ble_ll_conn_priv.h
+++ b/nimble/controller/src/ble_ll_conn_priv.h
@@ -197,14 +197,21 @@ void ble_ll_disconn_comp_event_send(struct ble_ll_conn_sm *connsm,
 void ble_ll_auth_pyld_tmo_event_send(struct ble_ll_conn_sm *connsm);
 int ble_ll_conn_hci_disconnect_cmd(const struct ble_hci_lc_disconnect_cp *cmd);
 int ble_ll_conn_hci_rd_rem_ver_cmd(const uint8_t *cmdbuf, uint8_t len);
+
+#if MYNEWT_VAL(BLE_LL_ROLE_CENTRAL)
 int ble_ll_conn_hci_create(const uint8_t *cmdbuf, uint8_t len);
+int ble_ll_conn_create_cancel(void);
+#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
+int ble_ll_conn_hci_ext_create(const uint8_t *cmdbuf, uint8_t len);
+#endif
+#endif
+
 int ble_ll_conn_hci_update(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_conn_hci_set_chan_class(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_conn_hci_param_rr(const uint8_t *cmdbuf, uint8_t len,
                              uint8_t *rspbuf, uint8_t *rsplen);
 int ble_ll_conn_hci_param_nrr(const uint8_t *cmdbuf, uint8_t len,
                              uint8_t *rspbuf, uint8_t *rsplen);
-int ble_ll_conn_create_cancel(void);
 void ble_ll_conn_num_comp_pkts_event_send(struct ble_ll_conn_sm *connsm);
 void ble_ll_conn_comp_event_send(struct ble_ll_conn_sm *connsm, uint8_t status,
                                  uint8_t *evbuf, struct ble_ll_adv_sm *advsm);
@@ -267,9 +274,6 @@ int ble_ll_conn_hci_le_rd_phy(const uint8_t *cmdbuf, uint8_t len,
                               uint8_t *rsp, uint8_t *rsplen);
 int ble_ll_conn_hci_le_set_phy(const uint8_t *cmdbuf, uint8_t len);
 int ble_ll_conn_phy_update_if_needed(struct ble_ll_conn_sm *connsm);
-#if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_EXT_ADV)
-int ble_ll_conn_hci_ext_create(const uint8_t *cmdbuf, uint8_t len);
-#endif
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LL_PERIODIC_ADV_SYNC_TRANSFER)
 int ble_ll_set_sync_transfer_params(const uint8_t *cmdbuf, uint8_t len,


### PR DESCRIPTION
**Changes**

- `ble_ll_conn_tx_connect_ind_pducb` is now declared static, as it is only used within ble_ll_conn.c.

The following declarations/definitions are now guarded with `BLE_LL_ROLE_CENTRAL`:

- `g_ble_ll_conn_comp_ev`: its declaration in ble_ll_conn.c is already under `BLE_LL_ROLE_CENTRAL`, so its usage in ble_ll_conn_hci.c is now guarded as well.
- `ble_ll_conn_hci_create`: its only usage (in ble_ll_hci.c) is already guarded.
- `ble_ll_conn_hci_ext_create`: same as above.
- `ble_ll_conn_create_cancel`: same reasoning.

**Rationale**

We recently migrated our codebase to Keil MDK (Armlink), which performs garbage collection after symbol resolution. Due to that difference in link-order behavior, a few unresolved symbols appear when building this project. While I understand this repository does not officially target this toolchain, these changes resolve the linking issues for our setup and also align the guards more consistently across the codebase.

(For context: we are using only the PERIPHERAL role at the moment; other configurations with Keil MDK haven't been tested.)