### PR TITLE
ci: Fix workflow check action

### DIFF
--- a/.github/workflows/check_workflows.yml
+++ b/.github/workflows/check_workflows.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr_branch
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Check for label override
         id: label_check


### PR DESCRIPTION
Github started blocking PR code checkouts on pull_request_target. However, since this action only compares PR code and not actually run any code from there it is safe to bypass this restriction.