### PR TITLE
nimble/host: Add Read Multiple Var Len timeout callback

### DIFF
--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -320,6 +320,7 @@ static ble_gattc_tmo_fn ble_gattc_read_tmo;
 static ble_gattc_tmo_fn ble_gattc_read_uuid_tmo;
 static ble_gattc_tmo_fn ble_gattc_read_long_tmo;
 static ble_gattc_tmo_fn ble_gattc_read_mult_tmo;
+static ble_gattc_tmo_fn ble_gattc_read_mult_var_tmo;
 static ble_gattc_tmo_fn ble_gattc_write_tmo;
 static ble_gattc_tmo_fn ble_gattc_write_long_tmo;
 static ble_gattc_tmo_fn ble_gattc_write_reliable_tmo;
@@ -338,6 +339,7 @@ ble_gattc_tmo_dispatch[BLE_GATT_OP_CNT] = {
     [BLE_GATT_OP_READ_UUID]         = ble_gattc_read_uuid_tmo,
     [BLE_GATT_OP_READ_LONG]         = ble_gattc_read_long_tmo,
     [BLE_GATT_OP_READ_MULT]         = ble_gattc_read_mult_tmo,
+    [BLE_GATT_OP_READ_MULT_VAR]     = ble_gattc_read_mult_var_tmo,
     [BLE_GATT_OP_WRITE]             = ble_gattc_write_tmo,
     [BLE_GATT_OP_WRITE_LONG]        = ble_gattc_write_long_tmo,
     [BLE_GATT_OP_WRITE_RELIABLE]    = ble_gattc_write_reliable_tmo,
@@ -3503,6 +3505,15 @@ ble_gattc_read_mult_var_err(struct ble_gattc_proc *proc, int status,
 {
     ble_gattc_dbg_assert_proc_not_inserted(proc);
     ble_gattc_read_mult_cb_var(proc, status, att_handle, NULL);
+}
+
+static void
+ble_gattc_read_mult_var_tmo(struct ble_gattc_proc *proc)
+{
+    BLE_HS_DBG_ASSERT(!ble_hs_locked_by_cur_task());
+    ble_gattc_dbg_assert_proc_not_inserted(proc);
+
+    ble_gattc_read_mult_cb_var(proc, BLE_HS_ETIMEOUT, 0, 0);
 }
 
 static int

--- a/nimble/host/src/ble_gattc.c
+++ b/nimble/host/src/ble_gattc.c
@@ -326,8 +326,7 @@ static ble_gattc_tmo_fn ble_gattc_write_long_tmo;
 static ble_gattc_tmo_fn ble_gattc_write_reliable_tmo;
 static ble_gattc_tmo_fn ble_gatts_indicate_tmo;
 
-static ble_gattc_tmo_fn * const
-ble_gattc_tmo_dispatch[BLE_GATT_OP_CNT] = {
+static ble_gattc_tmo_fn * const ble_gattc_tmo_dispatch[BLE_GATT_OP_CNT] = {
     [BLE_GATT_OP_MTU]               = ble_gattc_mtu_tmo,
     [BLE_GATT_OP_DISC_ALL_SVCS]     = ble_gattc_disc_all_svcs_tmo,
     [BLE_GATT_OP_DISC_SVC_UUID]     = ble_gattc_disc_svc_uuid_tmo,


### PR DESCRIPTION
Timeout function related to Read Multiple Variable Length procedure was missing. The application was never notified when this procedure has timed out.

This was tested with https://github.com/apache/mynewt-nimble/pull/2181 on GATT/CL/GAT/BV-03-C qualification test case that verifies IUTs handling timeout of Read Multiple Variable Length procedure 