### PR TITLE
ci: Use mcuboot from main branch for unittests

### DIFF
--- a/.github/workflows/newt_test_all.yml
+++ b/.github/workflows/newt_test_all.yml
@@ -55,6 +55,13 @@ jobs:
              rm -rf repos/apache-mynewt-nimble
              git clone .. repos/apache-mynewt-nimble
              cd ..
+      - name: Switch to main mcuboot
+        # This is temporary until next mcuboot release is available
+        shell: bash
+        run: |
+             cd build/repos/mcuboot
+             git fetch origin main:main
+             git checkout main
       - name: newt test all
         shell: bash
         run: |


### PR DESCRIPTION
This is temporary solution until next mcuboot release which will contain required fix.