### PR TITLE
nimble/host: add Client Supported Features bit masks

### DIFF
--- a/nimble/host/services/gatt/include/services/gatt/ble_svc_gatt.h
+++ b/nimble/host/services/gatt/include/services/gatt/ble_svc_gatt.h
@@ -32,6 +32,11 @@ struct ble_hs_cfg;
 #define BLE_SVC_GATT_CHR_SERVER_SUPPORTED_FEAT_UUID16   0x2b3a
 #define BLE_SVC_GATT_CHR_CLIENT_SUPPORTED_FEAT_UUID16   0x2b29
 
+/* Client Supported Features masks */
+#define BLE_GATT_CLI_SUP_FEAT_ROBUST_CACHING_MASK 0x01
+#define BLE_GATT_CLI_SUP_FEAT_EATT_MASK           0x02
+#define BLE_GATT_CLI_SUP_FEAT_MULT_NTF_MASK       0x04
+
 uint8_t ble_svc_gatt_get_local_cl_supported_feat(void);
 void ble_svc_gatt_changed(uint16_t start_handle, uint16_t end_handle);
 void ble_svc_gatt_init(void);

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -60,6 +60,7 @@
 #include "host/ble_uuid.h"
 #include "host/ble_gap.h"
 #include "ble_hs_priv.h"
+#include "../services/gatt/include/services/gatt/ble_svc_gatt.h"
 
 #if NIMBLE_BLE_CONNECT
 
@@ -4461,7 +4462,7 @@ ble_gatts_notify_multiple_custom(uint16_t conn_handle,
         goto err;
     }
 
-    if ((supported & 0x04) == 0) {
+    if ((supported & BLE_GATT_CLI_SUP_FEAT_MULT_NTF_MASK) == 0) {
         rc = BLE_HS_EREJECT;
         goto err;
     }


### PR DESCRIPTION
Define possible bit masks for GATT Client Supported Features characteristic value to get rid of magic numbers.