### PR TITLE
nimble/transport: Fix Nuttx socket build

### DIFF
--- a/nimble/transport/socket/src/ble_hci_socket.c
+++ b/nimble/transport/socket/src/ble_hci_socket.c
@@ -318,7 +318,7 @@ ble_hci_sock_cmdevt_tx(uint8_t *hci_ev, uint8_t h4_type)
 }
 #endif
 
-#if MYNEWT_VAL_CHOICE(BLE_SOCK_TYPE, linux_nuttx)
+#if MYNEWT_VAL_CHOICE(BLE_SOCK_TYPE, nuttx)
 static int
 ble_hci_sock_acl_tx(struct os_mbuf *om)
 {
@@ -725,7 +725,7 @@ err:
 }
 #endif
 
-#if MYNEWT_VAL_CHOICE(BLE_SOCK_TYPE, linux_nuttx)
+#if MYNEWT_VAL_CHOICE(BLE_SOCK_TYPE, nuttx)
 static int
 ble_hci_sock_config(void)
 {


### PR DESCRIPTION
There was a typo in MYNEWT_VAL_CHOICE name when buidling for NuttX.