### PR TITLE
host: document GATT error status encoding

### DIFF
--- a/nimble/host/include/host/ble_gatt.h
+++ b/nimble/host/include/host/ble_gatt.h
@@ -204,7 +204,12 @@ struct ble_hs_cfg;
 /*** @client. */
 /** Represents a GATT error. */
 struct ble_gatt_error {
-    /** The GATT status code indicating the type of error. */
+    /**
+     * The NimBLE host status code indicating the type of error.
+     *
+     * Values follow the NimBLE host return-code convention; see:
+     * https://mynewt.apache.org/latest/network/ble_hs/ble_hs_return_codes.html
+     */
     uint16_t status;
 
     /** The attribute handle associated with the error. */


### PR DESCRIPTION
## Summary

- Clarify that `ble_gatt_error.status` is a NimBLE host status code.
- Link the NimBLE host return-code documentation from `struct ble_gatt_error`.

Closes #1827

## Testing

- `git diff --check origin/master...HEAD`
- The tree-identical previous head passed coding style, licensing, Doxygen style, unit tests, app and port builds, GCC target builds, and test-target builds on Ubuntu, Windows, and macOS.
- The current head only rewrites commit metadata to satisfy the 72-character commit-message rule and correct Old-Ding attribution. PR-target checks pass; the fork `pull_request` workflows are waiting for maintainer approval (`action_required`, no jobs).