### PR TITLE
nimble: Add BLE version 6.2 and 6.3 definitions

### DIFF
--- a/nimble/include/nimble/hci_common.h
+++ b/nimble/include/nimble/hci_common.h
@@ -2380,6 +2380,8 @@ struct ble_hci_ev_le_subev_cs_test_end_complete {
 #define BLE_HCI_VER_BCS_5_4                 (13)
 #define BLE_HCI_VER_BCS_6_0                 (14)
 #define BLE_HCI_VER_BCS_6_1                 (15)
+#define BLE_HCI_VER_BCS_6_2                 (16)
+#define BLE_HCI_VER_BCS_6_3                 (17)
 
 #define BLE_LMP_VER_BCS_1_0b                (0)
 #define BLE_LMP_VER_BCS_1_1                 (1)
@@ -2397,6 +2399,8 @@ struct ble_hci_ev_le_subev_cs_test_end_complete {
 #define BLE_LMP_VER_BCS_5_4                 (13)
 #define BLE_LMP_VER_BCS_6_0                 (14)
 #define BLE_LMP_VER_BCS_6_1                 (15)
+#define BLE_LMP_VER_BCS_6_2                 (16)
+#define BLE_LMP_VER_BCS_6_3                 (17)
 
 /* selected HCI and LMP version */
 #if MYNEWT_VAL(BLE_VERSION) == 50
@@ -2420,6 +2424,12 @@ struct ble_hci_ev_le_subev_cs_test_end_complete {
 #elif MYNEWT_VAL(BLE_VERSION) == 61
 #define BLE_HCI_VER_BCS BLE_HCI_VER_BCS_6_1
 #define BLE_LMP_VER_BCS BLE_LMP_VER_BCS_6_1
+#elif MYNEWT_VAL(BLE_VERSION) == 62
+#define BLE_HCI_VER_BCS BLE_HCI_VER_BCS_6_2
+#define BLE_LMP_VER_BCS BLE_LMP_VER_BCS_6_2
+#elif MYNEWT_VAL(BLE_VERSION) == 63
+#define BLE_HCI_VER_BCS BLE_HCI_VER_BCS_6_3
+#define BLE_LMP_VER_BCS BLE_LMP_VER_BCS_6_3
 #else
 #error Unsupported BLE_VERSION selected
 #endif

--- a/nimble/syscfg.yml
+++ b/nimble/syscfg.yml
@@ -87,7 +87,7 @@ syscfg.defs:
             This allows to configure supported Bluetooth Core version. Some
             features may not be available if version is too low. Version is
             integer for easy comparison.
-        range: 50, 51, 52, 53, 54, 60, 61
+        range: 50, 51, 52, 53, 54, 60, 61, 62, 63
         value: 50
     BLE_ISO:
         description: >


### PR DESCRIPTION
Updates the system configuration with Bluetooth versions 6.2 and 6.3.

Wires up the corresponding Host Controller Interface (HCI) and Link Manager Protocol (LMP) version definitions required for these newer specifications.