### PR TITLE
host/gap: Handle BLE_GAP_OP_NULL in ble_gap_master_failed

### DIFF
--- a/nimble/host/src/ble_gap.c
+++ b/nimble/host/src/ble_gap.c
@@ -1198,6 +1198,9 @@ static void
 ble_gap_master_failed(int status)
 {
     switch (ble_gap_master.op) {
+    case BLE_GAP_OP_NULL:
+        break;
+
 #if NIMBLE_BLE_CONNECT
     case BLE_GAP_OP_M_CONN:
         STATS_INC(ble_gap_stats, initiate_fail);


### PR DESCRIPTION
ble_gap_reset_state() calls ble_gap_master_failed() unconditionally. When no master procedure is active (op == BLE_GAP_OP_NULL), this hits an unconditional BLE_HS_DBG_ASSERT(0) in the default case.

This happens when the host is stopped while no scanning or connection is in progress.

Add an explicit case for BLE_GAP_OP_NULL that does nothing.