### PR TITLE
apps/bttester: Remove a leftover/broken implementation

### DIFF
--- a/apps/bttester/src/btp_gatt.c
+++ b/apps/bttester/src/btp_gatt.c
@@ -1059,12 +1059,6 @@ fail:
     return BTP_STATUS_FAILED;
 }
 
-static struct bt_gatt_subscribe_params {
-    uint16_t ccc_handle;
-    uint16_t value;
-    uint16_t value_handle;
-} subscribe_params;
-
 static uint8_t
 read_uuid(const void *cmd, uint16_t cmd_len,
           void *rsp, uint16_t *rsp_len)
@@ -1594,8 +1588,6 @@ enable_subscription(uint16_t conn_handle, uint16_t ccc_handle,
         return -EINVAL;
     }
 
-    subscribe_params.ccc_handle = value;
-
     tester_rsp(BTP_SERVICE_ID_GATT, op, BTP_STATUS_SUCCESS);
     return 0;
 }
@@ -1607,18 +1599,11 @@ disable_subscription(uint16_t conn_handle, uint16_t ccc_handle)
 
     SYS_LOG_DBG("");
 
-    /* Fail if CCC handle doesn't match */
-    if (ccc_handle != subscribe_params.ccc_handle) {
-        SYS_LOG_ERR("CCC handle doesn't match");
-        return -EINVAL;
-    }
-
     if (ble_gattc_write_no_rsp_flat(conn_handle, ccc_handle,
                                     &value, sizeof(value))) {
         return -EINVAL;
     }
 
-    subscribe_params.ccc_handle = 0;
     return 0;
 }
 
@@ -2147,10 +2132,6 @@ tester_gatt_notify_rx_ev(uint16_t conn_handle, uint16_t attr_handle,
 
     SYS_LOG_DBG("");
 
-    if (!subscribe_params.ccc_handle) {
-        goto fail;
-    }
-
     if (ble_gap_conn_find(conn_handle, &conn)) {
         goto fail;
     }
@@ -2190,7 +2171,6 @@ tester_gatt_subscribe_ev(uint16_t conn_handle,
 
     if (cur_notify == 0 && cur_indicate == 0) {
         SYS_LOG_INF("Unsubscribed");
-        memset(&subscribe_params, 0, sizeof(subscribe_params));
         return 0;
     }
 

--- a/apps/bttester/src/btp_gatt_cl.c
+++ b/apps/bttester/src/btp_gatt_cl.c
@@ -66,11 +66,6 @@ static struct {
     uint8_t buf[MAX_BUFFER_SIZE];
     uint16_t cnt;
 } gatt_buf;
-static struct bt_gatt_subscribe_params {
-    uint16_t ccc_handle;
-    uint16_t value;
-    uint16_t value_handle;
-} subscribe_params;
 
 static void *
 gatt_buf_add(const void *data, size_t len)
@@ -1259,8 +1254,6 @@ enable_subscription(uint16_t conn_handle, uint16_t ccc_handle,
         return -EINVAL;
     }
 
-    subscribe_params.ccc_handle = value;
-
     return 0;
 }
 
@@ -1275,12 +1268,6 @@ disable_subscription(uint16_t conn_handle, uint16_t ccc_handle)
     opcode = (uint32_t) (value == 0x0001 ? BTP_GATTC_CFG_NOTIFY_RP
                                          : BTP_GATTC_CFG_INDICATE_RP);
 
-    /* Fail if CCC handle doesn't match */
-    if (ccc_handle != subscribe_params.ccc_handle) {
-        SYS_LOG_ERR("CCC handle doesn't match");
-        return -EINVAL;
-    }
-
     if (ble_gattc_write_flat(conn_handle,
                              ccc_handle,
                              &value,
@@ -1290,7 +1277,6 @@ disable_subscription(uint16_t conn_handle, uint16_t ccc_handle)
         return -EINVAL;
     }
 
-    subscribe_params.ccc_handle = 0;
     return 0;
 }
 
@@ -1457,10 +1443,6 @@ tester_gattc_notify_rx_ev(uint16_t conn_handle, uint16_t attr_handle,
     struct os_mbuf *buf = os_msys_get(0, 0);
 
     SYS_LOG_DBG("");
-
-    if (!subscribe_params.ccc_handle) {
-        goto fail;
-    }
 
     if (ble_gap_conn_find(conn_handle, &conn)) {
         goto fail;


### PR DESCRIPTION
It seems that the ccc_handle was intended to store the handle of the most recently updated CCC descriptor, however the field was overwritten with the descriptor value instead, so the unsubscription was failing. Apart from that in the RAP profile test cases there are multiple subsequent subscriptions and unsubscriptions, so the storing and the checks would be an obstacle.