### PR TITLE
host: Fix recursive lock in ble_hs_stop_done

### DIFF
--- a/nimble/host/src/ble_hs_stop.c
+++ b/nimble/host/src/ble_hs_stop.c
@@ -69,17 +69,20 @@ ble_hs_stop_done(int status)
 
     ble_hs_enabled_state = BLE_HS_ENABLED_STATE_OFF;
 
+    ble_hs_unlock();
+
     ble_hs_stop_hci_reset();
 
-    /* Clear advertising, scanning and connection states. */
+    /* Clear advertising, scanning and connection states.
+     * Called outside the lock because ble_gap_reset_state() acquires
+     * it internally (via ble_gap_conn_broken, ble_hs_atomic_*, etc).
+     */
     ble_gap_reset_state(0);
 
     /* After LL reset the controller loses its random address */
     ble_hs_id_reset();
 
     ble_hs_pvcy_reset();
-
-    ble_hs_unlock();
 
     SLIST_FOREACH(listener, &slist, link) {
         listener->fn(status, listener->arg);


### PR DESCRIPTION
ble_hs_stop_done() held ble_hs_lock while calling ble_gap_reset_state() which internally acquires the same lock via ble_hs_atomic_first_conn_handle() and ble_gap_conn_broken(). On platforms with non-recursive mutexes this causes a deadlock or assertion failure.

Move ble_hs_stop_hci_reset(), ble_gap_reset_state(), ble_hs_id_reset(), and ble_hs_pvcy_reset() outside the locked section. These functions either manage their own locking internally or don't need the lock. ble_hs_enabled_state is set to OFF under the lock before releasing, preventing new operations.