### PR TITLE
nimble/host: reset resource counts in ble_gatts_reset()

### DIFF
--- a/nimble/host/include/host/ble_gatt.h
+++ b/nimble/host/include/host/ble_gatt.h
@@ -1135,8 +1135,11 @@ void ble_gatts_show_local(void);
 
 /**
  * Resets the GATT server to its initial state.  On success, this function
- * removes all supported services, characteristics, and descriptors.  This
- * function requires that:
+ * removes all supported services, characteristics, and descriptors,
+ * discards services added with ble_gatts_add_svcs() but not yet started, and
+ * clears the resource counts collected by ble_gatts_count_cfg().  Services
+ * must be counted and added again before the next call to ble_gatts_start().
+ * This function requires that:
  *     o No peers are connected, and
  *     o No GAP operations are active (advertise, discover, or connect).
  *

--- a/nimble/host/src/ble_gatts.c
+++ b/nimble/host/src/ble_gatts.c
@@ -2375,6 +2375,15 @@ ble_gatts_reset(void)
         /* Unregister all ATT attributes. */
         ble_att_svr_reset();
         ble_gatts_num_cfgable_chrs = 0;
+
+        /* Discard services added but not yet started, along with the
+         * resource counts accumulated by ble_gatts_count_cfg(); the next
+         * count/add/start sequence sizes the pools from scratch.
+         */
+        ble_gatts_free_svc_defs();
+        ble_hs_max_services = 0;
+        ble_hs_max_attrs = 0;
+        ble_hs_max_client_configs = 0;
         rc = 0;
 
         /* Note: gatts memory gets freed on next call to ble_gatts_start(). */

--- a/nimble/host/test/src/ble_hs_test_util.c
+++ b/nimble/host/test/src/ble_hs_test_util.c
@@ -2006,6 +2006,9 @@ ble_hs_test_util_reg_svcs(const struct ble_gatt_svc_def *svcs,
     rc = ble_gatts_reset();
     TEST_ASSERT_FATAL(rc == 0);
 
+    rc = ble_gatts_count_cfg(svcs);
+    TEST_ASSERT_FATAL(rc == 0);
+
     rc = ble_gatts_add_svcs(svcs);
     TEST_ASSERT_FATAL(rc == 0);
 


### PR DESCRIPTION
`ble_gatts_count_cfg()` only ever adds to `ble_hs_max_services`, `ble_hs_max_attrs` and `ble_hs_max_client_configs`, and nothing ever resets them. `ble_gatts_start()` drops the added service definitions, so an application that resets the GATT server and registers its services again (host stop/start cycles, MicroPython soft reboots) has to count them again, and every cycle grows the pools allocated by `ble_att_svr_start()` and `ble_gatts_start()`. The only way to avoid the leak today is to poke the `ble_hs_priv.h` counters from application code.

Clear the counters in `ble_gatts_reset()`, together with any service definitions added but not yet started (they would otherwise fail to register against zero-sized pools), so the server really returns to its initial state and the next count/add/start sequence sizes the pools from scratch. The test helper is adjusted, as it relied on the counts preset by `ble_hs_test_util_init()` surviving the reset.

Fixes #896
