### PR TITLE
nimble/host: Fix handle validation in Read Mult Response

### DIFF
--- a/nimble/host/src/ble_att_svr.c
+++ b/nimble/host/src/ble_att_svr.c
@@ -1641,10 +1641,9 @@ ble_att_svr_build_read_mult_rsp(uint16_t conn_handle, uint16_t cid,
     }
 
     /* Iterate through requested handles, reading the corresponding attribute
-     * for each.  Stop when there are no more handles to process, or the
-     * response is full.
+     * for each.  Stop when there are no more handles to process.
      */
-    while (OS_MBUF_PKTLEN(*rxom) >= 2 && OS_MBUF_PKTLEN(txom) < mtu) {
+    while (OS_MBUF_PKTLEN(*rxom) >= 2) {
         /* Ensure the full 16-bit handle is contiguous at the start of the
          * mbuf.
          */
@@ -1667,9 +1666,19 @@ ble_att_svr_build_read_mult_rsp(uint16_t conn_handle, uint16_t cid,
         }
     }
 
+    /* Concatenated values should not exceed ATT_MTU - 1 octets */
+    if (OS_MBUF_PKTLEN(txom) > mtu) {
+        os_mbuf_adj(txom, mtu - OS_MBUF_PKTLEN(txom));
+    }
+
     rc = 0;
 
 done:
+    if (rc != 0 && txom != NULL) {
+        os_mbuf_free_chain(txom);
+        txom = NULL;
+    }
+
     *out_txom = txom;
     return rc;
 }


### PR DESCRIPTION
If one of the requested characteristic values filled the MTU, this caused the while loop to exit early. Remaining handle validation was skipped and as a result a response was issued even when the remaining handle was invalid.

Validate all requested handles first. Move MTU check outside while loop and truncate the response if needed after all handles were validated.

Fixes qualification test case GATT/SR/GAR/BI-19-C