### PR TITLE
host/sm: Reject Legacy pairing confirm reflection attack

### DIFF
--- a/nimble/host/src/ble_sm_lgcy.c
+++ b/nimble/host/src/ble_sm_lgcy.c
@@ -215,6 +215,18 @@ ble_sm_lgcy_random_rx(struct ble_sm_proc *proc, struct ble_sm_result *res)
 
     ble_sm_ia_ra(proc, &iat, ia, &rat, ra);
 
+    /* If the peer echoed our own random back (Srand == Mrand), the c1 check
+     * would trivially pass because the peer also mirrored Mconfirm.
+     * Reject this immediately with Confirm Value Failed.
+     */
+    if ((proc->flags & BLE_SM_PROC_F_INITIATOR) &&
+        memcmp(ble_sm_peer_pair_rand(proc), ble_sm_our_pair_rand(proc), 16) == 0) {
+        res->app_status = BLE_HS_SM_US_ERR(BLE_SM_ERR_CONFIRM_MISMATCH);
+        res->sm_err = BLE_SM_ERR_CONFIRM_MISMATCH;
+        res->enc_cb = 1;
+        return;
+    }
+
     rc = ble_sm_alg_c1(proc->tk, ble_sm_peer_pair_rand(proc), proc->pair_req,
                        proc->pair_rsp, iat, rat, ia, ra, confirm_val);
     if (rc != 0) {


### PR DESCRIPTION
When the responder mirrors the initiator's confirm and random values
(Sconfirm=Mconfirm, Srand=Mrand), the c1 check passes trivially,
bypassing mismatch detection and causing an
HCI encryption failure (0x06) instead of Pairing Failed (0x04).

Detect Srand==Mrand in ble_sm_lgcy_random_rx and abort
with BLE_SM_ERR_CONFIRM_MISMATCH.

Fixes SM/CEN/JW/BI-06-C and SM/CEN/PKE/BI-03-C