### PR TITLE
ci: Add clang style specific file ignore config

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,3 @@
+# Skip those directories while doing style checks in the CI.
+
+ext/tinycrypt

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -8,7 +8,7 @@ RELEASE_NOTES.md
 Doxyfile
 .clang-format
 .mailmap
-.style_ignored_dirs
+.clang-format-ignore
 **/requirements.txt
 
 # Ignore documentation folder

--- a/.style_ignored_dirs
+++ b/.style_ignored_dirs
@@ -1,4 +1,0 @@
-# Skip those directories while doing style checks in the CI. Do not add '/' at
-# the beginning!
-
-ext/tinycrypt


### PR DESCRIPTION
Delete deprecated directory ignore configuration.
Introduce clang specific file providing the same functionality.