### PR TITLE
nimble/audio: Add explicit init for LE Audio common code

### DIFF
--- a/nimble/host/audio/pkg.yml
+++ b/nimble/host/audio/pkg.yml
@@ -37,6 +37,9 @@ pkg.deps.BLE_AUDIO_BROADCAST_SINK:
 pkg.deps.BLE_AUDIO_SCAN_DELEGATOR:
     - nimble/host/audio/services/bass
 
+pkg.init:
+    ble_audio_init: 'MYNEWT_VAL(BLE_AUDIO_SYSINIT_STAGE)'
+
 pkg.init.BLE_AUDIO_BROADCAST_SINK:
     ble_audio_broadcast_sink_init: 'MYNEWT_VAL(BLE_AUDIO_BROADCAST_SINK_SYSINIT_STAGE)'
 

--- a/nimble/host/audio/src/ble_audio.c
+++ b/nimble/host/audio/src/ble_audio.c
@@ -26,8 +26,7 @@
 #include "ble_audio_priv.h"
 
 static struct ble_gap_event_listener ble_audio_gap_event_listener;
-static SLIST_HEAD(, ble_audio_event_listener) ble_audio_event_listener_list =
-    SLIST_HEAD_INITIALIZER(ble_audio_event_listener_list);
+static SLIST_HEAD(, ble_audio_event_listener) ble_audio_event_listener_list;
 
 struct ble_audio_adv_parse_broadcast_announcement_data {
     struct ble_audio_event event;
@@ -526,4 +525,10 @@ ble_audio_base_bis_iter(struct ble_audio_base_iter *bis_iter,
     }
 
     return 0;
+}
+
+void
+ble_audio_init(void)
+{
+    SLIST_INIT(&ble_audio_event_listener_list);
 }

--- a/nimble/host/audio/syscfg.yml
+++ b/nimble/host/audio/syscfg.yml
@@ -35,6 +35,11 @@ syscfg.defs:
             This option enables BLE Audio Scan Delegator support.
         value: 0
 
+    BLE_AUDIO_SYSINIT_STAGE:
+        description: >
+            Primary sysinit stage for BLE Audio.
+        value: 300
+
 syscfg.defs.BLE_AUDIO_BROADCAST_SINK:
     BLE_AUDIO_BROADCAST_SINK_SYSINIT_STAGE:
         description: >


### PR DESCRIPTION
This allows to properly unit test code.