### PR TITLE
host: reset privacy state when resetting

### DIFF
--- a/nimble/host/src/ble_hs.c
+++ b/nimble/host/src/ble_hs.c
@@ -375,6 +375,9 @@ ble_hs_reset(void)
     /* Clear configured addresses. */
     ble_hs_id_reset();
 
+    /* Drop cached privacy state so sync re-runs the full setup. */
+    ble_hs_pvcy_reset();
+
     if (ble_hs_cfg.reset_cb != NULL && ble_hs_reset_reason != 0) {
         ble_hs_cfg.reset_cb(ble_hs_reset_reason);
     }


### PR DESCRIPTION
Without this fix, ble_hs_reset() left the privacy module's cached IRK and started flag intact, so the next ble_hs_sync()'s call to ble_hs_pvcy_set_our_irk() short-circuited on the unchanged IRK and skipped re-enabling resolution plus rebuilding the resolving list. The controller had cleared both on its side, so RPA-based reconnects after a host reset came in unresolved and the host couldn't match them to bonded peers.

Mirror what ble_hs_stop() already does and call ble_hs_pvcy_reset() from ble_hs_reset() so the next set_our_irk() does the full clear/enable/add sequence, matching the first-boot path.