### PR TITLE
apps/bttester: Fix null pointer dereference

### DIFF
--- a/apps/bttester/src/bttester.c
+++ b/apps/bttester/src/bttester.c
@@ -352,10 +352,10 @@ tester_rsp_full(uint8_t service, uint8_t opcode, const void *rsp, size_t len)
     cmd = delayed_cmd;
     delayed_cmd = NULL;
 
-    (void)memset(cmd, 0, sizeof(*cmd));
+    (void)memset(cmd->data, 0, sizeof(cmd->data));
+    (void)memset(cmd->rsp, 0, sizeof(cmd->rsp));
 
-    os_eventq_put(&avail_queue,
-                  CONTAINER_OF(cmd, struct btp_buf, data)->ev);
+    os_eventq_put(&avail_queue, cmd->ev);
 }
 
 void
@@ -371,9 +371,10 @@ tester_rsp(uint8_t service, uint8_t opcode, uint8_t status)
     cmd = delayed_cmd;
     delayed_cmd = NULL;
 
-    (void)memset(cmd, 0, sizeof(*cmd));
-    os_eventq_put(&avail_queue,
-                  CONTAINER_OF(cmd, struct btp_buf, data)->ev);
+    (void)memset(cmd->data, 0, sizeof(cmd->data));
+    (void)memset(cmd->rsp, 0, sizeof(cmd->rsp));
+
+    os_eventq_put(&avail_queue, cmd->ev);
 }
 
 uint16_t


### PR DESCRIPTION
The 'cmd' is a pointer to struct btp_buf, not a flat buffer. The 'ev' field of the 'struct btp_buf' is initiated only once, in the avail_queue_init(void) function, so the 'struct btp_buf' instance cannot be completely zeroed out when restoring to 'avail_queue'.