### PR TITLE
apps/bttester: Fix BTP event data truncation in GATT Read Long response

### DIFF
--- a/apps/bttester/src/btp_gatt_cl.c
+++ b/apps/bttester/src/btp_gatt_cl.c
@@ -942,10 +942,10 @@ read_long_cb(uint16_t conn_handle,
              struct ble_gatt_attr *attr,
              void *arg)
 {
-    struct btp_gattc_read_rp *rp;
+    struct btp_gattc_read_rp *rp = NULL;
     uint8_t opcode = (uint8_t)(int)arg;
-    struct os_mbuf *buf = os_msys_get(0, 0);
     struct ble_gap_conn_desc conn;
+    uint16_t len;
     int rc = 0;
     uint8_t err = 0;
 
@@ -965,7 +965,8 @@ read_long_cb(uint16_t conn_handle,
         goto free;
     }
 
-    rp = os_mbuf_extend(buf, sizeof(*rp));
+    len = sizeof(*rp) + (error->status == BLE_HS_EDONE ? gatt_buf.len : 0);
+    rp = malloc(len);
     if (!rp) {
         rc = BLE_HS_ENOMEM;
         goto free;
@@ -977,8 +978,7 @@ read_long_cb(uint16_t conn_handle,
 
     if (error->status != 0 && error->status != BLE_HS_EDONE) {
         rp->data_length = 0;
-        tester_event(BTP_SERVICE_ID_GATTC, opcode,
-                     buf->om_data, buf->om_len);
+        tester_event(BTP_SERVICE_ID_GATTC, opcode, rp, sizeof(*rp));
         read_destroy();
         goto free;
     }
@@ -986,9 +986,10 @@ read_long_cb(uint16_t conn_handle,
     if (error->status == BLE_HS_EDONE) {
         rp->status = 0;
         rp->data_length = gatt_buf.len;
-        os_mbuf_append(buf, gatt_buf.buf, gatt_buf.len);
-        tester_event(BTP_SERVICE_ID_GATTC, opcode,
-                     buf->om_data, buf->om_len);
+        if (gatt_buf.len > 0) {
+            memcpy(rp->data, gatt_buf.buf, gatt_buf.len);
+        }
+        tester_event(BTP_SERVICE_ID_GATTC, opcode, rp, len);
         read_destroy();
         goto free;
     }
@@ -1002,7 +1003,7 @@ read_long_cb(uint16_t conn_handle,
     rp->data_length += attr->om->om_len;
 
 free:
-    os_mbuf_free_chain(buf);
+    free(rp);
     return rc;
 }
 


### PR DESCRIPTION
Fixes an issue where large GATT Read Long response (e.g. 512 bytes) was truncated in tester_event causing the GATT/CL/GAR/BV-04-C qualification test case to fail. This was caused by passing buf->om_data and buf->om_len to tester_event. The data exceeding single memory chain buffer was left ignored in next mbuf in the list (buf->om_next).