### PR TITLE
nimble/host: Initialize att_len in ble_att_svr_service_uuid

### DIFF
--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -1821,7 +1821,7 @@ ble_att_svr_service_uuid(struct ble_att_svr_entry *entry,
                          ble_uuid_any_t *uuid, uint8_t *out_att_err)
 {
     uint8_t val[16];
-    uint16_t attr_len;
+    uint16_t attr_len = 0;
     int rc;
 
     rc = ble_att_svr_read_flat(BLE_HS_CONN_HANDLE_NONE, entry, 0, sizeof(val), val,


### PR DESCRIPTION
This is false positive as apparently some compilers doesn't handle rc and attr_len correlation correctly.

In function 'ble_att_svr_service_uuid',
    inlined from 'ble_att_svr_build_read_group_type_rsp' at nimble/mynewt-nimble/nimble/host/src/ble_att_svr.c:1956:22,
    inlined from 'ble_att_svr_rx_read_group_type' at nimble/mynewt-nimble/nimble/host/src/ble_att_svr.c:2101:10:
nimble/mynewt-nimble/nimble/host/src/ble_att_svr.c:1833:10: warning: 'attr_len' may be used uninitialized [-Wmaybe-uninitialized]
 1833 |     rc = ble_uuid_init_from_buf(uuid, val, attr_len);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
nimble/mynewt-nimble/nimble/host/src/ble_att_svr.c: In function 'ble_att_svr_rx_read_group_type':
nimble/mynewt-nimble/nimble/host/src/ble_att_svr.c:1824:14: note: 'attr_len' was declared here
 1824 |     uint16_t attr_len;